### PR TITLE
Change .env to reference development Solr core.

### DIFF
--- a/.env
+++ b/.env
@@ -4,7 +4,7 @@ REGISTRY_HOST=
 # Can't have dashes
 REGISTRY_URI=notch8/blacklight-yul
 TAG=latest
-SOLR_URL=http://solr:8983/solr/blacklight-core
+SOLR_URL=http://solr:8983/solr/blacklight-development
 SOLR_CORE=blacklight-core
 # Required by Postgres / Blacklight
 POSTGRES_HOST=db


### PR DESCRIPTION
The `.env` file is out of date after the renaming of the Solr cores.   Fixes #6 