### PR TITLE
Add oid from ladybird to solr records

### DIFF
--- a/app/services/voyager_indexing_service.rb
+++ b/app/services/voyager_indexing_service.rb
@@ -1,8 +1,10 @@
 require 'json'
 class VoyagerIndexingService
 
-  # Define a location for voyager metadata. We expect the metadata to be a directory of .json files
+  # Define a location for voyager and ladybird metadata.
+  # We expect the metadata to be a directory of .json files
   attr_accessor :voyager_metadata_path
+  attr_accessor :ladybird_metadata_path
 
   # Index a directory of voyager json files
   def index_voyager_metadata
@@ -12,17 +14,45 @@ class VoyagerIndexingService
     end
   end
 
+  def oid_hash
+    @oid_hash ||= build_oid_hash
+  end
+
+  ##
+  # Read in a directory of ladybird json files and create a hash mapping orbisBibId to oid
+  # Blacklight will need the oid in order to fetch the image for display. 
+  def build_oid_hash
+    oid_hash = {}
+    Dir.foreach(ladybird_metadata_path) do |filename|
+      begin
+        next if filename == '.' or filename == '..' or filename.match(/.swp/)
+        file = File.read(File.join(ladybird_metadata_path, filename))
+        data_hash = JSON.parse(file)
+        orbis_bib_id = data_hash["orbisBibId"].to_s
+        oid = data_hash["oid"].to_s
+        oid_hash[orbis_bib_id] = oid
+      # TODO: We need a better way to surface parsing errors
+      # Ideally these would go to an error tracking service that someone would review
+      rescue JSON::ParserError => e
+        puts "JSON::ParserError for #{filename}: #{e}"
+      end
+    end
+    oid_hash
+  end
+
   # Index a single voyager metadata json file
   # @param [String] filename - a full path to a json file
   def index_voyager_json_file(filename)
     file = File.read(File.join(filename))
     data_hash = JSON.parse(file)
+    orbis_bib_id = data_hash["orbisBibId"].to_s
     solr_doc =     {
-      id: data_hash["orbisBibId"],
+      id: orbis_bib_id,
       title_tsim: data_hash["title"],
       language_ssim: data_hash["language"],
       description_tesim: data_hash["description"],
-      author_tsim: data_hash["creator"]
+      author_tsim: data_hash["creator"],
+      oid_ssm: oid_hash[orbis_bib_id]
     }
     solr = Blacklight.default_index.connection
     solr.add([solr_doc])

--- a/spec/services/voyager_indexing_service_spec.rb
+++ b/spec/services/voyager_indexing_service_spec.rb
@@ -1,7 +1,8 @@
 RSpec.describe VoyagerIndexingService, clean: true do
 
-  let(:voyager_metadata_path) { File.join(fixture_path, 'voyager') }
   let(:vis) { VoyagerIndexingService.new }
+  let(:voyager_metadata_path) { File.join(fixture_path, 'voyager') }
+  let(:ladybird_metadata_path) { File.join(fixture_path, 'ladybird') }
   let(:voyager_json_file) { File.join(fixture_path, 'voyager', 'bid-752400.json') }
 
   it "can be instantiated" do
@@ -11,6 +12,18 @@ RSpec.describe VoyagerIndexingService, clean: true do
   it "knows where to find the voyager metadata" do
     vis.voyager_metadata_path = voyager_metadata_path
     expect(vis.voyager_metadata_path).to eq voyager_metadata_path
+  end
+
+  it "knows where to find the ladybird metadata" do
+    vis.ladybird_metadata_path = ladybird_metadata_path
+    expect(vis.ladybird_metadata_path).to eq ladybird_metadata_path
+  end
+
+  it "builds a hash mapping orbisBibId to oid" do
+    vis.voyager_metadata_path = voyager_metadata_path
+    vis.ladybird_metadata_path = ladybird_metadata_path
+    oid_hash = vis.oid_hash
+    expect(oid_hash["13881242"]).to eq "16685691"
   end
 
   # it "indexes a directory of voyager metadata" do
@@ -23,11 +36,16 @@ RSpec.describe VoyagerIndexingService, clean: true do
   #   # expect()
   # end
 
-  it "indexes a single voyager json file" do
+  it "indexes a voyager json file and merges it with the oid from ladybird" do
     vis.voyager_metadata_path = voyager_metadata_path
+    vis.ladybird_metadata_path = ladybird_metadata_path
     vis.index_voyager_json_file(voyager_json_file)
     solr = Blacklight.default_index.connection
     response = solr.get 'select', :params => {:q => '*:*'}
     expect(response["response"]["numFound"]).to eq 1
+    solr_doc = response["response"]["docs"][0]
+    expect(solr_doc["id"]).to eq "752400"
+    expect(solr_doc["title_tsim"]).to eq ["Ebony"]
+    expect(solr_doc["oid_ssm"]).to contain_exactly("2034600")
   end
 end


### PR DESCRIPTION
Blacklight will need the metadata from voyager plus the oid from ladybird in order to display records properly.

Connected to https://github.com/yalelibrary/YUL-DC/issues/89