### PR TITLE
Add a set of ingest ready solr fixtures that can be version controlled - WIP

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,8 @@ services:
     volumes:
       # think this may need to be changed to /var/solr/data
       - solr:/opt/solr/server/solr/mycores
+      # samples for solr bin/post load
+      - ./spec/fixtures/solr:/home/samples/solr:delegated
     env_file:
       - .env
     command: bash -c 'precreate-core ${SOLR_CORE} /opt/config; precreate-core ${SOLR_TEST_CORE} /opt/config; exec solr -f'

--- a/spec/fixtures/ladybird-to-solr.sh
+++ b/spec/fixtures/ladybird-to-solr.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+mkdir -p solr
+cp ./ladybird/*.json ./solr
+sed -i '' 's/"oid"/"id"/g' ./solr/*.json
+sed -i '' 's/"title"/"title_tsim"/g' ./solr/*.json
+sed -i '' 's/"language"/"language_ssim"/g' ./solr/*.json
+sed -i '' 's/"creator"/"author_tsim"/g' ./solr/*.json
+sed -i '' 's/"description"/"description_ssim"/g' ./solr/*.json
+sed -i '' 's/"orbisBibId"/"bib_id_ssm"/g' ./solr/*.json
+sed -i '' 's/"alternativeTitle"/"alternativeTitle_tesim"/g' ./solr/*.json
+sed -i '' 's/"source"/"source_ssim"/g' ./solr/*.json
+sed -i '' 's/"recordType"/"recordType_ssim"/g' ./solr/*.json
+sed -i '' 's/"ssim"/"uri_ssim"/g' ./solr/*.json
+sed -i '' 's/"identifierMfhd"/"identifierMfhd_ssim"/g' ./solr/*.json
+sed -i '' 's/"identifierShelfMark"/"identifierShelfMark_ssim"/g' ./solr/*.json
+sed -i '' 's/"box"/"box_ssim"/g' ./solr/*.json
+sed -i '' 's/"sourceTitle"/"sourceTitle_ssim"/g' ./solr/*.json
+sed -i '' 's/"sourceDate"/"sourceDate_ssim"/g' ./solr/*.json
+sed -i '' 's/"sourceNote"/"sourceNote_ssim"/g' ./solr/*.json
+sed -i '' 's/"extentOfDigitization"/"extentOfDigitization_ssim"/g' ./solr/*.json
+sed -i '' 's/"date"/"date_ssim"/g' ./solr/*.json
+sed -i '' 's/"extent"/"extent_ssim"/g' ./solr/*.json
+sed -i '' 's/"subjectName"/"subjectName_ssim"/g' ./solr/*.json
+sed -i '' 's/"subjectTopic"/"subjectTopic_ssim"/g' ./solr/*.json
+sed -i '' 's/"genre"/"genre_ssim"/g' ./solr/*.json
+sed -i '' 's/"format"/"format_ssim"/g' ./solr/*.json
+sed -i '' 's/"partOf"/"partOf_ssim"/g' ./solr/*.json
+sed -i '' 's/"rights"/"rights_ssim"/g' ./solr/*.json
+sed -i '' 's/"orbisBarcode"/"orbisBarcode_ssim"/g' ./solr/*.json
+sed -i '' 's/"findingAid"/"findingAid_ssim"/g' ./solr/*.json
+sed -i '' 's/"references"/"references_ssi./m"/g' ./solr/*.json
+sed -i '' 's/"dateStructured"/"dateStructured_ssim"/g' ./solr/*.json
+sed -i '' 's/"collectionId"/"collectionId_ssim"/g' ./solr/*.json
+sed -i '' 's/"children"/"children_ssim"/g' ./solr/*.json
+sed -i '' 's/"publicationPlace"/"publicationPlace_ssim"/g' ./solr/*.json
+sed -i '' 's/"folder"/"folder_ssim"/g' ./solr/*.json
+sed -i '' 's/"numberOfPages"/"numberOfPages_ssim"/g' ./solr/*.json
+sed -i '' 's/"importUrl"/"importUrl_ssim"/g' ./solr/*.json
+sed -i '' 's/"resourceType"/"resourceType_ssim"/g' ./solr/*.json
+sed -i '' 's/"sourceCreated"/"sourceCreated_ssim"/g' ./solr/*.json
+sed -i '' 's/"edition"/"edition_ssim"/g' ./solr/*.json
+sed -i '' 's/"uri"/"uri_ssim"/g' ./solr/*.json
+sed -i '' 's/"abstract"/"abstract_ssim"/g' ./solr/*.json
+sed -i '' 's/"geoSubject"/"geoSubject_ssim"/g' ./solr/*.json
+sed -i '' 's/"illustrativeMatter"/"illustrativeMatter_ssim"/g' ./solr/*.json
+sed -i '' 's/"publisher"/"publisher_ssim"/g' ./solr/*.json
+sed -i '' 's/"material"/"material_ssim"/g' ./solr/*.json
+sed -i '' 's/"scale"/"scale_ssim"/g' ./solr/*.json
+sed -i '' 's/"digital"/"digital_ssim"/g' ./solr/*.json
+sed -i '' 's/"coordinates"/"coordinates_ssim"/g' ./solr/*.json
+sed -i '' 's/"copyrightDate"/"copyrightDate_ssim"/g' ./solr/*.json
+sed -i '' 's/"projection"/"projection_ssim"/g' ./solr/*.json
+sed -i '' 's/}/  ,\
+  "public_bsi": true\
+}/g' ./solr/*.json # make works public for now

--- a/spec/fixtures/solr/oid-10001192.json
+++ b/spec/fixtures/solr/oid-10001192.json
@@ -1,0 +1,49 @@
+{
+  "source_ssim": "ladybird",
+  "recordType_ssim": "id",
+  "uri_ssim": "/ladybird/oid/10001192",
+  "identifierMfhd_ssim": "/repositories/11/archival_objects/304086",
+  "identifierShelfMark_ssim": "GEN MSS 963",
+  "box_ssim": "7",
+  "sourceTitle_ssim": "George Eliot and George Henry Lewes collection",
+  "sourceDate_ssim": "1834-1981",
+  "sourceNote_ssim": "Section III. Letters to/about GEORGE ELIOT & GEORGE HENRY LEWES. Bracebridge, Charles Holte, 1799-1872",
+  "author_tsim": [
+    "Bracebridge, Charles Holte, 1799-1872 "
+  ],
+  "title_tsim": [
+    "to GE"
+  ],
+  "extentOfDigitization_ssim": "Complete folder digitized.",
+  "date_ssim": "1859 Oct 10",
+  "extent_ssim": "3 p.",
+  "description_ssim": [
+    "Holograph letter, signed."
+  ],
+  "subjectName_ssim": [
+    "Eliot, George, 1819-1880"
+  ],
+  "subjectTopic_ssim": [
+    "Authors, English --19th century --Archives"
+  ],
+  "genre_ssim": [
+    "Correspondence"
+  ],
+  "format_ssim": "text",
+  "partOf_ssim": "Beinecke Library",
+  "rights_ssim": [
+    "The use of this image may be subject to the copyright law of the United States (Title 17, United States Code) or to site license or other rights management terms and conditions. The person using the image is liable for any infringement."
+  ],
+  "bib_id_ssm": "3659107",
+  "orbisBarcode_ssim": "39002091548348",
+  "findingAid_ssim": "http://hdl.handle.net/10079/fa/beinecke.eliot",
+  "references_ssim": [
+    "George Eliot and George Henry Lewes Collection. General Collection, Beinecke Rare Book and Manuscript Library.\n\n"
+  ],
+  "dateStructured_ssim": "1859-10-10T00:00:00Z",
+  "id": 10001192,
+  "collectionId_ssim": 1,
+  "children_ssim": []
+  ,
+  "public_bsi": true
+}

--- a/spec/fixtures/solr/oid-10269867.json
+++ b/spec/fixtures/solr/oid-10269867.json
@@ -1,0 +1,55 @@
+{
+  "source_ssim": "ladybird",
+  "recordType_ssim": "id",
+  "uri_ssim": "/ladybird/oid/10269867",
+  "identifierShelfMark_ssim": "Beinecke MS 410",
+  "title_tsim": [
+    "Indulgence Scroll"
+  ],
+  "extentOfDigitization_ssim": "Complete work digitized.",
+  "publicationPlace_ssim": [
+    "England"
+  ],
+  "date_ssim": "s. XV^^4",
+  "extent_ssim": "f. 1 : parchment ; 1515 x 165 (1391 x 141) mm.",
+  "language_ssim": [
+    "English",
+    "Latin"
+  ],
+  "description_ssim": [
+    "Note of a 16th-century owner at the end of the roll: An Indulgence of Innocent VI ca. 1352.",
+    "Parchment roll, unevenly trimmed at top and bottom, composed of three membranes segments glued together, the third an addition of the late fifteenth century."
+  ],
+  "subjectName_ssim": [
+    "Innocent VI, Pope, d. 1362"
+  ],
+  "subjectTopic_ssim": [
+    "Indulgences--England--Early works to 1800"
+  ],
+  "genre_ssim": [
+    "Illuminated manuscripts",
+    "Indulgences (documents)",
+    "Manuscripts",
+    "Miniatures (Illuminations)",
+    "Scrolls (information artifacts)"
+  ],
+  "format_ssim": "mixed material",
+  "partOf_ssim": "Teaching resource: Barbara A. Shailor, Medieval Studies",
+  "rights_ssim": [
+    "The use of this image may be subject to the copyright law of the United States (Title 17, United States Code) or to site license or other rights management terms and conditions. The person using the image is liable for any infringement."
+  ],
+  "bib_id_ssm": "9734851",
+  "orbisBarcode_ssim": "39002091597519",
+  "importUrl_ssim": "https://pre1600ms.beinecke.library.yale.edu/docs/pre1600.ms410.htm",
+  "references_ssim": [
+    "Indulgence Scroll. General Collection, Beinecke Rare Book and Manuscript Library, Yale University.",
+    "Shailor, B. Catalogue of Medieval and Renaissance Manuscripts in the Beinecke Rare Book and Manuscript Library, MS 410."
+  ],
+  "resourceType_ssim": "Archives or Manuscripts",
+  "id": 10269867,
+  "collectionId_ssim": 1,
+  "children_ssim": [],
+  "abstract_ssim": "Manuscript on parchment roll, unevenly trimmed at top and bottom, composed of three membranes segments glued together, the third an addition of the late 15th century. Includes Prayers to be said for a pardon of 32,055 years; and Prayer based on the measurement of the length of the body of Christ. The texts are written on one side of a roll (dorse is blank)."
+  ,
+  "public_bsi": true
+}

--- a/spec/fixtures/solr/oid-10958722.json
+++ b/spec/fixtures/solr/oid-10958722.json
@@ -1,0 +1,61 @@
+{
+  "source_ssim": "ladybird",
+  "recordType_ssim": "id",
+  "uri_ssim": "/ladybird/oid/10958722",
+  "identifierShelfMark_ssim": "Beinecke MS 801",
+  "title_tsim": [
+    "Texts on St. Jerome"
+  ],
+  "extentOfDigitization_ssim": "Complete work digitized.",
+  "publicationPlace_ssim": [
+    "Settimo near Florence,"
+  ],
+  "date_ssim": "1 May 1457.",
+  "extent_ssim": "ff. i + 79 + ix : paper and parchment ; 230 x 170 mm.",
+  "material_ssim": "parchment",
+  "language_ssim": [
+    "Italian"
+  ],
+  "description_ssim": [
+    "Binding: Quarter binding of bevelled wooden boards (worm-eaten) and brown leather; spine with three raised bands and paper title label with handwritten 17th-century inscription: “Vita / di S. / Girola.” On the boards marks of one clasp attached to the front board and on the front board the ca. 1800 inscription “JO.” written in black ink. Possibly the binding once belonged to another manuscript.",
+    "Collection of Bernard M. Rosenthal (MS 38). Purchased from him on the Edwin J. Beinecke Fund.",
+    "Description follow modern foliation which includes two preliminary leaves..",
+    "Headings in pale red, often difficult to read. Yellow heightening of the majuscules. Initials, with guide letters written in the space reserved for the initial: (1) flourished initials (3-4 lines) in red with pale red (or brown) penwork or in blue with red penwork, sometimes with marginal penwork extensions; (2) at the beginning of each text a larger initial; the letters following this type of initial are majuscules. F. 3r: 12-line blue initial of the littera duplex type with extensive penwork in red and some blue, with decorative border in the same colours in the inner and lower margin and tendrils in the other margins containing flowers and acorns; the border of the lower margin terminates in a medallion containing a coat of arms; ff. 8r, 41r: 9-line initial of the same type and in the same colours; f. 47v: 6-line, idem; f. 77v: 7-line black initial.",
+    "Script: Copied by one hand in a peculiar form of Southern Gothica Textualis Libraria under Humanistic influence as visible in the total lack of compression; special features are: the sloping hairline at the top of the second stroke of e, parallelled by the sloping stroke on i; h with exceptionally long curved extension under the baseline; the forked lower ending of f and straight s on or under the baseline and the forked descender of p; and the very fancy majuscules.",
+    "The lower margin of f. 62 torn off."
+  ],
+  "subjectName_ssim": [
+    "Jerome,--Saint,--d. 419 or 20"
+  ],
+  "subjectTopic_ssim": [
+    "Christian hagiography",
+    "Illumination of books and manuscripts, Medieval",
+    "Latin letters",
+    "Manuscripts, Medieval--Connecticut--New Haven",
+    "Medieval and Renaissance Manuscripts in Beinecke Library"
+  ],
+  "genre_ssim": [
+    "Decorated initials",
+    "Manuscript waste (Binding)",
+    "Manuscripts",
+    "Rubrics"
+  ],
+  "format_ssim": "text",
+  "partOf_ssim": "Beinecke Library",
+  "rights_ssim": [
+    "The use of this image may be subject to the copyright law of the United States (Title 17, United States Code) or to site license or other rights management terms and conditions. The person using the image is liable for any infringement."
+  ],
+  "bib_id_ssm": "9869346",
+  "orbisBarcode_ssim": "39002104686564",
+  "importUrl_ssim": "https://pre1600ms.beinecke.library.yale.edu/docs/MS801.pdf",
+  "references_ssim": [
+    "Texts on St. Jerome. General Collection, Beinecke Rare Book and Manuscript Library, Yale University."
+  ],
+  "resourceType_ssim": "Archives or Manuscripts",
+  "id": 10958722,
+  "collectionId_ssim": 1,
+  "children_ssim": [],
+  "abstract_ssim": "Manuscript on paper and parchment containing 1) Ownership inscription and note on the scribe, followed by a variant form of a Biblical quotation (Lamentations 3:27-28). 2) Legend of St. Jerome in Italian, with special attention for miraculous events, as an introduction to artt. 4-6. Quotes Iohannes Belet (12th century), St. Augustine, Prosper of Aquitaine, Isidore of Seville, Sulpicius Severus. 3) Ps.-Eusebius, Epistula de morte Hieronymi (BHL 3866), Italian translation. 4) Ps. -Augustinus Hipponensis, Epistola de magnificentiis Hieronymi (BHL 3867), Italian translation. 5) Ps.-Cyrillus, Epistola de miraculis Hieronymi (BHL 3868), in Italian translation. 6) History of abbot Daniel living in Thebais and his disobedient servant, to whom he tells the life of a virtuous man they have met, called Eulogius, who eventually became patricius and praefectus praetorio in Constantinople at the time of emperor Justinus I (518-527); due to the loss of one or more quires the major part of the text, containing the intervention of the Virgin, is missing."
+  ,
+  "public_bsi": true
+}

--- a/spec/fixtures/solr/oid-11607445.json
+++ b/spec/fixtures/solr/oid-11607445.json
@@ -1,0 +1,41 @@
+{
+  "source_ssim": "ladybird",
+  "recordType_ssim": "id",
+  "uri_ssim": "/ladybird/oid/11607445",
+  "identifierShelfMark_ssim": "Landberg MSS 596",
+  "title_tsim": [
+    "[Qiṣṣat Sindbād al-barrī]"
+  ],
+  "alternativeTitle_tesim": [
+    "Book of Sindbad.",
+    "Sindbad the sailor"
+  ],
+  "extentOfDigitization_ssim": "Complete work digitized.",
+  "date_ssim": "[17--?]",
+  "extent_ssim": "81 leaves ; 20.5 x 14.5 cm.",
+  "description_ssim": [
+    "A few leaves supplied in a later hand.",
+    "Fair modern (18th century?) naskhī, in red and black.",
+    "Islamic binding, paper covered, with flap."
+  ],
+  "subjectTopic_ssim": [
+    "Arabic language and literature--Belles lettres",
+    "Islamic binding"
+  ],
+  "format_ssim": "mixed material",
+  "partOf_ssim": "Beinecke Library",
+  "rights_ssim": [
+    "The use of this image may be subject to the copyright law of the United States (Title 17, United States Code) or to site license or other rights management terms and conditions. The person using the image is liable for any infringement."
+  ],
+  "bib_id_ssm": "3832098",
+  "references_ssim": [
+    "Brockelmann, S I, pp. 237, 239, 252."
+  ],
+  "dateStructured_ssim": "1700-00-00T00:00:00Z",
+  "id": 11607445,
+  "collectionId_ssim": 1,
+  "children_ssim": [],
+  "abstract_ssim": "The tale of Sindbād and his princely pupil, in colloquial Arabic."
+  ,
+  "public_bsi": true
+}

--- a/spec/fixtures/solr/oid-11684565.json
+++ b/spec/fixtures/solr/oid-11684565.json
@@ -1,0 +1,62 @@
+{
+  "source_ssim": "ladybird",
+  "recordType_ssim": "id",
+  "uri_ssim": "/ladybird/oid/11684565",
+  "identifierShelfMark_ssim": "Beinecke MS 2",
+  "author_tsim": [
+    "Zeno, Jacopo, 1417-1481"
+  ],
+  "title_tsim": [
+    "Vita Caroli Zeni"
+  ],
+  "extentOfDigitization_ssim": "Complete work digitized.",
+  "publicationPlace_ssim": [
+    "Italy,"
+  ],
+  "date_ssim": "[ca. 1458]",
+  "extent_ssim": "ff. ii + 192 + i : parchment ; 271 x 177 (177 x 106) mm.",
+  "language_ssim": [
+    "Latin"
+  ],
+  "description_ssim": [
+    "Binding: Eighteenth century. Brownish-red goatskin, gold-tooled; pale green and gold, Dutch gilt paper boards.",
+    "On f. 1r, a foliage border which includes hares, stork, vase, and arms of the Piccolomini family (argent, a cross azur with 5 crescents or; surmounted by keys in saltire argent and a papal tiara; supported by a pair of angels). Eleven elaborate initials, 11- to 7-line, in gold, red, blue, and green entwined with foliage. The style of decoration is decidedly Roman.",
+    "Purchased by William Loring Andrews who presented it to Yale in 1894.",
+    "Script: Written in humanistic script by Franciscus de Tianis of Pistoia."
+  ],
+  "subjectName_ssim": [
+    "Zeno, Carlo,--1334-1418",
+    "Zeno, Jacopo,--1417-1481"
+  ],
+  "subjectTopic_ssim": [
+    "Biography--Middle Ages, 500-1500",
+    "Crusades--13th-15th centuries",
+    "Illumination of books and manuscripts, Medieval",
+    "Manuscripts, Medieval--Connecticut--New Haven",
+    "Medieval and Renaissance Manuscripts in Beinecke Library"
+  ],
+  "genre_ssim": [
+    "Decorated initials",
+    "Manuscripts"
+  ],
+  "format_ssim": "mixed material",
+  "partOf_ssim": "Beinecke Library",
+  "rights_ssim": [
+    "The use of this image may be subject to the copyright law of the United States (Title 17, United States Code) or to site license or other rights management terms and conditions. The person using the image is liable for any infringement."
+  ],
+  "bib_id_ssm": "9801995",
+  "orbisBarcode_ssim": "39002091594300",
+  "importUrl_ssim": "https://pre1600ms.beinecke.library.yale.edu/docs/pre1600.ms002.htm",
+  "references_ssim": [
+    "Jacopo Zeno, Vita Caroli Zeni. General Collection, Beinecke Rare Book and Manuscript Library, Yale University.",
+    "Shailor, B. Catalogue of Medieval and Renaissance Manuscripts in the Beinecke Rare Book and Manuscript Library, MS 2."
+  ],
+  "dateStructured_ssim": "1458-00-00T00:00:00Z",
+  "resourceType_ssim": "Archives or Manuscripts",
+  "id": 11684565,
+  "collectionId_ssim": 1,
+  "children_ssim": [],
+  "abstract_ssim": "Manuscript on parchment of Jacopo Zeno, Vita Caroli Zeni. With a dedicatory preface to Pope Pius II. This manuscript is of special importance because it contains the complete work."
+  ,
+  "public_bsi": true
+}

--- a/spec/fixtures/solr/oid-11913649.json
+++ b/spec/fixtures/solr/oid-11913649.json
@@ -1,0 +1,46 @@
+{
+  "source_ssim": "ladybird",
+  "recordType_ssim": "id",
+  "uri_ssim": "/ladybird/oid/11913649",
+  "identifierShelfMark_ssim": "Landberg MSS 492",
+  "author_tsim": [
+    "Maqrīzī, Aḥmad ibn ʻAlī, 1364-1442"
+  ],
+  "title_tsim": [
+    "al-Bayān wa-al-iʻrāb ʻammā bi-arḍ Miṣr min al-Aʻrāb / Aḥmad ibn ʻAlī al-Maqrīzī"
+  ],
+  "extentOfDigitization_ssim": "Complete work digitized.",
+  "date_ssim": "[18--?]",
+  "extent_ssim": "leaves ;",
+  "language_ssim": [
+    "Arabic"
+  ],
+  "description_ssim": [
+    "Modern (19th century) naskhī."
+  ],
+  "subjectTopic_ssim": [
+    "History--Egypt"
+  ],
+  "genre_ssim": [
+    "Manuscripts"
+  ],
+  "format_ssim": "text",
+  "partOf_ssim": "Beinecke Library",
+  "rights_ssim": [
+    "The use of this image may be subject to the copyright law of the United States (Title 17, United States Code) or to site license or other rights management terms and conditions. The person using the image is liable for any infringement."
+  ],
+  "bib_id_ssm": "3827095",
+  "orbisBarcode_ssim": "39002097273412",
+  "references_ssim": [
+    "Brockelmann,",
+    "II, 40; S II, p. 37."
+  ],
+  "dateStructured_ssim": "1800-00-00T00:00:00Z",
+  "illustrativeMatter_ssim": "ara d",
+  "id": 11913649,
+  "collectionId_ssim": 1,
+  "children_ssim": [],
+  "abstract_ssim": "Treatise on the Arab tribes which settled in Egypt."
+  ,
+  "public_bsi": true
+}

--- a/spec/fixtures/solr/oid-14716192.json
+++ b/spec/fixtures/solr/oid-14716192.json
@@ -1,0 +1,54 @@
+{
+  "source_ssim": "ladybird",
+  "recordType_ssim": "id",
+  "uri_ssim": "/ladybird/oid/14716192",
+  "identifierShelfMark_ssim": "Landberg MSS 75",
+  "author_tsim": [
+    "Kinānī, ʻAbd al-ʻAzīz ibn Yaḥyá, d. 854 or 5"
+  ],
+  "title_tsim": [
+    "Kitāb al-ḥaydah / li-ʻAbd al-ʻAzīz al-Kinānī al-Makkī. -- 1116."
+  ],
+  "alternativeTitle_tesim": [
+    "Ḥaydah wa-al-iʻtidhār fī al-radd ʾalá man qāla bi-khalq al-Qurʾān"
+  ],
+  "extentOfDigitization_ssim": "Complete work digitized.",
+  "extent_ssim": "82 leaves ; 21.5 x 15 cm.",
+  "language_ssim": [
+    "Arabic"
+  ],
+  "description_ssim": [
+    "Fair naskhī."
+  ],
+  "subjectName_ssim": [
+    "Maʾmūn,--Caliph,--786-833",
+    "Marīsī, Bishr ibn Ghayāth,--d. 833"
+  ],
+  "subjectTopic_ssim": [
+    "Theology--Dogmatics"
+  ],
+  "genre_ssim": [
+    "Manuscripts"
+  ],
+  "format_ssim": "text",
+  "partOf_ssim": "Beinecke Library",
+  "rights_ssim": [
+    "The use of this image may be subject to the copyright law of the United States (Title 17, United States Code) or to site license or other rights management terms and conditions. The person using the image is liable for any infringement."
+  ],
+  "bib_id_ssm": "3798665",
+  "orbisBarcode_ssim": "39002094341147",
+  "references_ssim": [
+    "440.",
+    "Berlin catalog,",
+    "Brockelmann,",
+    "I, 193; S I, p. 340."
+  ],
+  "dateStructured_ssim": "1116-00-00T00:00:00Z",
+  "illustrativeMatter_ssim": "ara d",
+  "id": 14716192,
+  "collectionId_ssim": 1,
+  "children_ssim": [],
+  "abstract_ssim": "Followed by 1 leaf of notes."
+  ,
+  "public_bsi": true
+}

--- a/spec/fixtures/solr/oid-15234629.json
+++ b/spec/fixtures/solr/oid-15234629.json
@@ -1,0 +1,43 @@
+{
+  "source_ssim": "ladybird",
+  "recordType_ssim": "id",
+  "uri_ssim": "/ladybird/oid/15234629",
+  "identifierShelfMark_ssim": "11 1860A",
+  "folder_ssim": "BRBL_00009",
+  "title_tsim": [
+    "[World map in Chinese, 1860.]"
+  ],
+  "extentOfDigitization_ssim": "Complete work digitized.",
+  "publicationPlace_ssim": [
+    "[China,"
+  ],
+  "date_ssim": "1860?]",
+  "extent_ssim": "85 x 160 cm.",
+  "language_ssim": [
+    "Chinese"
+  ],
+  "description_ssim": [
+    "Title supplied by cataloger."
+  ],
+  "scale_ssim": "Scale [ca. 1:35 000 000].",
+  "coordinates_ssim": "a",
+  "genre_ssim": [
+    "Maps",
+    "World maps--1860"
+  ],
+  "format_ssim": "cartographic",
+  "partOf_ssim": "Beinecke Library",
+  "rights_ssim": [
+    "The use of this image may be subject to the copyright law of the United States (Title 17, United States Code) or to site license or other rights management terms and conditions. The person using the image is liable for any infringement"
+  ],
+  "bib_id_ssm": "8394689",
+  "orbisBarcode_ssim": "39002091118928",
+  "dateStructured_ssim": "1860-00-00T00:00:00Z",
+  "resourceType_ssim": "Maps, Atlases & Globes",
+  "illustrativeMatter_ssim": "chi d",
+  "id": 15234629,
+  "collectionId_ssim": 1,
+  "children_ssim": []
+  ,
+  "public_bsi": true
+}

--- a/spec/fixtures/solr/oid-16057777.json
+++ b/spec/fixtures/solr/oid-16057777.json
@@ -1,0 +1,59 @@
+{
+  "source_ssim": "ladybird",
+  "recordType_ssim": "id",
+  "uri_ssim": "/ladybird/oid/16057777",
+  "identifierShelfMark_ssim": "WA MSS S-3019",
+  "box_ssim": "Box 1",
+  "sourceTitle_ssim": "[Objects associated with Buffalo Bill]",
+  "sourceDate_ssim": "[circa 1870-1895]",
+  "author_tsim": [
+    "James Dalziel Dougall and Sons"
+  ],
+  "title_tsim": [
+    "Double-barrel shotgun"
+  ],
+  "date_ssim": "ca. 1874",
+  "extent_ssim": "1 shotgun ; 121 cm.",
+  "description_ssim": [
+    "One double-barrel shotgun made by James Dalziel Dougall and Sons, and owned by John Burwell \"Texas Jack\" Omohundro, as a gift from the Irish game hunter Windham Thomas Wyndham-Quin, 4th Earl of Dunraven. The gun is 121 cm in length and was engraved by the maker in several places: \"J. D. Dougall. Gun and Rifle Manufacturer to H. R. H. The Prince of Wales. 59 St. James's St. London\" on low concave game rib, \"J. D. Dougall's Patent Lockfast\" on the bottom of the action, \"J. D. Dougall\" on each lockplate, and the serial number \"3303\" on the tang. An oval copper plate set in the bottom edge of the European walnut straight grip buttstock is engraved: \"From / Earl Dunraven / to / Texas Jack / 1874.\""
+  ],
+  "subjectName_ssim": [
+    "Buffalo Bill,--1846-1917.",
+    "Buffalo Bill's Wild West Company.",
+    "Buffalo Bill's Wild West Show.",
+    "Dunraven, Windham Thomas Wyndham-Quin,--Earl of,--1841-1926.",
+    "Dunraven, Windham Thomas Wyndham-Quin,--Earl of,--1841-1926--Presentation inscription to John Burwell Omohundro.",
+    "James Dalziel Dougall and Sons",
+    "Omohundro, John Burwell,--1846-1880.",
+    "Omohundro, John Burwell,--1846-1880--Presentation inscription from Windham Thomas Wyndham-Quin.",
+    "Salsbury, Nathan,--1846-1902.",
+    "Sitting Bull,--1831-1890."
+  ],
+  "subjectTopic_ssim": [
+    "Theatrical managers--United States.",
+    "Wild west shows."
+  ],
+  "genre_ssim": [
+    "Shotguns--England--19th century."
+  ],
+  "format_ssim": "three dimensional object",
+  "partOf_ssim": "Beinecke Library",
+  "rights_ssim": [
+    "The use of this image may be subject to the copyright law of the United States (Title 17, United States Code) or to site license or other rights management terms and conditions. The person using the image is liable for any infringement"
+  ],
+  "bib_id_ssm": "12442385",
+  "importUrl_ssim": "http://beinecke.library.yale.edu/dl_crosscollex/callnumSRCHXC.asp?&amp;CN=WA_MSS_S-3019",
+  "references_ssim": [
+    "Nathan Salsbury, Objects Associated with Buffalo Bill. Yale Collection of Western Americana, Beinecke Rare Book and Manuscript Library."
+  ],
+  "dateStructured_ssim": "1870-00-00T00:00:00Z",
+  "resourceType_ssim": "Tools, Equipment & Instruments",
+  "illustrativeMatter_ssim": "150424i18701895vp nnn            rneng d",
+  "copyrightDate_ssim": "[circa 1870-1895]",
+  "id": 16057777,
+  "collectionId_ssim": 1,
+  "children_ssim": [],
+  "abstract_ssim": "Nathan Salsbury (1846-1902), Civil War veteran, actor, and theatrical entrepreneur; after 1884 co-owner, producer and manager of \"Buffalo Bill's Wild West Show.\""
+  ,
+  "public_bsi": true
+}

--- a/spec/fixtures/solr/oid-16057779.json
+++ b/spec/fixtures/solr/oid-16057779.json
@@ -1,0 +1,51 @@
+{
+  "source_ssim": "ladybird",
+  "recordType_ssim": "id",
+  "uri_ssim": "/ladybird/oid/16057779",
+  "identifierShelfMark_ssim": "WA MSS S-3019",
+  "box_ssim": "Box 2",
+  "sourceTitle_ssim": "[Objects associated with Buffalo Bill]",
+  "sourceDate_ssim": "[circa 1870-1895]",
+  "title_tsim": [
+    "Rawhide bolas"
+  ],
+  "date_ssim": "[1870]",
+  "extent_ssim": "1 bolas : 121 cm.",
+  "description_ssim": [
+    "One twisted rawhide bolas with three rawhide-covered weights, and measuring 121 cm in length. Used to capture running game during a hunt, the bolas is unmarked and its original owner is unidentified."
+  ],
+  "subjectName_ssim": [
+    "Buffalo Bill,--1846-1917.",
+    "Buffalo Bill's Wild West Company.",
+    "Buffalo Bill's Wild West Show.",
+    "Salsbury, Nathan,--1846-1902.",
+    "Sitting Bull,--1831-1890."
+  ],
+  "subjectTopic_ssim": [
+    "Theatrical managers--United States.",
+    "Wild west shows."
+  ],
+  "genre_ssim": [
+    "Bolas (projectile weapons)--United States--19th century."
+  ],
+  "format_ssim": "three dimensional object",
+  "partOf_ssim": "Beinecke Library",
+  "rights_ssim": [
+    "The use of this image may be subject to the copyright law of the United States (Title 17, United States Code) or to site license or other rights management terms and conditions. The person using the image is liable for any infringement"
+  ],
+  "bib_id_ssm": "12442385",
+  "importUrl_ssim": "http://beinecke.library.yale.edu/dl_crosscollex/callnumSRCHXC.asp?&amp;CN=WA_MSS_S-3019",
+  "references_ssim": [
+    "Nathan Salsbury, Objects Associated with Buffalo Bill. Yale Collection of Western Americana, Beinecke Rare Book and Manuscript Library."
+  ],
+  "dateStructured_ssim": "1870-00-00T00:00:00Z",
+  "resourceType_ssim": "Tools, Equipment & Instruments",
+  "illustrativeMatter_ssim": "150424i18701895vp nnn            rneng d",
+  "copyrightDate_ssim": "[circa 1870-1895]",
+  "id": 16057779,
+  "collectionId_ssim": 1,
+  "children_ssim": [],
+  "abstract_ssim": "Nathan Salsbury (1846-1902), Civil War veteran, actor, and theatrical entrepreneur; after 1884 co-owner, producer and manager of \"Buffalo Bill's Wild West Show.\""
+  ,
+  "public_bsi": true
+}

--- a/spec/fixtures/solr/oid-16057780.json
+++ b/spec/fixtures/solr/oid-16057780.json
@@ -1,0 +1,56 @@
+{
+  "source_ssim": "ladybird",
+  "recordType_ssim": "id",
+  "uri_ssim": "/ladybird/oid/16057780",
+  "identifierShelfMark_ssim": "WA MSS S-3019",
+  "box_ssim": "Box 5",
+  "sourceTitle_ssim": "[Objects associated with Buffalo Bill]",
+  "sourceDate_ssim": "[circa 1870-1895]",
+  "author_tsim": [
+    "Colt's Patent Fire Arms Manufacturing Co"
+  ],
+  "title_tsim": [
+    "Colt revolver"
+  ],
+  "date_ssim": "ca. 1895",
+  "extent_ssim": "1 revolver + case : 29 cm.",
+  "description_ssim": [
+    "One revolver made by Colt's Patent Fire-Arms Manufacturing Company and owned by Nathan Salsbury. The gun is 29 cm in length and was stamped in several places: \"Colt's PT. F. A. Mfg. Co. Hartford CT. U.S.A. / Patented Aug.5.1884 Nov.6.88. Mar.5.95.\" along the top of the barrel, \"Colt. D. A. 38\" along the side of the barrel, and a rampant colt in a circle at the top of the ivory grip. It is stamped \"411\" on the cylinder release, and with serial number \"15 / 936\" on the buttstrap. The monogram \"NS\" is inlaid in gold on the side between the grip and the cylinder, and is surrounded by engraved flourishes. The revolver is housed in a fitted velvet-lined box."
+  ],
+  "subjectName_ssim": [
+    "Buffalo Bill,--1846-1917.",
+    "Buffalo Bill's Wild West Company.",
+    "Buffalo Bill's Wild West Show.",
+    "Colt's Patent Fire Arms Manufacturing Co",
+    "Colt's Patent Fire Arms Manufacturing Co.",
+    "Salsbury, Nathan,--1846-1902.",
+    "Sitting Bull,--1831-1890."
+  ],
+  "subjectTopic_ssim": [
+    "Theatrical managers--United States.",
+    "Wild west shows."
+  ],
+  "genre_ssim": [
+    "Revolvers (firearms)--United States--19th century."
+  ],
+  "format_ssim": "three dimensional object",
+  "partOf_ssim": "Beinecke Library",
+  "rights_ssim": [
+    "The use of this image may be subject to the copyright law of the United States (Title 17, United States Code) or to site license or other rights management terms and conditions. The person using the image is liable for any infringement"
+  ],
+  "bib_id_ssm": "12442385",
+  "importUrl_ssim": "http://beinecke.library.yale.edu/dl_crosscollex/callnumSRCHXC.asp?&amp;CN=WA_MSS_S-3019",
+  "references_ssim": [
+    "Nathan Salsbury, Objects Associated with Buffalo Bill. Yale Collection of Western Americana, Beinecke Rare Book and Manuscript Library."
+  ],
+  "dateStructured_ssim": "1870-00-00T00:00:00Z",
+  "resourceType_ssim": "Tools, Equipment & Instruments",
+  "illustrativeMatter_ssim": "150424i18701895vp nnn            rneng d",
+  "copyrightDate_ssim": "[circa 1870-1895]",
+  "id": 16057780,
+  "collectionId_ssim": 1,
+  "children_ssim": [],
+  "abstract_ssim": "Nathan Salsbury (1846-1902), Civil War veteran, actor, and theatrical entrepreneur; after 1884 co-owner, producer and manager of \"Buffalo Bill's Wild West Show.\""
+  ,
+  "public_bsi": true
+}

--- a/spec/fixtures/solr/oid-16156712.json
+++ b/spec/fixtures/solr/oid-16156712.json
@@ -1,0 +1,67 @@
+{
+  "source_ssim": "ladybird",
+  "recordType_ssim": "id",
+  "uri_ssim": "/ladybird/oid/16156712",
+  "identifierShelfMark_ssim": "Takamiya MS 97",
+  "title_tsim": [
+    "Mirour of mans salvacioune."
+  ],
+  "alternativeTitle_tesim": [
+    "Speculum humanae salvationis. English, Middle (ca. 1100-1500)"
+  ],
+  "extentOfDigitization_ssim": "Complete work digitized.",
+  "publicationPlace_ssim": [
+    "[England],"
+  ],
+  "date_ssim": "[ca. 1450]",
+  "extent_ssim": "64 l. : paper ; 284 x 210 mm.",
+  "language_ssim": [
+    "English, Middle (1100-1500)"
+  ],
+  "description_ssim": [
+    "Binding: nineteenth-century full brown morocco, gilt.",
+    "Decoration: some initials, line fillers, underlining, in red ink.",
+    "Ex libris Alfred Henry Huth; Sir Leicester Harmsworth; William and Christina Foyle. On deposit from the collection of Toshiyuki Takamiya, 2013-.",
+    "Layout: single columns of 17 lines.",
+    "Script: gothic bookhand.",
+    "Some errors in contemporary foliation."
+  ],
+  "subjectName_ssim": [
+    "Foyle, William A.--(William Alfred),--1885-1963--Bookplate.",
+    "Harmsworth, R. Leicester--(Robert Leicester),--Sir,--1870-1937--Ownership.",
+    "Huth, Alfred Henry,--1850-1910--Bookplate."
+  ],
+  "subjectTopic_ssim": [
+    "Christian life--Early works to 1800.",
+    "Devotional literature, English (Middle)",
+    "English literature--Middle English, 1100-1500.",
+    "English poetry--Middle English, 1100-1500.",
+    "Manuscripts, Medieval--Connecticut--New Haven.",
+    "Medieval and Renaissance Manuscripts in Beinecke Library.",
+    "Salvation--Early works to 1800.",
+    "Typology (Theology)--Early works to 1800."
+  ],
+  "genre_ssim": [
+    "Manuscripts, Medieval--England--15th century."
+  ],
+  "format_ssim": "text",
+  "partOf_ssim": "Beinecke Library",
+  "rights_ssim": [
+    "The use of this image may be subject to the copyright law of the United States (Title 17, United States Code) or to site license or other rights management terms and conditions. The person using the image is liable for any infringement."
+  ],
+  "bib_id_ssm": "11756910",
+  "orbisBarcode_ssim": "39002091549304",
+  "references_ssim": [
+    "A handlist of western Medieval manuscripts in the Takamiya collection / Toshiyuki Takamiya, in The Medieval book: glosses from friends &amp; colleagues of Christopher de Hamel, ed. by Richard Linenthal, James Marrow and William Noel. 't Goy-Houten: Hes &amp; De Graff, 2010, pp. 421-437.",
+    "Mirour of mans salvacioune. Takamiya MS 97."
+  ],
+  "dateStructured_ssim": "1450-00-00T00:00:00Z",
+  "resourceType_ssim": "Archives or Manuscripts",
+  "illustrativeMatter_ssim": "131114s1450    ctu                 enm d",
+  "id": 16156712,
+  "collectionId_ssim": 1,
+  "children_ssim": [],
+  "abstract_ssim": "Manuscript, on paper, in a single hand, of the English verse translation of this work of popular theology and devotional meditation."
+  ,
+  "public_bsi": true
+}

--- a/spec/fixtures/solr/oid-16162984.json
+++ b/spec/fixtures/solr/oid-16162984.json
@@ -1,0 +1,60 @@
+{
+  "source_ssim": "ladybird",
+  "recordType_ssim": "id",
+  "uri_ssim": "/ladybird/oid/16162984",
+  "identifierShelfMark_ssim": "Takamiya MS 36",
+  "title_tsim": [
+    "Old testament chronicle and genealogy of Christ (Part 1)."
+  ],
+  "extentOfDigitization_ssim": "Complete work digitized.",
+  "publicationPlace_ssim": [
+    "[England],"
+  ],
+  "date_ssim": "[ca. 1400-1450]",
+  "extent_ssim": "1 roll : parchment ; 1600 x 291 mm.",
+  "language_ssim": [
+    "English, Middle (1100-1500)"
+  ],
+  "description_ssim": [
+    "Annotation at top of roll in late 18th century hand attributing ownership in 1485 to Richard Kidderminster, Abbot of Winchecombe.",
+    "Binding: modern case.",
+    "Decoration: names in colored cartouches of green or brown squares.",
+    "Layout: double column.",
+    "On deposit from the collection of Toshiyuki Takamiya, 2013-.",
+    "Originally formed a single roll with Takamiya MS 53.",
+    "Script: English gothic bookhand."
+  ],
+  "subjectName_ssim": [
+    "Jesus Christ--Genealogy--Early works to 1800."
+  ],
+  "subjectTopic_ssim": [
+    "Bible--Chronology--Early works to 1800.",
+    "English literature--Middle English, 1100-1500.",
+    "English prose literature--Middle English, 1100-1500.",
+    "Manuscripts, Medieval--Connecticut--New Haven.",
+    "Medieval and Renaissance Manuscripts in Beinecke Library."
+  ],
+  "genre_ssim": [
+    "Manuscripts, Medieval--England--15th century."
+  ],
+  "format_ssim": "text",
+  "partOf_ssim": "Beinecke Library",
+  "rights_ssim": [
+    "The use of this image may be subject to the copyright law of the United States (Title 17, United States Code) or to site license or other rights management terms and conditions. The person using the image is liable for any infringement."
+  ],
+  "bib_id_ssm": "11781026",
+  "orbisBarcode_ssim": "39002091549445",
+  "references_ssim": [
+    "A handlist of western Medieval manuscripts in the Takamiya collection / Toshiyuki Takamiya, in The Medieval book: glosses from friends &amp; colleagues of Christopher de Hamel, ed. by Richard Linenthal, James Marrow and William Noel. 't Goy-Houten: Hes &amp; De Graff, 2010, pp. 421-437.",
+    "Old Testament Chronicle and Genealogy of Christ (Part 1). Takamiya MS 36."
+  ],
+  "dateStructured_ssim": "1400-00-00T00:00:00Z",
+  "resourceType_ssim": "Archives or Manuscripts",
+  "illustrativeMatter_ssim": "131202i14001450ctu                 enm d",
+  "id": 16162984,
+  "collectionId_ssim": 1,
+  "children_ssim": [],
+  "abstract_ssim": "Manuscript, on vellum, in a single hand, containing the first section of an Old Testament chronicle and genealogy of Christ in Middle English prose."
+  ,
+  "public_bsi": true
+}

--- a/spec/fixtures/solr/oid-16173726.json
+++ b/spec/fixtures/solr/oid-16173726.json
@@ -1,0 +1,58 @@
+{
+  "source_ssim": "ladybird",
+  "recordType_ssim": "id",
+  "uri_ssim": "/ladybird/oid/16173726",
+  "identifierShelfMark_ssim": "Covers 5626 +1880",
+  "author_tsim": [
+    "Li, Mengquan (Cartographer), cartographer.",
+    "李蒙泉 (Cartographer), cartographer."
+  ],
+  "title_tsim": [
+    "Su Sheng yu di ying wu quan tu / ji yong zhi xian Li Mengquan, Chen Jiaxun tong jian hua."
+  ],
+  "alternativeTitle_tesim": [
+    "蘇省輿地營伍全圖 / 即用知縣李蒙泉, 陳嘉勲仝監畫."
+  ],
+  "extentOfDigitization_ssim": "Complete work digitized.",
+  "extent_ssim": "1 map on 6 volumes : color ; 124 x 159 cm, folded to 27 x 9 cm",
+  "language_ssim": [
+    "Chinese"
+  ],
+  "description_ssim": [
+    "\"Mei fang er shi li\"--Volume 6.",
+    "\"每方二十里\"--Volume 6."
+  ],
+  "subjectName_ssim": [
+    "Chen, Jiaxun (Cartographer), cartographer.",
+    "陳嘉勲 (Cartographer), cartographer."
+  ],
+  "subjectTopic_ssim": [
+    "Chinese rare maps.",
+    "Military camps.--(OCoLC)fst01021054",
+    "Military camps--China--Jiangsu Sheng--Maps."
+  ],
+  "geoSubject_ssim": "a-cc-ku",
+  "scale_ssim": "Scale not given.",
+  "coordinates_ssim": "a",
+  "genre_ssim": [
+    "Maps.--(OCoLC)fst01423704",
+    "Military maps.",
+    "Pictorial maps."
+  ],
+  "format_ssim": "cartographic",
+  "partOf_ssim": "Beinecke Library",
+  "rights_ssim": [
+    "The use of this image may be subject to the copyright law of the United States (Title 17, United States Code) or to site license or other rights management terms and conditions. The person using the image is liable for any infringement."
+  ],
+  "bib_id_ssm": "12286028",
+  "orbisBarcode_ssim": "39002113593728",
+  "dateStructured_ssim": "1880-00-00T00:00:00Z",
+  "resourceType_ssim": "Maps, Atlases & Globes",
+  "illustrativeMatter_ssim": "141028s1880    cc        a     0   chi d",
+  "copyrightDate_ssim": "[1880?]",
+  "id": 16173726,
+  "collectionId_ssim": 1,
+  "children_ssim": []
+  ,
+  "public_bsi": true
+}

--- a/spec/fixtures/solr/oid-16189096.json
+++ b/spec/fixtures/solr/oid-16189096.json
@@ -1,0 +1,52 @@
+{
+  "source_ssim": "ladybird",
+  "recordType_ssim": "id",
+  "uri_ssim": "/ladybird/oid/16189096",
+  "identifierShelfMark_ssim": "Covers 5615 +1857",
+  "author_tsim": [
+    "Dong, Chun (Cartographer), cartographer.",
+    "董醇 (Cartographer), cartographer."
+  ],
+  "title_tsim": [
+    "Zhi li Da Qing He yuan liu zong tu / Qing he dao Dong Chun."
+  ],
+  "alternativeTitle_tesim": [
+    "Map of Ta Ch'ing River",
+    "直隷大清河源流總圖 / 清河道董醇."
+  ],
+  "extentOfDigitization_ssim": "Complete work digitized.",
+  "extent_ssim": "1 map : color ; 27 x 150 cm, folded to 27 x 13 cm",
+  "language_ssim": [
+    "Chinese"
+  ],
+  "description_ssim": [
+    "Jing zhe zhuang.",
+    "經折裝."
+  ],
+  "subjectTopic_ssim": [
+    "Chinese rare maps."
+  ],
+  "geoSubject_ssim": "a-cc---",
+  "scale_ssim": "Scale not given.",
+  "coordinates_ssim": "a",
+  "genre_ssim": [
+    "Maps.--(OCoLC)fst01423704",
+    "Pictorial maps."
+  ],
+  "format_ssim": "cartographic",
+  "partOf_ssim": "Beinecke Library",
+  "rights_ssim": [
+    "The use of this image may be subject to the copyright law of the United States (Title 17, United States Code) or to site license or other rights management terms and conditions. The person using the image is liable for any infringement."
+  ],
+  "bib_id_ssm": "8317945",
+  "orbisBarcode_ssim": "39002113593827",
+  "dateStructured_ssim": "1857-00-00T00:00:00Z",
+  "resourceType_ssim": "Maps, Atlases & Globes",
+  "illustrativeMatter_ssim": "080805s1857    cc        a     0   chi d",
+  "copyrightDate_ssim": "咸豐7 [1857]",
+  "id": 16189096,
+  "collectionId_ssim": 1,
+  "children_ssim": []
+  ,
+  "public_bsi": true
+}

--- a/spec/fixtures/solr/oid-16189097.json
+++ b/spec/fixtures/solr/oid-16189097.json
@@ -1,0 +1,46 @@
+{
+  "source_ssim": "ladybird",
+  "recordType_ssim": "id",
+  "uri_ssim": "/ladybird/oid/16189097",
+  "identifierShelfMark_ssim": "Lanman Covers 56 189x",
+  "title_tsim": [
+    "[Map of China]."
+  ],
+  "extentOfDigitization_ssim": "Complete work digitized.",
+  "publicationPlace_ssim": [
+    "Kyoto [Japan] :"
+  ],
+  "publisher_ssim": [
+    "Umemura Yahaku,"
+  ],
+  "date_ssim": "[189x?]",
+  "extent_ssim": "1 map ; folded in covers 25 x 16 cm.",
+  "language_ssim": [
+    "Japanese"
+  ],
+  "description_ssim": [
+    "In Japanese.",
+    "Japanese reprint of a Chinese map published in 1663.",
+    "Transliteration supplied by cataloger."
+  ],
+  "geoSubject_ssim": "China--Maps.",
+  "scale_ssim": "Scale not given.",
+  "coordinates_ssim": "a",
+  "genre_ssim": [
+    "Maps."
+  ],
+  "format_ssim": "cartographic",
+  "partOf_ssim": "Beinecke Library",
+  "rights_ssim": [
+    "The use of this image may be subject to the copyright law of the United States (Title 17, United States Code) or to site license or other rights management terms and conditions. The person using the image is liable for any infringement."
+  ],
+  "bib_id_ssm": "8330740",
+  "orbisBarcode_ssim": "39002113593819",
+  "resourceType_ssim": "Maps, Atlases & Globes",
+  "illustrativeMatter_ssim": "080815s189u    ja ",
+  "id": 16189097,
+  "collectionId_ssim": 1,
+  "children_ssim": []
+  ,
+  "public_bsi": true
+}

--- a/spec/fixtures/solr/oid-16301942.json
+++ b/spec/fixtures/solr/oid-16301942.json
@@ -1,0 +1,73 @@
+{
+  "source_ssim": "ladybird",
+  "recordType_ssim": "id",
+  "uri_ssim": "/ladybird/oid/16301942",
+  "identifierShelfMark_ssim": "YCAL MSS 229",
+  "sourceDate_ssim": "1958-1967",
+  "sourceNote_ssim": "Three scrapbooks, compiled by Jane Wodening, containing correspondence, photographs, manuscripts, printed material, artwork, cut film, and objects documenting the work and family life of Wodening (ne?e Collom) and Stan Brakhage from 1958 to 1967.",
+  "author_tsim": [
+    "Brakhage, Stan"
+  ],
+  "title_tsim": [
+    "Jane Wodening and Stan Brakhage scrapbook"
+  ],
+  "numberOfPages_ssim": "Vol. 3",
+  "extentOfDigitization_ssim": "Complete work digitized.",
+  "date_ssim": "1958-1967",
+  "extent_ssim": "1 vol. ; 36 cm.",
+  "language_ssim": [
+    "English"
+  ],
+  "subjectName_ssim": [
+    "Beck, Julian, 1925-1985",
+    "Branaman, Robert R",
+    "Coleridge, Samuel Taylor, 1772-1834",
+    "Creeley, Robert, 1926-2005",
+    "Duncan, Robert, 1919-1988.",
+    "Flaming creatures (Motion picture)",
+    "Gamow, George, 1904-1968",
+    "Ginsberg, Allen, 1926-1997",
+    "Goodyear, John, 1930-",
+    "Highet, Gilbert, 1906-1978",
+    "Kelly, Robert, 1935-",
+    "Lytton, Edward Robert Bulwer Lytton,--Earl of,--1831-1891",
+    "Malina, Judith, 1926-",
+    "McClure, Michael",
+    "Mekas, Jonas, 1922-",
+    "Munsell, Joel, 1808-1880",
+    "Olson, Charles, 1910-1970",
+    "Stein, Gertrude, 1874-1946",
+    "Steinbeck, John, 1902-1968"
+  ],
+  "geoSubject_ssim": "Crazy Horse Mountain (S.D.)",
+  "genre_ssim": [
+    "Artifacts",
+    "Clippings",
+    "Correspondence",
+    "Ephemera",
+    "Filmstrips",
+    "Illustrations",
+    "Photographic prints",
+    "Photographs",
+    "Poems",
+    "Scrapbooks"
+  ],
+  "format_ssim": "still image",
+  "partOf_ssim": "Beinecke Library",
+  "rights_ssim": [
+    "The use of this image may be subject to the copyright law of the United States (Title 17, United States Code) or to site license or other rights management terms and conditions. The person using the image is liable for any infringement."
+  ],
+  "bib_id_ssm": "7748458",
+  "orbisBarcode_ssim": "39002098971766",
+  "references_ssim": [
+    "Jane Wodening and Stan Brakhage Scrapbooks. Yale Collection of American Literature, Beinecke Rare Book and Manuscript Library."
+  ],
+  "dateStructured_ssim": "1958-00-00T00:00:00Z",
+  "resourceType_ssim": "Archives or Manuscripts",
+  "id": 16301942,
+  "collectionId_ssim": 1,
+  "children_ssim": [],
+  "abstract_ssim": "Binding: ivory with gold embossing."
+  ,
+  "public_bsi": true
+}

--- a/spec/fixtures/solr/oid-16371253.json
+++ b/spec/fixtures/solr/oid-16371253.json
@@ -1,0 +1,57 @@
+{
+  "source_ssim": "ladybird",
+  "recordType_ssim": "id",
+  "uri_ssim": "/ladybird/oid/16371253",
+  "identifierShelfMark_ssim": "Takamiya MS 81",
+  "title_tsim": [
+    "Missal, use of Sarum (fragment)"
+  ],
+  "extentOfDigitization_ssim": "Complete work digitized.",
+  "publicationPlace_ssim": [
+    "England,"
+  ],
+  "date_ssim": "[between 1400 and 1450]",
+  "extent_ssim": "3 l. : parchment ; 491 x 340 mm.",
+  "language_ssim": [
+    "Latin"
+  ],
+  "description_ssim": [
+    "Decoration: numerous initials in burnished gold or blue; extensive penwork.",
+    "From the collection of Toshiyuki Takamiya, 2013-.",
+    "Layout: double columns of 39 lines.",
+    "Script: gothic liturgical script."
+  ],
+  "subjectName_ssim": [
+    "Catholic Church.--Sarum manual."
+  ],
+  "subjectTopic_ssim": [
+    "Manuscripts, Medieval--Connecticut--New Haven.",
+    "Medieval and Renaissance Manuscript Fragments in Beinecke Library.",
+    "Medieval and Renaissance Manuscripts in Beinecke Library.",
+    "Missals--Early works to 1800."
+  ],
+  "genre_ssim": [
+    "Manuscripts, Medieval--England--15th century.",
+    "Missals--England--15th century."
+  ],
+  "format_ssim": "text",
+  "partOf_ssim": "Beinecke Library",
+  "rights_ssim": [
+    "The use of this image may be subject to the copyright law of the United States (Title 17, United States Code) or to site license or other rights management terms and conditions. The person using the image is liable for any infringement."
+  ],
+  "bib_id_ssm": "12297336",
+  "orbisBarcode_ssim": "39002104623971",
+  "references_ssim": [
+    "A handlist of western Medieval manuscripts in the Takamiya collection / Toshiyuki Takamiya, in The Medieval book: glosses from friends & colleagues of Christopher de Hamel, ed. by Richard Linenthal, James Marrow and William Noel. 't Goy-Houten: Hes & De Graff, 2010, pp. 421-437.",
+    "Missal, Use of Sarum (Fragment). Takamiya MS 81."
+  ],
+  "dateStructured_ssim": "1400-00-00T00:00:00Z",
+  "resourceType_ssim": "Archives or Manuscripts",
+  "illustrativeMatter_ssim": "141112i14001450ctu                 lat d",
+  "id": 16371253,
+  "collectionId_ssim": 1,
+  "children_ssim": [],
+  "abstract_ssim": "Manuscript leaves from a Sarum missal, containing text from Masses for the third and eighth Sundays after Pentecost and for the dedication of a church."
+  ,
+  "public_bsi": true
+}

--- a/spec/fixtures/solr/oid-16371267.json
+++ b/spec/fixtures/solr/oid-16371267.json
@@ -1,0 +1,53 @@
+{
+  "source_ssim": "ladybird",
+  "recordType_ssim": "id",
+  "uri_ssim": "/ladybird/oid/16371267",
+  "identifierShelfMark_ssim": "Takamiya MS 99",
+  "title_tsim": [
+    "Livre du Lancelot du Lac: three miniatures."
+  ],
+  "extentOfDigitization_ssim": "Complete work digitized.",
+  "publicationPlace_ssim": [
+    "Paris,"
+  ],
+  "date_ssim": "[ca. 1440]",
+  "extent_ssim": "3 items : parchment ; 100 x100 mm (largest)",
+  "language_ssim": [
+    "French, Middle (ca.1400-1600)"
+  ],
+  "description_ssim": [
+    "Binding: individually mounted.",
+    "From the collection of Toshiyuki Takamiya, 2013-."
+  ],
+  "subjectName_ssim": [
+    "Lancelot--(Legendary character)"
+  ],
+  "subjectTopic_ssim": [
+    "Arthurian romances in art.",
+    "Arthurian romances in art--Early works to 1800.",
+    "Manuscripts, Medieval--Connecticut--New Haven.",
+    "Medieval and Renaissance Manuscripts in Beinecke Library."
+  ],
+  "genre_ssim": [
+    "Manuscripts, Medieval--France--14th century."
+  ],
+  "format_ssim": "text",
+  "partOf_ssim": "Beinecke Library",
+  "rights_ssim": [
+    "The use of this image may be subject to the copyright law of the United States (Title 17, United States Code) or to site license or other rights management terms and conditions. The person using the image is liable for any infringement."
+  ],
+  "bib_id_ssm": "13006050",
+  "references_ssim": [
+    "A handlist of western Medieval manuscripts in the Takamiya collection / Toshiyuki Takamiya, in The Medieval book: glosses from friends & colleagues of Christopher de Hamel, ed. by Richard Linenthal, James Marrow and William Noel. 't Goy-Houten: Hes & De Graff, 2010, pp. 421-437.",
+    "Livre du Lancelot du Lac: three miniatures.. Takamiya MS 99."
+  ],
+  "dateStructured_ssim": "1440-00-00T00:00:00Z",
+  "resourceType_ssim": "Archives or Manuscripts",
+  "illustrativeMatter_ssim": "161219s1440    ctu                 frm d",
+  "id": 16371267,
+  "collectionId_ssim": 1,
+  "children_ssim": [],
+  "abstract_ssim": "Three miniatures, on vellum, from the copy of the Livre du Lancelot du Lac illustrated by the Dunois Master. They depict: 1) the Duke of Clarence and esquire, meeting a knight cutting off a woman's hair; 2) King Baudemagnus leading the battle against the Romans; 3) Lancelot's arrival at the city of Gorre."
+  ,
+  "public_bsi": true
+}

--- a/spec/fixtures/solr/oid-16371272.json
+++ b/spec/fixtures/solr/oid-16371272.json
@@ -1,0 +1,64 @@
+{
+  "source_ssim": "ladybird",
+  "recordType_ssim": "id",
+  "uri_ssim": "/ladybird/oid/16371272",
+  "identifierShelfMark_ssim": "Takamiya MS 104",
+  "title_tsim": [
+    "Bible (Proverbs to Apocalypse)."
+  ],
+  "extentOfDigitization_ssim": "Complete work digitized.",
+  "publicationPlace_ssim": [
+    "England,"
+  ],
+  "date_ssim": "[between 1200 and 1299]",
+  "extent_ssim": "218 l. : parchment ; 212 x 145 mm.",
+  "language_ssim": [
+    "Latin"
+  ],
+  "description_ssim": [
+    "Binding: modern goatskin.",
+    "Decoration: red and blue penwork initials.",
+    "Ex libris Ronald A. Coates; Eric Millar; Brian S. Cron. From the collection of Toshiyuki Takamiya, 2013-.",
+    "Layout: double columns of 49 lines.",
+    "Script: small gothic script.",
+    "With an Oxford pledge note for the Selton Loan Chest dated 1469 and the mark of the stationer John More. There is also a note by M. Paris, possibly Master Thomas Paris of Oriel College."
+  ],
+  "subjectName_ssim": [
+    "Coates, Ronald A.--Autograph.",
+    "Cron, Brian S.--Ownership.",
+    "Millar, Eric George--Bookplate.",
+    "Oriel College.",
+    "University of Oxford."
+  ],
+  "subjectTopic_ssim": [
+    "Bible.--Latin.",
+    "Bible.--Latin--Versions--Vulgate.",
+    "Manuscripts, Medieval--Connecticut--New Haven.",
+    "Medieval and Renaissance Manuscripts in Beinecke Library.",
+    "Universities and colleges--Great Britain."
+  ],
+  "genre_ssim": [
+    "Decorated initials",
+    "Manuscripts, Medieval--England--13th century."
+  ],
+  "format_ssim": "text",
+  "partOf_ssim": "Beinecke Library",
+  "rights_ssim": [
+    "The use of this image may be subject to the copyright law of the United States (Title 17, United States Code) or to site license or other rights management terms and conditions. The person using the image is liable for any infringement."
+  ],
+  "bib_id_ssm": "12329381",
+  "orbisBarcode_ssim": "39002104624045",
+  "references_ssim": [
+    "A handlist of western Medieval manuscripts in the Takamiya collection / Toshiyuki Takamiya, in The Medieval book: glosses from friends & colleagues of Christopher de Hamel, ed. by Richard Linenthal, James Marrow and William Noel. 't Goy-Houten: Hes & De Graff, 2010, pp. 421-437.",
+    "Bible (Proverbs to Apocalypse). Takamiya MS 104."
+  ],
+  "dateStructured_ssim": "1200-00-00T00:00:00Z",
+  "resourceType_ssim": "Archives or Manuscripts",
+  "illustrativeMatter_ssim": "141215i12001299ctu                 lat d",
+  "id": 16371272,
+  "collectionId_ssim": 1,
+  "children_ssim": [],
+  "abstract_ssim": "Manuscript, on parchment, of the books of the Bible from Proverbs through the Apocalypse."
+  ,
+  "public_bsi": true
+}

--- a/spec/fixtures/solr/oid-16414889.json
+++ b/spec/fixtures/solr/oid-16414889.json
@@ -1,0 +1,45 @@
+{
+  "source_ssim": "ladybird",
+  "recordType_ssim": "id",
+  "uri_ssim": "/ladybird/oid/16414889",
+  "identifierShelfMark_ssim": "1978 1351",
+  "author_tsim": [
+    "Cruikshank, George, 1792-1878."
+  ],
+  "title_tsim": [
+    "A comic alphabet, designed, etched & published by George Cruikshank, No. 23 Myddelton Terrace, Pentonville."
+  ],
+  "extentOfDigitization_ssim": "Complete work digitized.",
+  "date_ssim": "1836.",
+  "extent_ssim": "24 plates. 13 cm.",
+  "language_ssim": [
+    "English"
+  ],
+  "description_ssim": [
+    "Cover-title.",
+    "Plates printed on a continuous strip of paper, folded in Japanese fashion ; linen backed ; portrait of the publisher Tilt on back cover. cf. A. M. Cohn, George Cruikshank, no. 189."
+  ],
+  "genre_ssim": [
+    "Accordion fold format (Binding).",
+    "Alphabet books",
+    "Book illustrations",
+    "Cartoons (Humorous images)",
+    "Etchings",
+    "Intaglio prints"
+  ],
+  "format_ssim": "mixed material",
+  "partOf_ssim": "Beinecke Library",
+  "rights_ssim": [
+    "The use of this image may be subject to the copyright law of the United States (Title 17, United States Code) or to site license or other rights management terms and conditions. The person using the image is liable for any infringement."
+  ],
+  "bib_id_ssm": "3577942",
+  "orbisBarcode_ssim": "39002113596465",
+  "dateStructured_ssim": "1836-00-00T00:00:00Z",
+  "resourceType_ssim": "Books, Journals & Pamphlets",
+  "illustrativeMatter_ssim": "931103s1836    enk           00010 eng d",
+  "id": 16414889,
+  "collectionId_ssim": 1,
+  "children_ssim": []
+  ,
+  "public_bsi": true
+}

--- a/spec/fixtures/solr/oid-16425155.json
+++ b/spec/fixtures/solr/oid-16425155.json
@@ -1,0 +1,54 @@
+{
+  "source_ssim": "ladybird",
+  "recordType_ssim": "id",
+  "uri_ssim": "/ladybird/oid/16425155",
+  "identifierShelfMark_ssim": "Globe 21",
+  "author_tsim": [
+    "Coronelli, Vincenzo, 1650-1718."
+  ],
+  "title_tsim": [
+    "Amico Lettore / Oltre al molti Globi delineati dal P. Cosmografo Coronelli per Sourani diuersi di uarie e uaste misure ne ha ultimamente composti e stampi di cinque grandezze a publica beneficio, fra quali i piu commodi, ed exalti sono i presenti. I Numer"
+  ],
+  "extentOfDigitization_ssim": "Complete work digitized.",
+  "publicationPlace_ssim": [
+    "[Venice :"
+  ],
+  "publisher_ssim": [
+    "Accademia Cosmografica degli Argonauti,"
+  ],
+  "date_ssim": "1699]",
+  "extent_ssim": "1 globe : hand col., paper gores over papier-mâché and plaster, mounted on a carved baroque walnut stand . Brass meridian with wooden horizon (5 cm wide) with mounted hand col. zodiacal paper 47 cm. in diam.",
+  "description_ssim": [
+    "From the library of Jonathan T. Lanman.",
+    "Image of globe with further description is listed online under \"Lanman Globe Collection\"",
+    "Not in Younge's \"Catalogue of early globes\".",
+    "The globe shows three cartouches, one includes title the other two are left blank.",
+    "This celestial globe corresponds to Coronelli's terrestrial globe of 1699."
+  ],
+  "subjectName_ssim": [
+    "Lanman, Jonathan T"
+  ],
+  "subjectTopic_ssim": [
+    "Celestial globes--Early works to 1800."
+  ],
+  "scale_ssim": "Scale not given ;",
+  "projection_ssim": "Convex proj.",
+  "coordinates_ssim": "a",
+  "genre_ssim": [
+    "Celestial globes."
+  ],
+  "format_ssim": "three dimensional object",
+  "partOf_ssim": "Beinecke Library",
+  "rights_ssim": [
+    "The use of this image may be subject to the copyright law of the United States (Title 17, United States Code) or to site license or other rights management terms and conditions. The person using the image is liable for any infringement."
+  ],
+  "bib_id_ssm": "9884809",
+  "dateStructured_ssim": "1699-00-00T00:00:00Z",
+  "resourceType_ssim": "Maps, Atlases & Globes",
+  "illustrativeMatter_ssim": "850124q1699    it     zz d     0   ita",
+  "id": 16425155,
+  "collectionId_ssim": 1,
+  "children_ssim": []
+  ,
+  "public_bsi": true
+}

--- a/spec/fixtures/solr/oid-16570776.json
+++ b/spec/fixtures/solr/oid-16570776.json
@@ -1,0 +1,57 @@
+{
+  "source_ssim": "ladybird",
+  "recordType_ssim": "id",
+  "uri_ssim": "/ladybird/oid/16570776",
+  "identifierShelfMark_ssim": "EEa 794b",
+  "author_tsim": [
+    "Baldwyn, George Augustus."
+  ],
+  "title_tsim": [
+    "A new, royal, authentic, complete, and universal system of geography: or, A modern history and description of the whole world. Containing ... accounts and descriptions of Europe, Asia, Africa, and America ... including the substance and essence of the most remarkable voyages and travels ... particularly the late discoveries in the South seas, and towards the North pole ... Comprising every interesting discovery and circumstance in the narratives of Captain Cook's voyages round the world. Together with all the recent discoveries ... carefully written and compiled from the late journals of ... Captains Phillips, King, Ball, Hunter, White, Dixon, Portlock, Mears, Patterson, Bruce, Anbury, Rochon, Morse, Blyth, Ross, Imlay, Keate, Brissot, Hodges, &c. &c. Also compendious histories of every empire, kingdom, state, &c. ... The whole embellished and enriched with upwards of an hundred most elegant and superb copperplates ... By George Augustus Baldwyn, esq. assisted by many gentlemen eminent for their knowledge ... of geography; particularly Charles Andres Robertson, esq.--Clement Walley Oulton. esq.-- and Henry Hogg ..."
+  ],
+  "extentOfDigitization_ssim": "Complete work digitized.",
+  "publicationPlace_ssim": [
+    "London,"
+  ],
+  "publisher_ssim": [
+    "Sold by A. Hogg"
+  ],
+  "date_ssim": "[1794?]",
+  "extent_ssim": "iv [4] v-viii, v-cxii, 812 (i.e. 816) [4] p. front., 71 pl., 17 maps. 40 x 25 cm.",
+  "language_ssim": [
+    "English"
+  ],
+  "description_ssim": [
+    "Autograph of N.B. Haswell.",
+    "Irregularities in paging 1 map (Europe) wanting.",
+    "Many of the plates dated 1794."
+  ],
+  "subjectName_ssim": [
+    "Haswell, N.B.--Autograph.",
+    "Hogg, Henry.",
+    "Outlon, Clement Walley.",
+    "Robertson, Charles Andrew."
+  ],
+  "subjectTopic_ssim": [
+    "Geography."
+  ],
+  "genre_ssim": [
+    "Intaglio prints",
+    "Maps"
+  ],
+  "format_ssim": "text",
+  "partOf_ssim": "Beinecke Library",
+  "rights_ssim": [
+    "The use of this image may be subject to the copyright law of the United States (Title 17, United States Code) or to site license or other rights management terms and conditions. The person using the image is liable for any infringement."
+  ],
+  "bib_id_ssm": "5404463",
+  "orbisBarcode_ssim": "39002002294065",
+  "dateStructured_ssim": "1794-00-00T00:00:00Z",
+  "resourceType_ssim": "Books, Journals & Pamphlets",
+  "illustrativeMatter_ssim": "841208s1794    enkbf         000 0 eng",
+  "id": 16570776,
+  "collectionId_ssim": 1,
+  "children_ssim": []
+  ,
+  "public_bsi": true
+}

--- a/spec/fixtures/solr/oid-16685691.json
+++ b/spec/fixtures/solr/oid-16685691.json
@@ -1,0 +1,58 @@
+{
+  "source_ssim": "ladybird",
+  "recordType_ssim": "id",
+  "uri_ssim": "/ladybird/oid/16685691",
+  "identifierShelfMark_ssim": "BrSides Elephant Folio 2018 22",
+  "author_tsim": [
+    "United States. Hydrographic Office"
+  ],
+  "title_tsim": [
+    "Tracks for full powered steam vessels with the shortest navigable distances in nautical miles from anchorage to anchorage, New York distances are measures to and from the Battery achorage."
+  ],
+  "extentOfDigitization_ssim": "Complete work digitized.",
+  "edition_ssim": [
+    "16th edition, I '16."
+  ],
+  "publicationPlace_ssim": [
+    "Washington, D.C. :"
+  ],
+  "publisher_ssim": [
+    "Published ... at the Hydrographic Office, "
+  ],
+  "date_ssim": "Sep., 1914 [that is, 1916]",
+  "extent_ssim": "1 map : color ; 67 x 112 cm",
+  "language_ssim": [
+    "English"
+  ],
+  "description_ssim": [
+    "\"No. 1262.\"",
+    "\"Small corrections from notices to mariners ('15-2, 18, 30, from other sources I '16.\"",
+    "Includes charts: \"Speeds per hour with daily and weekly distances in nautical miles\" and \"Reduction knots on nautical miles to statute miles.\" Also includes 4 distance charts.",
+    "Relief shown by hachures and spot heights."
+  ],
+  "subjectTopic_ssim": [
+    "Steam-navigation--Maps."
+  ],
+  "geoSubject_ssim": "x------",
+  "scale_ssim": "Scale approximately 1:50,000,000",
+  "coordinates_ssim": "a",
+  "genre_ssim": [
+    "World maps"
+  ],
+  "format_ssim": "cartographic",
+  "partOf_ssim": "Beinecke Library",
+  "rights_ssim": [
+    "The use of this image may be subject to the copyright law of the United States (Title 17, United States Code) or to site license or other rights management terms and conditions. The person using the image is liable for any infringement"
+  ],
+  "bib_id_ssm": "13881242",
+  "orbisBarcode_ssim": "39002131329220",
+  "dateStructured_ssim": "1916-00-00T00:00:00Z",
+  "resourceType_ssim": "Maps, Atlases & Globes",
+  "illustrativeMatter_ssim": "181211s1916    dcudg     a     0   eng d",
+  "copyrightDate_ssim": "Sep., 1914 [that is, 1916]",
+  "id": 16685691,
+  "collectionId_ssim": 1,
+  "children_ssim": []
+  ,
+  "public_bsi": true
+}

--- a/spec/fixtures/solr/oid-16700283.json
+++ b/spec/fixtures/solr/oid-16700283.json
@@ -1,0 +1,56 @@
+{
+  "source_ssim": "ladybird",
+  "recordType_ssim": "id",
+  "uri_ssim": "/ladybird/oid/16700283",
+  "identifierShelfMark_ssim": "Takamiya MS 142",
+  "title_tsim": [
+    "Book of hours (fragment)"
+  ],
+  "extentOfDigitization_ssim": "Complete work digitized.",
+  "publicationPlace_ssim": [
+    "Flanders,"
+  ],
+  "date_ssim": "[ca. 1300]",
+  "extent_ssim": "1 l. : parchment ; 65 x 85 mm",
+  "language_ssim": [
+    "Latin"
+  ],
+  "description_ssim": [
+    "Byname: Ghistelles Hours.",
+    "Decoration: decorated border showing two hounds chasing a stag.",
+    "Previously owned by Sir Sydney Cockerell? Previously owned by Alan G. Thomas. From the collection of Toshiyuki Takamiya, 2013-.",
+    "Script: Gothic."
+  ],
+  "subjectName_ssim": [
+    "Cockerell, Sydney Carlyle,--Sir,--1867-1962--Ownership.",
+    "Thomas, Alan G.--Ownership."
+  ],
+  "subjectTopic_ssim": [
+    "Books of hours--Early works to 1800",
+    "Manuscripts, Medieval--Connecticut--New Haven",
+    "Medieval and Renaissance Manuscripts in Beinecke Library"
+  ],
+  "genre_ssim": [
+    "Manuscripts, Medieval--Flanders--14th century"
+  ],
+  "format_ssim": "text",
+  "partOf_ssim": "Beinecke Library",
+  "rights_ssim": [
+    "The use of this image may be subject to the copyright law of the United States (Title 17, United States Code) or to site license or other rights management terms and conditions. The person using the image is liable for any infringement."
+  ],
+  "bib_id_ssm": "13640726",
+  "orbisBarcode_ssim": "39002094365690",
+  "references_ssim": [
+    "A handlist of western Medieval manuscripts in the Takamiya collection / Toshiyuki Takamiya, in The Medieval book: glosses from friends & colleagues of Christopher de Hamel, ed. by Richard Linenthal, James Marrow and William Noel. 't Goy-Houten: Hes & De Graff, 2010, pp. 421-437.",
+    "Book of Hours (Fragment). Takamiya MS 142."
+  ],
+  "dateStructured_ssim": "1300-00-00T00:00:00Z",
+  "resourceType_ssim": "Archives or Manuscripts",
+  "illustrativeMatter_ssim": "180618s1400    ctu                 lat d",
+  "id": 16700283,
+  "collectionId_ssim": 1,
+  "children_ssim": [],
+  "abstract_ssim": "Lower half of a single manuscript leaf, on parchment, containing five lines of text and marginal decoration. From the \"Ghistelles Hours.\""
+  ,
+  "public_bsi": true
+}

--- a/spec/fixtures/solr/oid-16712419.json
+++ b/spec/fixtures/solr/oid-16712419.json
@@ -1,0 +1,54 @@
+{
+  "source_ssim": "ladybird",
+  "recordType_ssim": "id",
+  "uri_ssim": "/ladybird/oid/16712419",
+  "identifierShelfMark_ssim": "Speck Ck99 R3 +830b",
+  "author_tsim": [
+    "Retzsch, Moritz, 1779-1857"
+  ],
+  "title_tsim": [
+    "Faust; esquisses dessinées par Retsch."
+  ],
+  "numberOfPages_ssim": "Copy 1",
+  "extentOfDigitization_ssim": "Complete work digitized.",
+  "publicationPlace_ssim": [
+    "Paris :"
+  ],
+  "publisher_ssim": [
+    "Giard,Editeur,"
+  ],
+  "date_ssim": "[1830]",
+  "extent_ssim": "1 p.l., 8 pp. : [66] plates. 22 x 28 cm.",
+  "language_ssim": [
+    "French"
+  ],
+  "description_ssim": [
+    "Contains 26 numbered etches plates before letters; lithographs of plates 1-21, 23-26 after letters; proof of border of t.p.; 15 plates without numbers or letters.",
+    "Etched t.p.; title within ornamental border."
+  ],
+  "subjectName_ssim": [
+    "Goethe, Johann Wolfgang von,--1749-1832.--Faust--Illustrations.",
+    "Miltitz, Carl Borromäus von, 1781-1845"
+  ],
+  "genre_ssim": [
+    "Engravings",
+    "Etchings",
+    "Lithographs",
+    "Marbled papers (Paper)"
+  ],
+  "format_ssim": "text",
+  "partOf_ssim": "Beinecke Library",
+  "rights_ssim": [
+    "The use of this image may be subject to the copyright law of the United States (Title 17, United States Code) or to site license or other rights management terms and conditions. The person using the image is liable for any infringement."
+  ],
+  "bib_id_ssm": "1289001",
+  "dateStructured_ssim": "1830-00-00T00:00:00Z",
+  "resourceType_ssim": "Books, Journals & Pamphlets",
+  "illustrativeMatter_ssim": "850813s1830    fr f          00000 fre d",
+  "id": 16712419,
+  "collectionId_ssim": 1,
+  "children_ssim": [],
+  "abstract_ssim": "Wanting lithograph of pl. 22."
+  ,
+  "public_bsi": true
+}

--- a/spec/fixtures/solr/oid-16797069.json
+++ b/spec/fixtures/solr/oid-16797069.json
@@ -1,0 +1,53 @@
+{
+  "source_ssim": "ladybird",
+  "recordType_ssim": "id",
+  "uri_ssim": "/ladybird/oid/16797069",
+  "identifierMfhd_ssim": "/repositories/11/archival_objects/608223",
+  "identifierShelfMark_ssim": "YCAL MSS 42",
+  "box_ssim": "25",
+  "folder_ssim": "787-93",
+  "sourceTitle_ssim": "Edith Wharton collection",
+  "sourceDate_ssim": "1868-1981 (inclusive)",
+  "sourceNote_ssim": "Series II:. Personal Correspondence",
+  "author_tsim": [
+    "Wharton, Edith, 1862-1937"
+  ],
+  "title_tsim": [
+    "Grant, Robert\n\n"
+  ],
+  "extentOfDigitization_ssim": "Complete folder digitized.",
+  "date_ssim": "1905-39",
+  "extent_ssim": "7 folders",
+  "language_ssim": [
+    "English"
+  ],
+  "description_ssim": [
+    "Folder 790 includes an undated letter from \"L.J.G.\", Jamestown, N.Y."
+  ],
+  "subjectName_ssim": [
+    "Grant, Robert, 1852-1940--Correspondence",
+    "Lapsley, Gaillard Thomas--Correspondence",
+    "Wharton, Edith, 1862-1937 --Correspondence"
+  ],
+  "genre_ssim": [
+    "correspondence (AAT)"
+  ],
+  "format_ssim": "text",
+  "partOf_ssim": "Beinecke Library",
+  "rights_ssim": [
+    "Copyright to material created by Edith Wharton may be held by her estate. To learn more, consult the WATCH file (http://norman.hrc.utexas.edu/watch/)."
+  ],
+  "bib_id_ssm": "3435140",
+  "orbisBarcode_ssim": "39002075038423",
+  "findingAid_ssim": "http://hdl.handle.net/10079/fa/beinecke.wharton",
+  "references_ssim": [
+    "Edith Wharton Collection. Yale Collection of American Literature. Beinecke Rare Book and Manuscript Library."
+  ],
+  "dateStructured_ssim": "1902-00-00T00:00:00Z",
+  "resourceType_ssim": "Archives or Manuscripts",
+  "id": 16797069,
+  "collectionId_ssim": 1,
+  "children_ssim": []
+  ,
+  "public_bsi": true
+}

--- a/spec/fixtures/solr/oid-16854285.json
+++ b/spec/fixtures/solr/oid-16854285.json
@@ -1,0 +1,47 @@
+{
+  "source_ssim": "ladybird",
+  "recordType_ssim": "id",
+  "uri_ssim": "/ladybird/oid/16854285",
+  "identifierMfhd_ssim": "/repositories/11/archival_objects/515305",
+  "identifierShelfMark_ssim": "YCAL MSS 1000",
+  "box_ssim": "1",
+  "sourceTitle_ssim": "Fowler & Wells Portrait Posters for Physiognomy Lectures",
+  "sourceDate_ssim": "circa 1860",
+  "author_tsim": [
+    "Fowler & Wells"
+  ],
+  "title_tsim": [
+    "Poster 1: Destructiveness small, Destructiveness large, Hydrocephalus James Cardinal, Thomas Sewall, Red Jacket, Language large"
+  ],
+  "extentOfDigitization_ssim": "Complete work digitized.",
+  "extent_ssim": "1 scroll ; approx. 164 x 83.8 cm.",
+  "subjectName_ssim": [
+    "Red Jacket, Seneca chief, approximately 1756-1830",
+    "Sewall, Thomas, 1786 or 1787-1845"
+  ],
+  "subjectTopic_ssim": [
+    "Phrenology--United States",
+    "Physiognomy--United States"
+  ],
+  "genre_ssim": [
+    "Portraits",
+    "Posters--United States--19th century"
+  ],
+  "format_ssim": "still image",
+  "partOf_ssim": "Beinecke Library",
+  "rights_ssim": [
+    "The use of this image may be subject to the copyright law of the United States (Title 17, United States Code) or to site license or other rights management terms and conditions. The person using the image is liable for any infringement."
+  ],
+  "bib_id_ssm": "12307100",
+  "orbisBarcode_ssim": "39002102340669",
+  "findingAid_ssim": "http://hdl.handle.net/10079/fa/beinecke.phrenology",
+  "references_ssim": [
+    "Fowler & Wells, Portrait Posters for Physiognomy Lectures. Yale Collection of American Literature, Beinecke Rare Book and Manuscript Library."
+  ],
+  "resourceType_ssim": "Paintings & Drawings",
+  "id": 16854285,
+  "collectionId_ssim": 1,
+  "children_ssim": []
+  ,
+  "public_bsi": true
+}

--- a/spec/fixtures/solr/oid-16854582.json
+++ b/spec/fixtures/solr/oid-16854582.json
@@ -1,0 +1,52 @@
+{
+  "source_ssim": "ladybird",
+  "recordType_ssim": "id",
+  "uri_ssim": "/ladybird/oid/16854582",
+  "identifierMfhd_ssim": "/repositories/11/archival_objects/699963",
+  "identifierShelfMark_ssim": "YCAL MSS 702",
+  "box_ssim": "8",
+  "sourceTitle_ssim": "Robert Giard papers",
+  "sourceDate_ssim": "1972-2002",
+  "sourceNote_ssim": "February 2005 Acquisition. Professional papers",
+  "author_tsim": [
+    "Giard, Robert, 1939-2002"
+  ],
+  "title_tsim": [
+    "Desk files, weekly calendars, grant proposals, resumes, professional correspondence, exhibition announcements and brochures, obituaries, awards, articles, plans for future projects"
+  ],
+  "extentOfDigitization_ssim": "Partial work digitized.",
+  "date_ssim": "1994-2002",
+  "extent_ssim": "16 Folders ; 27.8 x 21.1 cm.",
+  "language_ssim": [
+    "English"
+  ],
+  "subjectTopic_ssim": [
+    "LGBTQ resource",
+    "Photographers--United States--20th Century",
+    "Photographers--United States--Archives"
+  ],
+  "geoSubject_ssim": "United States--Maps, Manuscript",
+  "genre_ssim": [
+    "Manuscript maps",
+    "Manuscripts",
+    "Typescripts"
+  ],
+  "format_ssim": "text",
+  "partOf_ssim": "Beinecke Library",
+  "rights_ssim": [
+    "The use of this image may be subject to the copyright law of the United States (Title 17, United States Code) or to site license or other rights management terms and conditions. The person using the image is liable for any infringement."
+  ],
+  "bib_id_ssm": "7151233",
+  "orbisBarcode_ssim": "39002104850970",
+  "findingAid_ssim": "http://hdl.handle.net/10079/fa/beinecke.giard",
+  "references_ssim": [
+    "Robert Giard Papers. Yale Collection of American Literature, Beinecke Rare Book and Manuscript Library."
+  ],
+  "dateStructured_ssim": "1994-00-00T00:00:00Z",
+  "resourceType_ssim": "Archives or Manuscripts",
+  "id": 16854582,
+  "collectionId_ssim": 1,
+  "children_ssim": []
+  ,
+  "public_bsi": true
+}

--- a/spec/fixtures/solr/oid-2003431.json
+++ b/spec/fixtures/solr/oid-2003431.json
@@ -1,0 +1,63 @@
+{
+  "source_ssim": "ladybird",
+  "recordType_ssim": "id",
+  "uri_ssim": "/ladybird/oid/2003431",
+  "identifierShelfMark_ssim": "Beinecke MS 407",
+  "title_tsim": [
+    "Albergati Bible"
+  ],
+  "extentOfDigitization_ssim": "Complete work digitized.",
+  "publicationPlace_ssim": [
+    "Italy"
+  ],
+  "date_ssim": "1428",
+  "extent_ssim": "ff. i + 682 + i : parchment ; 231 x 161 (135 x 111) mm.",
+  "language_ssim": [
+    "Latin"
+  ],
+  "description_ssim": [
+    "Binding: 19th-20th centuries. A painted design under the gilt fore edge. Red velvet binding.",
+    "First two leaves slightly creased.",
+    "From the collection of A. Chester Beatty (Western MS 79). Acquired from H. P. Kraus in 1969 as the gift of Edwin J. Beinecke.",
+    "Ornamental initials (5 to 6-line) at the beginning of the prologues in red, blue, orange, and/or green, acanthus infilled red with white filigree against irregular gold grounds; gold against cusped pink and blue backgrounds with white filigree; some rinceaux initials in Franco-Flemish style, pink or blue with white highlights against cusped gold grounds. 2 and 1-line initials, gold on red and blue grounds with white filigree. Running titles in alternating red and blue letters or in gold against red and blue rectangular grounds with white  filigree. Line fillers (ff. 617r-682r) in red, blue and/or gold. Chapter numbers in red or blue. Rubrics throughout.",
+    "Script: Written in rounded gothic bookhand.",
+    "The Bible is a splendid example of the Italian late gothic illuminated manuscript. The decoration consists of two very richly illuminated pages (f. 5r, Genesis; f. 272r, Psalms), thirteen small miniatures (ff. 1r, 570v-576v), and 79 historiated initials, 7 to 10-line (not including ascenders or descenders) at the beginning of every book of the Bible, the sections of the Psalter, and a few prologues. The miniatures are in thin gold or yellow frames. The historiated initials are composed of acanthus, mauve, blue, pink, orange, and/or green. At least four artists collaborated in the illustration and decoration of the codex. On virtually every folio, recto and verso, are elaborate bar borders, in margins and/or between text columns, full or half-length, gold, blue, green, pink, and/or orange with white filigree, some with curling acanthus, leafy midpoints and terminals with acanthus and hair-spray extension. On folios with miniatures or initials, more elaborate borders (full borders on ff. 1r, 5r): curling hair-spray with gold dots and trefoil leaves, spikey ivy, pink, blue, orange and green flowers, putti, insects, birds, grotesques and, on f. 348v, a marginal scene, lower left corner, a fowler chasing rabbits."
+  ],
+  "subjectName_ssim": [
+    "Langton, Stephen,--d. 1228"
+  ],
+  "subjectTopic_ssim": [
+    "Bible.--Latin--Versions--Vulgate",
+    "Illumination of books and manuscripts, Medieval",
+    "Manuscripts, Medieval--Connecticut--New Haven",
+    "Medieval and Renaissance Manuscripts in Beinecke Library"
+  ],
+  "genre_ssim": [
+    "Bible",
+    "Hand coloring",
+    "Historiated initials",
+    "Illuminated manuscripts",
+    "Illustrations",
+    "Rubrics"
+  ],
+  "format_ssim": "text",
+  "partOf_ssim": "Beinecke Library",
+  "rights_ssim": [
+    "The use of this image may be subject to the copyright law of the United States (Title 17, United States Code) or to site license or other rights management terms and conditions. The person using the image is liable for any infringement."
+  ],
+  "bib_id_ssm": "9734763",
+  "orbisBarcode_ssim": "39002091549668",
+  "importUrl_ssim": "https://pre1600ms.beinecke.library.yale.edu/docs/pre1600.ms407.htm",
+  "references_ssim": [
+    "Albergati Bible. General Collection, Beinecke Rare Book and Manuscript Library, Yale University.",
+    "Shailor, B. Catalogue of Medieval and Renaissance Manuscripts in the Beinecke Rare Book and Manuscript Library, MS 407."
+  ],
+  "dateStructured_ssim": "1428-00-00T00:00:00Z",
+  "resourceType_ssim": "Archives or Manuscripts",
+  "id": 2003431,
+  "collectionId_ssim": 1,
+  "children_ssim": [],
+  "abstract_ssim": "Manuscript on parchment of 1) Bible in the usual order with some prologues. 2) Index of Hebrew names generally attributed to Stephen Langton. 3) Chapters 25-29 of the Testament of the 12 Patriarchs. Written for Cardinal Niccolo Albergati."
+  ,
+  "public_bsi": true
+}

--- a/spec/fixtures/solr/oid-2004628.json
+++ b/spec/fixtures/solr/oid-2004628.json
@@ -1,0 +1,35 @@
+{
+  "source_ssim": "ladybird",
+  "recordType_ssim": "id",
+  "uri_ssim": "/ladybird/oid/2004628",
+  "identifierShelfMark_ssim": "WA MSS 278",
+  "sourceTitle_ssim": "Paintings",
+  "sourceCreated_ssim": "1846-1848",
+  "title_tsim": [
+    "Fort Vancouver"
+  ],
+  "extentOfDigitization_ssim": "Complete work digitized.",
+  "date_ssim": "1846-1848",
+  "extent_ssim": "color",
+  "description_ssim": [
+    "A list of the paintings can be found in: Withington, M. C. 278.",
+    "By or after Lieutenant Warre.",
+    "Paintings described by Mr. C. P. Wilson in an article “Early Western Paintings” which appeared in The Beaver, June 1949 (no. 280)."
+  ],
+  "genre_ssim": [
+    "Oil paintings"
+  ],
+  "format_ssim": "still image",
+  "partOf_ssim": "Beinecke Library",
+  "rights_ssim": [
+    "The use of this image may be subject to the copyright law of the United States (Title 17, United States Code) or to site license or other rights management terms and conditions. The person using the image is liable for any infringement."
+  ],
+  "bib_id_ssm": "3163155",
+  "dateStructured_ssim": "1846-00-00T00:00:00Z",
+  "id": 2004628,
+  "collectionId_ssim": 1,
+  "children_ssim": [],
+  "abstract_ssim": "A series of six framed oil paintings, four of them attributed to Paul Kane. Paintings depict Fort Vancouver, Snake River, buffalo, and buffalo hunting. This painting was a part of Mr. Coe's gift of his Western Collection, acquired from the widow of a grandson of Sir George Simpson, Governor of the Hudson’s Bay Company’s Territories in North America."
+  ,
+  "public_bsi": true
+}

--- a/spec/fixtures/solr/oid-2005512.json
+++ b/spec/fixtures/solr/oid-2005512.json
@@ -1,0 +1,29 @@
+{
+  "source_ssim": "ladybird",
+  "recordType_ssim": "id",
+  "uri_ssim": "/ladybird/oid/2005512",
+  "identifierShelfMark_ssim": "GEN MSS 257",
+  "folder_ssim": "Folder 24",
+  "sourceTitle_ssim": "Abraham Lincoln collection, 1824-1865",
+  "title_tsim": [
+    "[Gold pen used by Lincoln to sign the Emancipation Proclamation in the Executive Mansion, Washington, D.C., 1863 Jan 1]"
+  ],
+  "extentOfDigitization_ssim": "Complete folder digitized.",
+  "date_ssim": "undated",
+  "extent_ssim": "17.5 cm.",
+  "genre_ssim": [
+    "Artifacts"
+  ],
+  "format_ssim": "three dimensional object",
+  "partOf_ssim": "Beinecke Library",
+  "rights_ssim": [
+    "The use of this image may be subject to the copyright law of the United States (Title 17, United States Code) or to site license or other rights management terms and conditions. The person using the image is liable for any infringement."
+  ],
+  "bib_id_ssm": "4113177",
+  "findingAid_ssim": "http://hdl.handle.net/10079/fa/beinecke.lincoln",
+  "id": 2005512,
+  "collectionId_ssim": 1,
+  "children_ssim": []
+  ,
+  "public_bsi": true
+}

--- a/spec/fixtures/solr/oid-2012036.json
+++ b/spec/fixtures/solr/oid-2012036.json
@@ -1,0 +1,52 @@
+{
+  "source_ssim": "ladybird",
+  "recordType_ssim": "id",
+  "uri_ssim": "/ladybird/oid/2012036",
+  "identifierMfhd_ssim": "/repositories/11/archival_objects/555049",
+  "identifierShelfMark_ssim": "YCAL MSS 202",
+  "box_ssim": "4",
+  "folder_ssim": "201",
+  "sourceTitle_ssim": "Walt Whitman collection",
+  "sourceDate_ssim": "1842-1949",
+  "sourceNote_ssim": "Series V. Adrian Van Sinderen Gift. OTHER PAPERS",
+  "title_tsim": [
+    "[Gold?] coin"
+  ],
+  "date_ssim": "n.d.",
+  "extent_ssim": "2 cm.",
+  "language_ssim": [
+    "English"
+  ],
+  "description_ssim": [
+    "Inscribed: Walt Whitman to Mary Davis Xmas 1891."
+  ],
+  "subjectName_ssim": [
+    "Whitman, Walt, 1819-1892"
+  ],
+  "subjectTopic_ssim": [
+    "American literature --19th century",
+    "Authors, American --19th century --Archives"
+  ],
+  "genre_ssim": [
+    "Artifacts"
+  ],
+  "format_ssim": "three dimensional object",
+  "partOf_ssim": "Beinecke Library",
+  "rights_ssim": [
+    "The use of this image may be subject to the copyright law of the United States (Title 17, United States Code) or to site license or other rights management terms and conditions. The person using the image is liable for any infringement."
+  ],
+  "bib_id_ssm": "6805375",
+  "orbisBarcode_ssim": "39002091459793",
+  "findingAid_ssim": "http://hdl.handle.net/10079/fa/beinecke.whitman",
+  "references_ssim": [
+    "Walt Whitman Collection. Yale Collection of American Literature, Beinecke Rare Book and Manuscript Library.\n\n"
+  ],
+  "digital_ssim": "Walt Whitman Collection",
+  "dateStructured_ssim": "1891-00-00T00:00:00Z",
+  "resourceType_ssim": "Archives or Manuscripts",
+  "id": 2012036,
+  "collectionId_ssim": 1,
+  "children_ssim": []
+  ,
+  "public_bsi": true
+}

--- a/spec/fixtures/solr/oid-2012143.json
+++ b/spec/fixtures/solr/oid-2012143.json
@@ -1,0 +1,33 @@
+{
+  "source_ssim": "ladybird",
+  "recordType_ssim": "id",
+  "uri_ssim": "/ladybird/oid/2012143",
+  "identifierShelfMark_ssim": "Ethiopic MSS 28",
+  "title_tsim": [
+    "Ethiopic ms. scroll"
+  ],
+  "extentOfDigitization_ssim": "Complete work digitized.",
+  "publicationPlace_ssim": [
+    "[Ethiopia]"
+  ],
+  "date_ssim": "[s.a.]",
+  "extent_ssim": "10.4 x 156.5 cm.",
+  "description_ssim": [
+    "Leaves are sewn vertically, end to end."
+  ],
+  "genre_ssim": [
+    "Handscrolls"
+  ],
+  "format_ssim": "text",
+  "partOf_ssim": "Beinecke Library",
+  "rights_ssim": [
+    "The use of this image may be subject to the copyright law of the United States (Title 17, United States Code) or to site license or other rights management terms and conditions. The person using the image is liable for any infringement."
+  ],
+  "bib_id_ssm": "13888969",
+  "resourceType_ssim": "Archives or Manuscripts",
+  "id": 2012143,
+  "collectionId_ssim": 1,
+  "children_ssim": []
+  ,
+  "public_bsi": true
+}

--- a/spec/fixtures/solr/oid-2012315.json
+++ b/spec/fixtures/solr/oid-2012315.json
@@ -1,0 +1,58 @@
+{
+  "source_ssim": "ladybird",
+  "recordType_ssim": "id",
+  "uri_ssim": "/ladybird/oid/2012315",
+  "identifierShelfMark_ssim": "Arabic MSS suppl. 584",
+  "title_tsim": [
+    "Islamic prayers, invocations and decorations : manuscript."
+  ],
+  "extentOfDigitization_ssim": "Partial work digitized.",
+  "publicationPlace_ssim": [
+    "Place not identified,"
+  ],
+  "date_ssim": "18th century.",
+  "extent_ssim": "1 volume (72 leaves) ; 19 cm",
+  "material_ssim": "paper",
+  "language_ssim": [
+    "Arabic",
+    "Turkish, Ottoman (1500-1928)"
+  ],
+  "description_ssim": [
+    "12 x 19 cm; written surface: 6 x 10 cm; lines per page vary.",
+    "Binding: In brown leather binding with flap; covers richly gilt with central medallion on both sides and corners decorations; edges slightly rubbed.",
+    "Colophon: Last page seems to be missing; ends with a magic square and the katchword \"barkamsah\".",
+    "In Arabic and Ottoman Turkish.",
+    "In large and beautiful naskh or thulth scripts, in black ink on thin white paper; with headings in white ink on gold background; catchwords.",
+    "Incipit: The first leaf seems to be missing.",
+    "Romanization supplied by cataloger.",
+    "Secundo folio: al-rāfiʻ al-muʻizz al-mudhill.",
+    "Title supplied by cataloger.",
+    "بداية الورقة الثانية: الرافع المعز المذل."
+  ],
+  "subjectTopic_ssim": [
+    "Arabic manuscripts.",
+    "Islamic decorative arts--Early works to 1800.",
+    "Prayer--Islam--Early works to 1800."
+  ],
+  "genre_ssim": [
+    "Manuscripts, Arabic--18th century."
+  ],
+  "format_ssim": "text",
+  "partOf_ssim": "Beinecke Library",
+  "rights_ssim": [
+    "The use of this image may be subject to the copyright law of the United States (Title 17, United States Code) or to site license or other rights management terms and conditions. The person using the image is liable for any infringement."
+  ],
+  "bib_id_ssm": "13226126",
+  "orbisBarcode_ssim": "39002099391428",
+  "references_ssim": [
+    "Islamic prayers, invocations and decorations. General Collection, Beinecke Rare Book and Manuscript Library, Yale University."
+  ],
+  "resourceType_ssim": "Archives or Manuscripts",
+  "illustrativeMatter_ssim": "170717s17uu    xx                  ara d",
+  "id": 2012315,
+  "collectionId_ssim": 1,
+  "children_ssim": [],
+  "abstract_ssim": "A collection of Islamic prayers, invocations and decorations, as follows: 1. Part of an invocation in Ottoman Turkish and Arabic (folio 1a). The first leaf seems to be missing. 2. Asmāʼ Allāh al-ḥusná (The 99 most beautiful names of God), written within gold squares (folio 1b-3a). 3. The name of the Prophet Muḥammad (folio 3a-4b). 4. Duʻāʼ istighfār kabīr (A prayer for seeking God's forgiveness) (folios 4b-5a). 5. Sharḥ muhr kabīr sharīf (An explanation of the noble seal of God) (folio 5b). 6. The seal itself written in large thulth script (folio 6a). 7. The word \"Allāh, jalla jalāluh\", written within a crescent moon surrounded by a decorative rectangle in gold and blue (folio 6b). 8. The word \"Muḥammad, ʻalyhi al-salām\" written in a similar fashion (folio 7a). 9. The name of \"Adam\" written within a circle surrounded by a decorative rectangle in gold and blue (folio 7b). 10. The names of Noah, Muḥammad, Abū Bakr, ʻUmar, ʻUthmān, ʻAlī, Ḥasan, Ḥusayn in a similar fashion (folios 8a-12a). 11. The names of the famous companions of the Prophet Muḥammad, written within decorative circles: Abū Bakr, ʻUmar, ʻUthmān, ʻAlī, Ṭalḥah, Zubayr, ʻAbd Allāh, ʻAbd al-Raḥmān, Ibn ʻAwf, Saʻd, Saʻīd, Abū ʻUbaydah, Ḥasan, Ḥusayn (folios 12b-19a). 12. The names of \"Ahl al-Kahf\" (Seven sleepers of Ephesus): Yamlīkhā, Makshalīnā, Mithlīnā, Marnūsh, Bardanūsh, Shādhanūsh,Kafshaṭṭayyūsh and their dog \"Qaṭmīr\" (folios 19b-23a). 13. A prayer in the form of cypress trees (folios 23b-32a). 14. Invocation seals \"muhrs\": \"Yā Ḥannān\", \"Yā Mannān\" (Oh Merciful, Oh Generous), \"Wa-huwa ʻalá kull shayʼ qadīr (He is able to do anything), Unity of God, Shifāʼ al-Qurʼān (Quranic medicine), seal of a prayer for getting well, seal for the great prayer of getting well, the seal of the Prophet, the seal of Sulaymān (Solomon), explanation of the seal of Jaʻfar al-Ṣādiq (the sixth Shiʻī Imām, died 765), the seal of the Almighty, all written within decorative circles (folios 32b-38a). 14. Drawings of: \"Hand of Faṭimah\", \"Dhū al-Fiqār\" (ʻAlī's sword), foot of the Prophet Muḥammad, the Prophet's shoes, \"Tawakkalū ʻalá Allāh\" (Rely upon God), the staff of Moses, an ax, a rose, the banner of gratitude, the cloak of the Prophet Muḥammad, his rosary, his ewer and his basin, all drawn in gold (folios 39b-43a). 15. Decorative sketches of Mecca and Medina in gold and other colors (folios 43b-44a). 16. A prayer for attaining \"al-Maqām al-Maḥmūd\" (the Glorious Station \"a place in Heaven\") (folios 44b-45a). 17. Various Islamic flags drawn in gold (folios 45b-47a). 18. Various prayers for variety of occasions (folios 47b-69a). 19. Various talismanic numerology squares (folios 69b-72b). Name of copyist and place and date of copying not mentioned, probably from the 18th century."
+  ,
+  "public_bsi": true
+}

--- a/spec/fixtures/solr/oid-2019757.json
+++ b/spec/fixtures/solr/oid-2019757.json
@@ -1,0 +1,56 @@
+{
+  "source_ssim": "ladybird",
+  "recordType_ssim": "id",
+  "uri_ssim": "/ladybird/oid/2019757",
+  "identifierShelfMark_ssim": "YCAL MSS 229",
+  "sourceNote_ssim": "Three scrapbooks, compiled by Jane Wodening, containing correspondence, photographs, manuscripts, printed material, artwork, cut film, and objects documenting the work and family life of Wodening (ne?e Collom) and Stan Brakhage from 1958 to 1967.",
+  "author_tsim": [
+    "Brakhage, Stan",
+    "Wodening, Jane, 1936-"
+  ],
+  "title_tsim": [
+    "Jane Wodening and Stan Brakhage scrapbook"
+  ],
+  "numberOfPages_ssim": "Vol. 1",
+  "extentOfDigitization_ssim": "Complete work digitized.",
+  "date_ssim": "1958-1967",
+  "extent_ssim": "1 of 3 vols. ; 36 cm.",
+  "language_ssim": [
+    "English"
+  ],
+  "subjectName_ssim": [
+    "Anger, Kenneth",
+    "Creeley, Robert, 1926-2005",
+    "Johnson, Ray, 1927-1995",
+    "Kuhler, R",
+    "Miller, Henry, 1891-1980",
+    "Ryder, Albert Pinkham, 1847-1917",
+    "Smith, Jessie Willcox, 1863-1935",
+    "Stevenson, Robert Louis, 1850-1894"
+  ],
+  "genre_ssim": [
+    "Clippings",
+    "Correspondence",
+    "Ephemera",
+    "Photographic prints",
+    "Photographs",
+    "Scrapbooks",
+    "Snapshots",
+    "Typescripts"
+  ],
+  "format_ssim": "mixed material",
+  "partOf_ssim": "Beinecke Library",
+  "rights_ssim": [
+    "The use of this image may be subject to the copyright law of the United States (Title 17, United States Code) or to site license or other rights management terms and conditions. The person using the image is liable for any infringement."
+  ],
+  "bib_id_ssm": "7748458",
+  "orbisBarcode_ssim": "39002098971741",
+  "dateStructured_ssim": "1958-00-00T00:00:00Z",
+  "resourceType_ssim": "Archives or Manuscripts",
+  "id": 2019757,
+  "collectionId_ssim": 1,
+  "children_ssim": [],
+  "abstract_ssim": "Binding: green with gold embossing. With a bookplate: \"A child's garden of verses Robert Louis Stevenson...\""
+  ,
+  "public_bsi": true
+}

--- a/spec/fixtures/solr/oid-2019759.json
+++ b/spec/fixtures/solr/oid-2019759.json
@@ -1,0 +1,69 @@
+{
+  "source_ssim": "ladybird",
+  "recordType_ssim": "id",
+  "uri_ssim": "/ladybird/oid/2019759",
+  "identifierShelfMark_ssim": "YCAL MSS 229",
+  "sourceTitle_ssim": "Jane Wodening and Stan Brakhage scrapbooks",
+  "sourceNote_ssim": "Three scrapbooks, compiled by Jane Wodening, containing correspondence, photographs, manuscripts, printed material, artwork, cut film, and objects documenting the work and family life of Wodening (ne?e Collom) and Stan Brakhage from 1958 to 1967.",
+  "author_tsim": [
+    "Brakhage, Stan",
+    "Wodening, Jane, 1936-"
+  ],
+  "title_tsim": [
+    "Jane Wodening and Stan Brakhage scrapbook"
+  ],
+  "numberOfPages_ssim": "Vol. 2",
+  "extentOfDigitization_ssim": "Complete work digitized.",
+  "date_ssim": "1958-1967",
+  "extent_ssim": "2 of 3 vols. ; 36 cm.",
+  "language_ssim": [
+    "English"
+  ],
+  "subjectName_ssim": [
+    "Creeley, Robert, 1926-2005",
+    "Crews, Judson",
+    "Dorn, Edward",
+    "Duncan, Robert, 1918-1988",
+    "Emerson, Ralph Waldo, 1803-1882",
+    "Ginsberg, Allen, 1926-1997",
+    "Hiler, Jerome",
+    "Kubelka, Peter",
+    "Kumari (Hindu deity)",
+    "Levertov, Denise, 1923-1997",
+    "McVicker, Roy H",
+    "Olson, Charles",
+    "Spengler, Oswald, 1880-1936",
+    "Zukofsky, Louis, 1904-1978"
+  ],
+  "subjectTopic_ssim": [
+    "Nature photography"
+  ],
+  "geoSubject_ssim": "Colorado--Maps",
+  "genre_ssim": [
+    "Artifacts",
+    "Clippings",
+    "Correspondence",
+    "Ephemera",
+    "Filmstrips",
+    "Illustrations",
+    "Photographic prints",
+    "Photographs",
+    "Scrapbooks",
+    "Studio portraits"
+  ],
+  "format_ssim": "still image",
+  "partOf_ssim": "Beinecke Library",
+  "rights_ssim": [
+    "The use of this image may be subject to the copyright law of the United States (Title 17, United States Code) or to site license or other rights management terms and conditions. The person using the image is liable for any infringement."
+  ],
+  "bib_id_ssm": "7748458",
+  "orbisBarcode_ssim": "39002098971758",
+  "dateStructured_ssim": "1958-00-00T00:00:00Z",
+  "resourceType_ssim": "Archives or Manuscripts",
+  "id": 2019759,
+  "collectionId_ssim": 1,
+  "children_ssim": [],
+  "abstract_ssim": "Binding: white with gold embossing."
+  ,
+  "public_bsi": true
+}

--- a/spec/fixtures/solr/oid-2030006.json
+++ b/spec/fixtures/solr/oid-2030006.json
@@ -1,0 +1,40 @@
+{
+  "source_ssim": "ladybird",
+  "recordType_ssim": "id",
+  "uri_ssim": "/ladybird/oid/2030006",
+  "identifierShelfMark_ssim": "BrSides By6 1740",
+  "author_tsim": [
+    "Bailey, William"
+  ],
+  "title_tsim": [
+    "The glory of old England ..."
+  ],
+  "extentOfDigitization_ssim": "Complete work digitized.",
+  "publicationPlace_ssim": [
+    "White-Hall, printed upon the ice, on the River Thames"
+  ],
+  "date_ssim": "1739-40 February 18",
+  "extent_ssim": "ill. engraving",
+  "subjectName_ssim": [
+    "Anne, Queen of Great Britain, 1665-1714"
+  ],
+  "genre_ssim": [
+    "Broadsides",
+    "Engravings",
+    "Illustrations",
+    "Prints (Visual works)"
+  ],
+  "format_ssim": "text",
+  "partOf_ssim": "Beinecke Library",
+  "rights_ssim": [
+    "The use of this image may be subject to the copyright law of the United States (Title 17, United States Code) or to site license or other rights management terms and conditions. The person using the image is liable for any infringement."
+  ],
+  "bib_id_ssm": "1264367",
+  "resourceType_ssim": "Books, Journals & Pamphlets",
+  "id": 2030006,
+  "collectionId_ssim": 1,
+  "children_ssim": [],
+  "abstract_ssim": "Engraving showing the statue of Queen Anne at Blenhiem Palace (in background), and text of inscription by Sarah Marlborough, dated 1738, with imprint: London, Printed & published ... by R. Walker, in Fleet Lane."
+  ,
+  "public_bsi": true
+}

--- a/spec/fixtures/solr/oid-2034600.json
+++ b/spec/fixtures/solr/oid-2034600.json
@@ -1,0 +1,42 @@
+{
+  "source_ssim": "ladybird",
+  "recordType_ssim": "id",
+  "uri_ssim": "/ladybird/oid/2034600",
+  "identifierShelfMark_ssim": "JWJ A +Eb74",
+  "sourceTitle_ssim": "Ebony magazine",
+  "sourceCreated_ssim": "Chicago : Johnson Pub. Co",
+  "title_tsim": [
+    "[Magazine page with various photographs of Leontyne Price]"
+  ],
+  "extentOfDigitization_ssim": "Partial work digitized.",
+  "date_ssim": "1961 April",
+  "extent_ssim": "b&w illustration",
+  "language_ssim": [
+    "English"
+  ],
+  "subjectName_ssim": [
+    "Price, Leontyne"
+  ],
+  "geoSubject_ssim": "Laurel (Miss.)",
+  "genre_ssim": [
+    "Halftones",
+    "Magazines (periodicals)",
+    "Photographic prints",
+    "Photographs",
+    "Photomechanical prints"
+  ],
+  "format_ssim": "mixed material",
+  "partOf_ssim": "Beinecke Library",
+  "rights_ssim": [
+    "The use of this image may be subject to the copyright law of the United States (Title 17, United States Code) or to site license or other rights management terms and conditions. The person using the image is liable for any infringement."
+  ],
+  "bib_id_ssm": "752400",
+  "dateStructured_ssim": "1961-04-00T00:00:00Z",
+  "resourceType_ssim": "Books, Journals & Pamphlets",
+  "id": 2034600,
+  "collectionId_ssim": 1,
+  "children_ssim": [],
+  "abstract_ssim": "Reproduced photographs accompanying article about Leontyne Price's visit to hometown of Laurel, Miss."
+  ,
+  "public_bsi": true
+}

--- a/spec/fixtures/solr/oid-2041002.json
+++ b/spec/fixtures/solr/oid-2041002.json
@@ -1,0 +1,40 @@
+{
+  "source_ssim": "ladybird",
+  "recordType_ssim": "id",
+  "uri_ssim": "/ladybird/oid/2041002",
+  "identifierShelfMark_ssim": "GEN MSS VOL 728 (Oversize)",
+  "author_tsim": [
+    "Johnson, Samuel, 1709-1784"
+  ],
+  "title_tsim": [
+    "A General dictionary of the English language"
+  ],
+  "numberOfPages_ssim": "Vol. 1",
+  "extentOfDigitization_ssim": "Complete work digitized.",
+  "date_ssim": "1755",
+  "extent_ssim": "43 cm.",
+  "language_ssim": [
+    "English"
+  ],
+  "description_ssim": [
+    "Three volume printer's proof with manuscript notes throughout."
+  ],
+  "genre_ssim": [
+    "Dictionaries"
+  ],
+  "format_ssim": "text",
+  "partOf_ssim": "Beinecke Library",
+  "rights_ssim": [
+    "The use of this image may be subject to the copyright law of the United States (Title 17, United States Code) or to site license or other rights management terms and conditions. The person using the image is liable for any infringement."
+  ],
+  "bib_id_ssm": "1169354",
+  "orbisBarcode_ssim": "39002094045128",
+  "dateStructured_ssim": "1755-00-00T00:00:00Z",
+  "resourceType_ssim": "Books, Journals & Pamphlets",
+  "id": 2041002,
+  "collectionId_ssim": 1,
+  "children_ssim": [],
+  "abstract_ssim": "Published on April 15, 1755 and written largely single-handedly by Samuel Johnson. Sometimes published as \"Johnson's Dictionary.\" The first edition was published in two folio volumes; later editions were published in four volumes."
+  ,
+  "public_bsi": true
+}

--- a/spec/fixtures/solr/oid-2046567.json
+++ b/spec/fixtures/solr/oid-2046567.json
@@ -1,0 +1,46 @@
+{
+  "source_ssim": "ladybird",
+  "recordType_ssim": "id",
+  "uri_ssim": "/ladybird/oid/2046567",
+  "identifierShelfMark_ssim": "GEN MSS VOL 728 (Oversize)",
+  "author_tsim": [
+    "Johnson, Samuel, 1709-1784"
+  ],
+  "title_tsim": [
+    "A General dictionary of the English language"
+  ],
+  "numberOfPages_ssim": "Vol. 2",
+  "extentOfDigitization_ssim": "Complete work digitized.",
+  "publicationPlace_ssim": [
+    "London"
+  ],
+  "publisher_ssim": [
+    "Printed by W. Strahan, for J. and P. Knapton [etc.]"
+  ],
+  "date_ssim": "1755",
+  "extent_ssim": "43 cm.",
+  "language_ssim": [
+    "English"
+  ],
+  "description_ssim": [
+    "Four volume printer's proof with manuscript notes throughout."
+  ],
+  "genre_ssim": [
+    "Dictionaries"
+  ],
+  "format_ssim": "text",
+  "partOf_ssim": "Beinecke Library",
+  "rights_ssim": [
+    "The use of this image may be subject to the copyright law of the United States (Title 17, United States Code) or to site license or other rights management terms and conditions. The person using the image is liable for any infringement."
+  ],
+  "bib_id_ssm": "1169354",
+  "orbisBarcode_ssim": "39002094045136",
+  "dateStructured_ssim": "1755-00-00T00:00:00Z",
+  "resourceType_ssim": "Books, Journals & Pamphlets",
+  "id": 2046567,
+  "collectionId_ssim": 1,
+  "children_ssim": [],
+  "abstract_ssim": "Published on April 15, 1755 and written largely single-handedly by Samuel Johnson. Sometimes published as \"Johnson's Dictionary.\" The first edition was published in two folio volumes; later editions were published in four volumes."
+  ,
+  "public_bsi": true
+}

--- a/spec/fixtures/solr/oid-2055095.json
+++ b/spec/fixtures/solr/oid-2055095.json
@@ -1,0 +1,49 @@
+{
+  "source_ssim": "ladybird",
+  "recordType_ssim": "id",
+  "uri_ssim": "/ladybird/oid/2055095",
+  "identifierShelfMark_ssim": "GEN MSS VOL 728 (Oversize)",
+  "author_tsim": [
+    "Johnson, Samuel, 1709-1784"
+  ],
+  "title_tsim": [
+    "A General dictionary of the English language"
+  ],
+  "numberOfPages_ssim": "Vol. 3",
+  "extentOfDigitization_ssim": "Complete work digitized.",
+  "publicationPlace_ssim": [
+    "London"
+  ],
+  "publisher_ssim": [
+    "Printed by W. Strahan, for J. and P. Knapton [etc.]"
+  ],
+  "date_ssim": "1755",
+  "extent_ssim": "43 cm.",
+  "language_ssim": [
+    "English"
+  ],
+  "description_ssim": [
+    "Four volume printer's proof with manuscript notes throughout."
+  ],
+  "genre_ssim": [
+    "Annotations",
+    "Dictionaries",
+    "Marginalia",
+    "Proofs (Printed matter)"
+  ],
+  "format_ssim": "text",
+  "partOf_ssim": "Beinecke Library",
+  "rights_ssim": [
+    "The use of this image may be subject to the copyright law of the United States (Title 17, United States Code) or to site license or other rights management terms and conditions. The person using the image is liable for any infringement."
+  ],
+  "bib_id_ssm": "1169354",
+  "orbisBarcode_ssim": "39002094045110",
+  "dateStructured_ssim": "1755-00-00T00:00:00Z",
+  "resourceType_ssim": "Books, Journals & Pamphlets",
+  "id": 2055095,
+  "collectionId_ssim": 1,
+  "children_ssim": [],
+  "abstract_ssim": "Published on April 15, 1755 and written largely single-handedly by Samuel Johnson. Sometimes published as \"Johnson's Dictionary.\" The first edition was published in two folio volumes; later editions were published in four volumes."
+  ,
+  "public_bsi": true
+}

--- a/spec/fixtures/solr/oid-2057976.json
+++ b/spec/fixtures/solr/oid-2057976.json
@@ -1,0 +1,51 @@
+{
+  "source_ssim": "ladybird",
+  "recordType_ssim": "id",
+  "uri_ssim": "/ladybird/oid/2057976",
+  "identifierShelfMark_ssim": "Osborn Music MS 7",
+  "title_tsim": [
+    "Vaudevilles et chansons"
+  ],
+  "extentOfDigitization_ssim": "Complete work digitized.",
+  "date_ssim": "[18th Century]",
+  "extent_ssim": "25 x 18 cm.",
+  "language_ssim": [
+    "French"
+  ],
+  "description_ssim": [
+    "Anonymous MS.",
+    "Binder's blanks unscanned.",
+    "Binder's title: Recueil de Vaudevill",
+    "Binding: Contemporary French blue morocco, gilt with the arms of Michel Begon on front and back.",
+    "Bookplate of E. Valdruche.",
+    "Index starts at p. 305 but is discreetly paginated.",
+    "Pages 292-304 blank (but with printed floral borders) and unscanned."
+  ],
+  "subjectName_ssim": [
+    "Valdruche, Eugene, d. 1913?, provenance"
+  ],
+  "subjectTopic_ssim": [
+    "Chansons--18th Century",
+    "Songs, French--18th century--Texts",
+    "Songs--France--18th century",
+    "Vaudeville--France--Early works to 1800",
+    "Vaudevilles--Librettos"
+  ],
+  "genre_ssim": [
+    "Musical works"
+  ],
+  "format_ssim": "notated music",
+  "partOf_ssim": "Beinecke Library",
+  "rights_ssim": [
+    "The use of this image may be subject to the copyright law of the United States (Title 17, United States Code) or to site license or other rights management terms and conditions. The person using the image is liable for any infringement."
+  ],
+  "bib_id_ssm": "7039963",
+  "orbisBarcode_ssim": "39002094210060",
+  "resourceType_ssim": "Music (Printed & Manuscript)",
+  "id": 2057976,
+  "collectionId_ssim": 1,
+  "children_ssim": [],
+  "abstract_ssim": "A collection of 87 anonymous French love songs and vaudevilles, with an alphabetical index at the back."
+  ,
+  "public_bsi": true
+}

--- a/spec/fixtures/solr/oid-2107188.json
+++ b/spec/fixtures/solr/oid-2107188.json
@@ -1,0 +1,40 @@
+{
+  "source_ssim": "ladybird",
+  "recordType_ssim": "id",
+  "uri_ssim": "/ladybird/oid/2107188",
+  "identifierShelfMark_ssim": "Brsides 2007 18",
+  "author_tsim": [
+    "Viets, Dan, 1751-"
+  ],
+  "title_tsim": [
+    "Fair Lucretia’s garland"
+  ],
+  "extentOfDigitization_ssim": "Complete work digitized.",
+  "publicationPlace_ssim": [
+    "[New Haven?]"
+  ],
+  "publisher_ssim": [
+    "Printed for Dan Viets"
+  ],
+  "date_ssim": "September, MDCCLXXIX [1779]",
+  "extent_ssim": "36 x 24 cm.",
+  "language_ssim": [
+    "English"
+  ],
+  "genre_ssim": [
+    "Autographs",
+    "Broadsides"
+  ],
+  "format_ssim": "text",
+  "partOf_ssim": "Treasures Old & New: Recent Additions to Beinecke Collections",
+  "rights_ssim": [
+    "The use of this image may be subject to the copyright law of the United States (Title 17, United States Code) or to site license or other rights management terms and conditions. The person using the image is liable for any infringement."
+  ],
+  "bib_id_ssm": "7972227",
+  "id": 2107188,
+  "collectionId_ssim": 1,
+  "children_ssim": [],
+  "abstract_ssim": "An apparently unrecorded eighteenth century American verse broadside. The poem recounts the tragic tale of a young merchant who falls in love with Lucretia, becomes engaged to her, then sails away to make his fortune. The text is surrounded by printer’s ornaments of four-petaled flowers, suns, and rosettes, including those used by Samuel and Thomas Green who were printing in partnership in New Haven, 1769-97."
+  ,
+  "public_bsi": true
+}

--- a/spec/fixtures/solr/oid-2111169.json
+++ b/spec/fixtures/solr/oid-2111169.json
@@ -1,0 +1,50 @@
+{
+  "source_ssim": "ladybird",
+  "recordType_ssim": "id",
+  "uri_ssim": "/ladybird/oid/2111169",
+  "identifierShelfMark_ssim": "Beinecke MS 1121",
+  "author_tsim": [
+    "Galen"
+  ],
+  "title_tsim": [
+    "Opera varia"
+  ],
+  "alternativeTitle_tesim": [
+    "[ad Glauconem de medendi methodo]",
+    "[On the therapeutic method. Greek]"
+  ],
+  "extentOfDigitization_ssim": "Complete work digitized.",
+  "publicationPlace_ssim": [
+    "[Constantinople or southern Italy]"
+  ],
+  "date_ssim": "ca. 1300",
+  "extent_ssim": "1 vol.",
+  "language_ssim": [
+    "Greek, Ancient (to 1453)"
+  ],
+  "description_ssim": [
+    "Brown ink on paper."
+  ],
+  "subjectTopic_ssim": [
+    "Medicine --Early works to 1800"
+  ],
+  "genre_ssim": [
+    "Manuscripts"
+  ],
+  "format_ssim": "text",
+  "partOf_ssim": "Beinecke Library",
+  "rights_ssim": [
+    "The use of this image may be subject to the copyright law of the United States (Title 17, United States Code) or to site license or other rights management terms and conditions. The person using the image is liable for any infringement."
+  ],
+  "bib_id_ssm": "9896328",
+  "orbisBarcode_ssim": "39002099258734",
+  "importUrl_ssim": "https://pre1600ms.beinecke.library.yale.edu/docs/pre1600.ms1121.htm",
+  "dateStructured_ssim": "1300-00-00T00:00:00Z",
+  "resourceType_ssim": "Archives or Manuscripts",
+  "id": 2111169,
+  "collectionId_ssim": 1,
+  "children_ssim": [],
+  "abstract_ssim": "MS of 8 works by Galen in Greek: 1. ff.1-15v Galen, de temperamentis. 2. ff.15v-54r Galen, de naturalibus facultatibus 3. ff.54r-54v short fragment of unknown provenance. 4. ff.54v-57v Galen, de inaequali intemperie. 5. ff.57v-60 Galen, de optima corporis nostri constitutione. 6. ff.60-61 Galen, de bono habitu 7. ff.62-106 Galen, de difficultate respirationis 8. ff.107-140 Galen ad Glauconem de medendi methodo 9.141-154 Galen de alimentorum facultatibus."
+  ,
+  "public_bsi": true
+}


### PR DESCRIPTION
This commit contains
1) A shell script to transform Ladybird output from the metadata cloud to solr-ready ingest documents
2) A current copy of the documents that we can version control
3) An update to the docker-compose file that mounts the samples to a volume in the Solr container

**TO UPDATE THE SOLR FIXTURES**
`cd ./spec/fixtures && ./ladybird-to-solr.sh`

**TO INGEST THE FIXTURES TO SOLR**
Start your environement: `docker-compose up web`
Run the ingest tool `docker-compose exec solr ./bin/post -c blacklight-core /home/samples/solr/`