### PR TITLE
i61-blacklight-app-services

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,6 @@ RUN /sbin/setuser app bash -l -c "set -x && \
     DB_ADAPTER=nulldb bundle exec rake assets:precompile && \
     mv ./public/assets ./public/assets-new"
 
+EXPOSE 3000
+
 CMD ["/sbin/my_init"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,32 +48,32 @@ services:
       - .env
     command: bash -c 'precreate-core blacklight-development /opt/config; precreate-core blacklight-test /opt/config; exec solr -f'
 
-  images:
-    image:
-    env_file:
-      - .env
-    ports:
-      - ''
-    volumes:
-      - ''
+  # images:
+  #   image:
+  #   env_file:
+  #     - .env
+  #   ports:
+  #     - ''
+  #   volumes:
+  #     - ''
 
-  manifests:
-    image:
-    env_file:
-      - .env
-    ports:
-      - ''
-    volumes:
-      - ''
+  # manifests:
+  #   image:
+  #   env_file:
+  #     - .env
+  #   ports:
+  #     - ''
+  #   volumes:
+  #     - ''
 
-  blacklight:
-    image:
-    env_file:
-      - .env
-    ports:
-      - ''
-    volumes:
-      - ''
+  # blacklight:
+  #   image:
+  #   env_file:
+  #     - .env
+  #   ports:
+  #     - ''
+  #   volumes:
+  #     - ''
 
 volumes:
   postgres:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,13 +9,13 @@ services:
       context: .
       dockerfile: Dockerfile.base
 
-  web:
+  web: # blacklight app
     build: .
     image: '${REGISTRY_HOST}${REGISTRY_URI}:${TAG:-master}'
     env_file:
       - .env
     ports:
-      - '80:80'
+      - '3000:3000'
     volumes:
       - .:/home/app/webapp
     # Keep the stdin open, so we can attach to our app container's process
@@ -26,6 +26,8 @@ services:
     depends_on:
       - solr
       - db
+      - images
+      - manifests
 
   # https://hub.docker.com/_/postgres
   db:
@@ -48,32 +50,15 @@ services:
       - .env
     command: bash -c 'precreate-core blacklight-development /opt/config; precreate-core blacklight-test /opt/config; exec solr -f'
 
-  # images:
-  #   image:
-  #   env_file:
-  #     - .env
-  #   ports:
-  #     - ''
-  #   volumes:
-  #     - ''
+  images:
+    image: notch8/yul-dc-iiif-imageserver
+    ports:
+      - '8182:8182'
 
-  # manifests:
-  #   image:
-  #   env_file:
-  #     - .env
-  #   ports:
-  #     - ''
-  #   volumes:
-  #     - ''
-
-  # blacklight:
-  #   image:
-  #   env_file:
-  #     - .env
-  #   ports:
-  #     - ''
-  #   volumes:
-  #     - ''
+  manifests:
+    image: notch8/yul-dc-iiif-manifest
+    ports:
+      - '80:80'
 
 volumes:
   postgres:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.1'
 services:
 
   base:
-    image: "${REGISTRY_HOST}${REGISTRY_URI}-base:latest"
+    image: '${REGISTRY_HOST}${REGISTRY_URI}-base:latest'
     env_file:
       - .env
     build:
@@ -11,11 +11,11 @@ services:
 
   web:
     build: .
-    image: "${REGISTRY_HOST}${REGISTRY_URI}:${TAG:-master}"
+    image: '${REGISTRY_HOST}${REGISTRY_URI}:${TAG:-master}'
     env_file:
       - .env
     ports:
-      - "80:80"
+      - '80:80'
     volumes:
       - .:/home/app/webapp
     # Keep the stdin open, so we can attach to our app container's process
@@ -33,20 +33,47 @@ services:
     env_file:
       - .env
     ports:
-      - "5432:5432"
+      - '5432:5432'
     volumes:
       - 'postgres:/var/lib/postgresql/data'
 
   solr:
     image: solr:8
     ports:
-      - "8983:8983"
+      - '8983:8983'
     volumes:
       - './solr/conf:/opt/config:delegated'
       - solr:/opt/solr/server/solr/mycores
     env_file:
       - .env
-    command: bash -c "precreate-core blacklight-development /opt/config; precreate-core blacklight-test /opt/config; exec solr -f"
+    command: bash -c 'precreate-core blacklight-development /opt/config; precreate-core blacklight-test /opt/config; exec solr -f'
+
+  images:
+    image:
+    env_file:
+      - .env
+    ports:
+      - ''
+    volumes:
+      - ''
+
+  manifests:
+    image:
+    env_file:
+      - .env
+    ports:
+      - ''
+    volumes:
+      - ''
+
+  blacklight:
+    image:
+    env_file:
+      - .env
+    ports:
+      - ''
+    volumes:
+      - ''
 
 volumes:
   postgres:

--- a/ops/webapp.conf
+++ b/ops/webapp.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80;
+    listen 3000;
     server_name _;
     root /home/app/webapp/public;
     client_body_in_file_only clean;


### PR DESCRIPTION
# Ticket
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/61

# Story
Running `docker-compose up web` should bring up all the services we need for the blacklight app

# Expected behavior
The docker-compose.yml file lists all of the yul-dc services:
- db
- images
-  manifests
- blacklight (listed as "web")
- solr

# Other
We may need to come back to the ports on some of the services at a later date. They all work for now though.