### PR TITLE
97 ensure all samples discoverable

### DIFF
--- a/app/services/voyager_indexing_service.rb
+++ b/app/services/voyager_indexing_service.rb
@@ -49,17 +49,17 @@ class VoyagerIndexingService
     data_hash = JSON.parse(file)
     orbis_bib_id = data_hash["orbisBibId"].to_s
     oid_hash[orbis_bib_id].flatten.each do |oid|
-    solr_doc =     {
-      id: oid,
-      title_tsim: data_hash["title"],
-      language_ssim: data_hash["language"],
-      description_tesim: data_hash["description"],
-      author_tsim: data_hash["creator"],
-      bib_id_ssm: orbis_bib_id
-    }
-    solr = Blacklight.default_index.connection
-    solr.add([solr_doc])
-    solr.commit
-      end
+      solr_doc = {
+        id: oid,
+        title_tsim: data_hash["title"],
+        language_ssim: data_hash["language"],
+        description_tesim: data_hash["description"],
+        author_tsim: data_hash["creator"],
+        bib_id_ssm: orbis_bib_id
+      }
+      solr = Blacklight.default_index.connection
+      solr.add([solr_doc])
+      solr.commit
+    end
   end
 end

--- a/app/services/voyager_indexing_service.rb
+++ b/app/services/voyager_indexing_service.rb
@@ -31,7 +31,8 @@ class VoyagerIndexingService
         data_hash = JSON.parse(file)
         orbis_bib_id = data_hash["orbisBibId"].to_s
         oid = data_hash["oid"].to_s
-        oid_hash[orbis_bib_id] = oid
+        oid_hash[orbis_bib_id] ||= []
+        oid_hash[orbis_bib_id] << oid
       # TODO: We need a better way to surface parsing errors
       # Ideally these would go to an error tracking service that someone would review
       rescue JSON::ParserError => e
@@ -47,16 +48,18 @@ class VoyagerIndexingService
     file = File.read(File.join(filename))
     data_hash = JSON.parse(file)
     orbis_bib_id = data_hash["orbisBibId"].to_s
+    oid_hash[orbis_bib_id].flatten.each do |oid|
     solr_doc =     {
-      id: orbis_bib_id,
+      id: oid,
       title_tsim: data_hash["title"],
       language_ssim: data_hash["language"],
       description_tesim: data_hash["description"],
       author_tsim: data_hash["creator"],
-      oid_ssm: oid_hash[orbis_bib_id]
+      bib_id_ssm: orbis_bib_id
     }
     solr = Blacklight.default_index.connection
     solr.add([solr_doc])
     solr.commit
+      end
   end
 end

--- a/app/views/catalog/_show_links.html.erb
+++ b/app/views/catalog/_show_links.html.erb
@@ -6,7 +6,7 @@
   <ul class="list-group list-group-flush">
     <li class="list-group-item manifest">
       <div class='nav-link'>
-        <% oid = @document['oid_ssm'].first %>
+        <% oid = @document.id %>
         <%= link_to image_tag('iiif.png'), manifest_url(oid), target: '_blank', class: 'iiif-logo' %>
         <%= link_to t('blacklight.sidebar.manifest'), manifest_url(oid), target: '_blank', id: 'manifestLink'%> 
       <div>

--- a/app/views/catalog/_uv.html.erb
+++ b/app/views/catalog/_uv.html.erb
@@ -1,4 +1,4 @@
-<% oid = @document['oid_ssm'].first %>
+<% oid = @document.id %>
 
 <iframe
     class="universal-viewer-iframe"

--- a/spec/services/voyager_indexing_service_spec.rb
+++ b/spec/services/voyager_indexing_service_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe VoyagerIndexingService, clean: true do
     vis.voyager_metadata_path = voyager_metadata_path
     vis.ladybird_metadata_path = ladybird_metadata_path
     oid_hash = vis.oid_hash
-    expect(oid_hash["13881242"]).to eq "16685691"
+    expect(oid_hash["13881242"]).to eq ["16685691"]
   end
 
   # it "indexes a directory of voyager metadata" do
@@ -45,8 +45,8 @@ RSpec.describe VoyagerIndexingService, clean: true do
     response = solr.get 'select', params: { q: '*:*' }
     expect(response["response"]["numFound"]).to eq 1
     solr_doc = response["response"]["docs"][0]
-    expect(solr_doc["id"]).to eq "752400"
+    expect(solr_doc["id"]).to eq "2034600"
     expect(solr_doc["title_tsim"]).to eq ["Ebony"]
-    expect(solr_doc["oid_ssm"]).to contain_exactly("2034600")
+    expect(solr_doc["bib_id_ssm"]).to contain_exactly("752400")
   end
 end

--- a/spec/views/catalog/_show_links.html.erb_spec.rb
+++ b/spec/views/catalog/_show_links.html.erb_spec.rb
@@ -3,7 +3,7 @@
 RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
 
 RSpec.describe 'catalog/_show_tools.html.erb' do
-  let(:document) { SolrDocument.new id: '123', oid_ssm: ['xyz'] }
+  let(:document) { SolrDocument.new id: 'xyz', bib_id_ssm: ['123'] }
 
   before do
     assign :document, document


### PR DESCRIPTION
This PR assumes that the docker contain was built previously.  

- Get branch 

Once the branch has been pulled:  
 
run the following rake task:
- rake yale:clean_solr

after running the rake task, confirm locally zero objects on the website, then run the following rake task to add the objects. 
- rake yale:load_voyager_sample_data

Once the objects are added, confirm locally 45 items in on the website.  
(There are images on Zenhub: https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/97)