### PR TITLE
Align solr names with yul-dc-solr

### DIFF
--- a/config/blacklight.yml
+++ b/config/blacklight.yml
@@ -1,9 +1,9 @@
 development:
   adapter: solr
-  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/blacklight-core" %>
+  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/blacklight-development" %>
 test: &test
   adapter: solr
-  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/blacklight-core" %>
+  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/blacklight-test" %>
 production:
   adapter: solr
   url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/blacklight-core" %>


### PR DESCRIPTION
Let's use solr core names blacklight-development and blacklight-test so it will be clear that we have different environments during development.