### PR TITLE
Support .env.development for overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@
   ``` bash
   docker-compose build web
   ```
+### Environment Variables for Development
+
+Create the following file to override anything in .env. The following two values must be overridden.
+```
+SOLR_URL=http://solr:8983/solr/blacklight-development
+POSTGRES_HOST=db
+```
+
 
 ### Starting the app
 - Start the web service

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     image: '${REGISTRY_HOST}${REGISTRY_URI}-base:latest'
     env_file:
       - .env
+      - .env.development
     build:
       context: .
       dockerfile: Dockerfile.base
@@ -14,6 +15,7 @@ services:
     image: '${REGISTRY_HOST}${REGISTRY_URI}:${TAG:-master}'
     env_file:
       - .env
+      - .env.development
     ports:
       - '3000:3000'
     volumes:


### PR DESCRIPTION
This PR:

* adds .env.development to docker-compose.yml
* adds info on .env.development to README

Current .env has localhost, presumably for ECS? This helps devs override.