### PR TITLE
Add ladybird_metadata_path to the load_voyager_sample_data rake task

### DIFF
--- a/lib/tasks/index_sample_data.rake
+++ b/lib/tasks/index_sample_data.rake
@@ -4,8 +4,10 @@ namespace :yale do
   desc "Load sample data"
   task load_voyager_sample_data: :environment do
     vis = VoyagerIndexingService.new
+    ladybird_metadata_path = Rails.root.join('spec', 'fixtures', 'ladybird').to_s
     voyager_metadata_path =  Rails.root.join('spec', 'fixtures', 'voyager').to_s
     vis.voyager_metadata_path = voyager_metadata_path
+    vis.ladybird_metadata_path = ladybird_metadata_path
     vis.index_voyager_metadata
     puts "Voyager sample metadata indexed"
   end


### PR DESCRIPTION
The `load_voyager_sample_data` now needs to set `ladybird_metadata_path` as the indexing service uses the ladybird data to get the oid.