### PR TITLE
add format to Solr indexing for tickets 128-130

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -20,6 +20,9 @@ Metrics/AbcSize:
 # ExcludedMethods: refine
 Metrics/BlockLength:
   Max: 33
+  Exclude:
+    - 'spec/**/*'
+    - 'app/controllers/catalog_controller.rb'
 
 # Offense count: 1
 # Configuration parameters: CountComments.

--- a/app/services/voyager_indexing_service.rb
+++ b/app/services/voyager_indexing_service.rb
@@ -19,7 +19,8 @@ class VoyagerIndexingService
     @oid_hash ||= build_oid_hash
   end
 
-  ##since we currently use bib to loop for oids we need storage for format
+  ##
+  # since we currently use bib to loop for oids we need storage for format
   def format_hash
     @format_hash ||= {}
   end

--- a/app/services/voyager_indexing_service.rb
+++ b/app/services/voyager_indexing_service.rb
@@ -19,6 +19,11 @@ class VoyagerIndexingService
     @oid_hash ||= build_oid_hash
   end
 
+  ##since we currently use bib to loop for oids we need storage for format
+  def format_hash
+    @format_hash ||= {}
+  end
+
   ##
   # Read in a directory of ladybird json files and create a hash mapping orbisBibId to oid
   # Blacklight will need the oid in order to fetch the image for display.
@@ -33,6 +38,7 @@ class VoyagerIndexingService
         oid = data_hash["oid"].to_s
         oid_hash[orbis_bib_id] ||= []
         oid_hash[orbis_bib_id] << oid
+        format_hash[oid] = data_hash['format']
       # TODO: We need a better way to surface parsing errors
       # Ideally these would go to an error tracking service that someone would review
       rescue JSON::ParserError => e
@@ -56,7 +62,8 @@ class VoyagerIndexingService
         description_tesim: data_hash["description"],
         author_tsim: data_hash["creator"],
         bib_id_ssm: orbis_bib_id,
-        public_bsi: data_hash["public"].presence || 0
+        public_bsi: data_hash["public"].presence || 0,
+        format: format_hash[oid]
       }
       solr = Blacklight.default_index.connection
       solr.add([solr_doc])

--- a/spec/system/view_facet_spec.rb
+++ b/spec/system/view_facet_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe 'Facets should display', type: :system, js: :true, clean: true do
+  before do
+    solr = Blacklight.default_index.connection
+    solr.add([llama,
+              dog,
+              eagle,
+              puppy])
+    solr.commit
+    visit root_path
+  end
+
+  let(:llama) do
+    {
+      id: '111',
+      title_tsim: ['Amor Llama'],
+      format: 'text',
+      language_ssim: 'la',
+      public_bsi: 1
+    }
+  end
+
+  let(:dog) do
+    {
+      id: '222',
+      title_tsim: ['HandsomeDan Bulldog'],
+      format: 'three dimensional object',
+      language_ssim: 'en',
+      public_bsi: 1
+    }
+  end
+
+  let(:eagle) do
+    {
+      id: '333',
+      title_tsim: ['Aquila Eccellenza'],
+      format: 'still image',
+      language_ssim: 'it',
+      public_bsi: 1
+    }
+  end
+
+  let(:puppy) do
+    {
+      id: '444',
+      title_tsim: ['Rhett Lecheire'],
+      format: 'text',
+      language_ssim: 'fr',
+      public_bsi: 1
+    }
+  end
+
+  it 'can filter results with format facets' do
+    click_on 'Format'
+    click_on 'text'
+    expect(page).to have_content('Amor Llama')
+    expect(page).not_to have_content('Aquila Eccellenza')
+    expect(page).not_to have_content('HandsomeDan Bulldog')
+  end
+
+  it 'can filter results with language facets' do
+    click_on 'Language'
+    click_on 'la'
+    expect(page).to have_content('Amor Llama')
+    expect(page).not_to have_content('Aquila Eccellenza')
+    expect(page).not_to have_content('HandsomeDan Bulldog')
+  end
+
+  it 'can filter results with pivot field facets' do
+    click_on 'Pivot Field'
+    click_on 'la'
+
+    expect(page).to have_content('Amor Llama')
+    expect(page).not_to have_content('Rhett Lecheire')
+  end
+end

--- a/spec/system/view_fields_in_display_spec.rb
+++ b/spec/system/view_fields_in_display_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.feature "View Search Results", type: :system, clean: true, js: false do
+  before do
+    solr = Blacklight.default_index.connection
+    solr.add([test_record])
+    solr.commit
+    visit '/catalog/111'
+  end
+
+  let(:test_record) do
+    {
+      id: '111',
+      title_tsim: ['HandsomeDan Bulldog'],
+      title_vern_ssim: ['HandsomeDan Bulldog'],
+      subtitle_tsim: "He's handsome",
+      subtitle_vern_ssim: "He's handsome",
+      author_tsim: 'Eric & Frederick',
+      author_vern_ssim: 'Eric & Frederick',
+      format: 'three dimensional object',
+      url_fulltext_ssim: 'http://0.0.0.0:3000/catalog/111',
+      url_suppl_ssim: 'http://0.0.0.0:3000/catalog/111',
+      published_ssim: "1997",
+      published_vern_ssim: "1997",
+      lc_callnum_ssim: "123213213",
+      language_ssim: 'en',
+      isbn_ssim: '2321321389',
+      description_tesim: "Handsome Dan is a bulldog who serves as Yale Univeristy's mascot.",
+      public_bsi: 1
+    }
+  end
+
+  it 'displays Author in results' do
+    expect(page).to have_content("Eric & Frederick").twice
+  end
+  it 'displays Title in results' do
+    expect(page).to have_content("HandsomeDan Bulldog", count: 3)
+  end
+  it 'displays Subtitle in results' do
+    expect(page).to have_content("He's handsome").twice
+  end
+  it 'displays Url Fulltext in results' do
+    expect(page).to have_content("http://0.0.0.0:3000/catalog/111").twice
+  end
+  it 'displays Publishing in results' do
+    expect(page).to have_content("1997").twice
+  end
+  it 'displays format in results' do
+    expect(page).to have_content("three dimensional object")
+  end
+  it 'displays call number in results' do
+    expect(page).to have_content("123213213")
+  end
+  it 'displays language in results' do
+    expect(page).to have_content("en")
+  end
+  it 'displays ISBN in results' do
+    expect(page).to have_content("2321321389")
+  end
+  it 'displays description in results' do
+    expect(page).to have_content("Handsome Dan is a bulldog who serves as Yale Univeristy's mascot.")
+  end
+end

--- a/spec/system/view_fields_in_search_spec.rb
+++ b/spec/system/view_fields_in_search_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe 'Search results displays field', type: :system, clean: true do
+  before do
+    solr = Blacklight.default_index.connection
+    solr.add([dog])
+    solr.commit
+    visit '/?search_field=all_fields&q='
+  end
+
+  let(:dog) do
+    {
+      id: '111',
+      title_tsim: ['HandsomeDan Bulldog'],
+      title_vern_ssim: ['HandsomeDan Bulldog'],
+      author_tsim: 'Me and You',
+      author_vern_ssim: 'Me and You',
+      format: 'three dimensional object',
+      published_ssim: "1997",
+      published_vern_ssim: "1997",
+      lc_callnum_ssim: "123213213",
+      language_ssim: 'en',
+      public_bsi: 1
+    }
+  end
+  it 'displays Author in results' do
+    expect(page).to have_content("Me and You").twice
+  end
+  it 'displays Title in results' do
+    expect(page).to have_content("HandsomeDan Bulldog", count: 3)
+  end
+  it 'displays Publishing in results' do
+    expect(page).to have_content("1997").twice
+  end
+  it 'displays format in results' do
+    expect(page).to have_content("three dimensional object")
+  end
+  it 'displays call number in results' do
+    expect(page).to have_content("123213213")
+  end
+  it 'displays language in results' do
+    expect(page).to have_content("en")
+  end
+end


### PR DESCRIPTION
Co-authored-by: Eric DeJesus <eric.dejesus@yale.com>

----
**For ticket 128**
1. git pull 
2. reindex Solr with the rake task `rake yale:load_voyager_sample_data`
3. then bring up the server and verify on local that the format facet appears on the lefthand side.  
<img width="1161" alt="Screen Shot 2020-05-12 at 3 00 10 PM" src="https://user-images.githubusercontent.com/41123693/81833779-215c4f80-950e-11ea-9c15-213e24781ac6.png">

**Continue testing for ticket 129**
4. complete a search
5. verify format field is under each item
<img width="1161" alt="Screen Shot 2020-05-12 at 3 00 10 PM" src="https://user-images.githubusercontent.com/41123693/81833749-19041480-950e-11ea-9224-0390578b631e.png">


**Lastly, testing for ticket 130**
6. click on an object to verify formatting is below image

<img width="1069" alt="Screen Shot 2020-05-12 at 3 01 15 PM" src="https://user-images.githubusercontent.com/41123693/81833874-3fc24b00-950e-11ea-91b6-86e7a6e536f9.png">



