### PR TITLE
i64-add-universal-viewer

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -48,6 +48,7 @@ class CatalogController < ApplicationController
 
     config.add_nav_action(:bookmark, partial: 'blacklight/nav/bookmark', if: :render_bookmarks_control?)
     config.add_nav_action(:search_history, partial: 'blacklight/nav/search_history')
+    config.show.partials.insert(1, :uv)
 
     # solr field configuration for document/show views
     #config.show.title_field = 'title_tsim'

--- a/app/views/catalog/_uv.html.erb
+++ b/app/views/catalog/_uv.html.erb
@@ -1,0 +1,9 @@
+<iframe
+    class="universal-viewer-iframe"
+    src="<%= request&.base_url %>/uv/uv.html#?manifest=<%= Rails.application.config.iiif_url %>/<%= document.id %>/manifest"
+    width="640"
+    height="480"
+    allowfullscreen
+    frameborder="0">
+</iframe>
+</br>

--- a/config/initializers/iiif_url.rb
+++ b/config/initializers/iiif_url.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+# TODO: set the 'IIIF_URL' env variable
+Rails.application.config.iiif_url = ENV['IIIF_URL'] || ''

--- a/config/uv/uv-config.json
+++ b/config/uv/uv-config.json
@@ -1,0 +1,14 @@
+{
+    "options": {
+        "rightPanelEnabled": true
+    },
+    "modules": {
+        "footerPanel": {
+            "options": {
+                "downloadEnabled": true,
+                "fullscreenEnabled": true,
+                "shareEnabled": true
+            }
+        }
+    }
+}

--- a/config/uv/uv.html
+++ b/config/uv/uv.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <!--
+        This is what the embed iframe src links to. It doesn't need to communicate with the parent page, only fill the available space and look for #? parameters
+      -->
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <link rel="icon" href="favicon.ico">
+    <link rel="stylesheet" type="text/css" href="uv.css">
+    <script type="text/javascript" src="lib/offline.js"></script>
+    <script type="text/javascript" src="helpers.js"></script>
+    <style>
+        body {
+            margin: 0;
+            padding: 0;
+            overflow: hidden;
+        }
+        .uv .mobileFooterPanel .options .btn.fullScreen {
+          display: inline !important;
+         }
+         .title > span {
+            display: none;
+         }
+    </style>
+    <script type="text/javascript">
+    window.addEventListener('uvLoaded', function(e) {
+            urlDataProvider = new UV.URLDataProvider(true);
+            var formattedLocales;
+            var locales = urlDataProvider.get('locales', '');
+            if (locales) {
+                var names = locales.split(',');
+                formattedLocales = [];
+                for (var i in names) {
+                    var nameparts = String(names[i]).split(':');
+                    formattedLocales[i] = {name: nameparts[0], label: nameparts[1]};
+                }
+            } else {
+                formattedLocales = [
+                    {
+                        name: 'en-GB'
+                    }
+                ]
+            }
+            uv = createUV('#uv', {
+                root: '.',
+                iiifResourceUri: urlDataProvider.get('manifest'),
+                configUri: 'uv-config.json',
+                collectionIndex: Number(urlDataProvider.get('c', 0)),
+                manifestIndex: Number(urlDataProvider.get('m', 0)),
+                sequenceIndex: Number(urlDataProvider.get('s', 0)),
+                canvasIndex: Number(urlDataProvider.get('cv', 0)),
+                rangeId: urlDataProvider.get('rid', 0),
+                rotation: Number(urlDataProvider.get('r', 0)),
+                xywh: urlDataProvider.get('xywh', ''),
+                embedded: true,
+                locales: formattedLocales
+            }, urlDataProvider);
+        }, false);
+    </script>
+</head>
+<body>
+
+<div id="uv" class="uv"></div>
+
+<script>
+    $(function() {
+        var $UV = $('#uv');
+        function resize() {
+            var windowWidth = window.innerWidth;
+            var windowHeight = window.innerHeight;
+            $UV.width(windowWidth);
+            $UV.height(windowHeight);
+        }
+        $(window).on('resize' ,function() {
+            resize();
+        });
+        resize();
+    });
+</script>
+
+<script type="text/javascript" src="uv.js"></script>
+
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -6,10 +6,18 @@
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "4.2.2",
-    "turbolinks": "^5.2.0"
+    "turbolinks": "^5.2.0",
+    "universalviewer": "^3.0.16"
   },
   "version": "0.1.0",
+  "scripts": {
+    "preinstall": "rm -rf ./public/uv",
+    "postinstall": "yarn run uv-install && yarn run uv-config",
+    "uv-install": "shx cp -r ./node_modules/universalviewer/uv ./public/",
+    "uv-config": "shx cp ./config/uv/uv.html ./public/uv/uv.html & shx cp ./config/uv/uv-config.json ./public/uv/"
+  },
   "devDependencies": {
-    "webpack-dev-server": "^3.10.3"
+    "webpack-dev-server": "^3.10.3",
+    "shx": "^0.3.2"
   }
 }

--- a/spec/view_uv_spec.rb
+++ b/spec/view_uv_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.describe 'viewing uv', type: :system do
+  it 'has expected text' do
+    visit "/uv/uv.html"
+    expect(page.html).to match(/uv/)
+  end
+end

--- a/spec/view_work_spec.rb
+++ b/spec/view_work_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.feature 'View a Work' do
+  before do
+    solr = Blacklight.default_index.connection
+    solr.add(work_attributes)
+    solr.commit
+    allow(Rails.application.config).to receive(:iiif_url).and_return('https://example.com')
+  end
+
+  let(:id) { '123' }
+
+  let(:work_attributes) do
+    {
+      id: id,
+      has_model_ssim: ['Work'],
+      title_tesim: ['The Title of my Work'],
+      description_tesim: ['Description 1', 'Description 2']
+    }
+  end
+
+  it 'has the uv html on the page' do
+    visit solr_document_path(id)
+    expect(page.html).to match(/universal-viewer-iframe/)
+  end
+end


### PR DESCRIPTION
# STORY
As a scholar, I'd like to be able to view the images related to the metadata on the work page I'm viewing, so I can visually confirm I've found the correct resource.

# ACCEPTANCE
Given a work with a an OID in it's metadata
 - Display Universal Viewer on the work's show page
 - Show the first image in the manifest in UV (see #63 for manifest link info)

# Resources
- https://curationexperts.github.io/playbook/tools/uv/uv_in_blacklight.html

# Notes
- when I ran `docker-compose build web` the result was:
```
Building web
Step 1/10 : FROM notch8/blacklight-yul-base:latest
 ---> 7ab937790bd9
Step 2/10 : ADD https://time.is/just build-time

 ---> 15f4d9cd9d3f
Step 3/10 : COPY ops/nginx.sh /etc/service/nginx/run
 ---> 8fb428035d63
Step 4/10 : COPY ops/webapp.conf /etc/nginx/sites-enabled/webapp.conf
 ---> 5e87712d5082
Step 5/10 : COPY ops/env.conf /etc/nginx/main.d/env.conf
 ---> eee6a8a1e555
Step 6/10 : RUN chmod +x /etc/service/nginx/run
 ---> Running in 7b1d5607be3f
Removing intermediate container 7b1d5607be3f
 ---> c7ee0c4ba3ef
Step 7/10 : COPY  --chown=app . $APP_HOME
 ---> e4eb27e49069
Step 8/10 : RUN /sbin/setuser app bash -l -c "set -x &&     (bundle check || bundle install) &&     DB_ADAPTER=nulldb bundle exec rake assets:precompile &&     mv ./public/assets ./public/assets-new"
 ---> Running in 2de09ca4222d
+ bundle check
Warning: the running version of Bundler (2.1.2) is older than the version that created the lockfile (2.1.4). We suggest you to upgrade to the version that created the lockfile by running `gem install bundler:2.1.4`.
The dependency tzinfo-data (>= 0) will be unused by any of the platforms Bundler is installing for. Bundler is installing for ruby but the dependency is only for x86-mingw32, x86-mswin32, x64-mingw32, java. To add those platforms to the bundle, run `bundle lock --add-platform x86-mingw32 x86-mswin32 x64-mingw32 java`.
The Gemfile's dependencies are satisfied
+ DB_ADAPTER=nulldb
+ bundle exec rake assets:precompile
yarn install v1.22.4
$ rm -rf ./public/uv
[1/4] Resolving packages...
warning universalviewer > core-js@2.4.1: core-js@<3 is no longer maintained and not recommended for usage due to the number of issues. Please, upgrade your dependencies to the actual version of core-js@3.
warning universalviewer > manifesto.js > request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
warning universalviewer > opencollective > babel-polyfill > core-js@2.6.11: core-js@<3 is no longer maintained and not recommended for usage due to the number of issues. Please, upgrade your dependencies to the actual version of core-js@3.
warning universalviewer > opencollective > babel-polyfill > babel-runtime > core-js@2.6.11: core-js@<3 is no longer maintained and not recommended for usage due to the number of issues. Please, upgrade your dependencies to the actual version of core-js@3.
[2/4] Fetching packages...
info fsevents@1.2.12: The platform "linux" is incompatible with this module.
info "fsevents@1.2.12" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
warning "universalviewer > pdfjs-dist > worker-loader@1.1.1" has unmet peer dependency "webpack@^2.0.0 || ^3.0.0 || ^4.0.0".
warning " > webpack-dev-server@3.10.3" has unmet peer dependency "webpack@^4.0.0 || ^5.0.0".
warning "webpack-dev-server > webpack-dev-middleware@3.7.2" has unmet peer dependency "webpack@^4.0.0".
[4/4] Building fresh packages...
success Saved lockfile.
$ yarn run uv-install && yarn run uv-config
yarn run v1.22.4
$ shx cp -r ./node_modules/universalviewer/uv ./public/
cp: no such file or directory: ./node_modules/universalviewer/uv
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
ERROR: Service 'web' failed to build: The command '/bin/sh -c /sbin/setuser app bash -l -c "set -x &&     (bundle check || bundle install) &&     DB_ADAPTER=nulldb bundle exec rake assets:precompile &&     mv ./public/assets ./public/assets-new"' returned a non-zero code: 1
```