### PR TITLE
i114-display-images-tray

### DIFF
--- a/app/assets/javascripts/uv_width.js
+++ b/app/assets/javascripts/uv_width.js
@@ -1,0 +1,7 @@
+$(document).on('turbolinks:load', function () {
+    $('#universal-viewer-iframe').width($('.uv-container').width())
+
+    $(window).on('resize', function () {
+        $('#universal-viewer-iframe').width($('.uv-container').width())
+    })
+})

--- a/app/assets/stylesheets/uv.css
+++ b/app/assets/stylesheets/uv.css
@@ -1,0 +1,6 @@
+.uv-container {
+    max-width: 1200px;
+    width: 100%;
+    display: flex;
+    justify-content: center;
+}

--- a/app/views/catalog/_uv.html.erb
+++ b/app/views/catalog/_uv.html.erb
@@ -1,11 +1,13 @@
 <% oid = @document.id %>
 
+<div class="uv-container">
 <iframe
     class="universal-viewer-iframe"
     src="<%= request&.base_url %>/uv/uv.html#?manifest=<%= manifest_url(oid) %>"
-    width="640"
-    height="480"
+    width="924"
+    height="668"
     allowfullscreen
     frameborder="0">
 </iframe>
+</div>
 </br>

--- a/config/uv/uv.html
+++ b/config/uv/uv.html
@@ -1,9 +1,10 @@
 <!DOCTYPE html>
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
-  <head>
+
+<head>
     <!--
         This is what the embed iframe src links to. It doesn't need to communicate with the parent page, only fill the available space and look for #? parameters
-      -->
+    -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <link rel="icon" href="favicon.ico">
     <link rel="stylesheet" type="text/css" href="uv.css">
@@ -15,15 +16,19 @@
             padding: 0;
             overflow: hidden;
         }
+
         .uv .mobileFooterPanel .options .btn.fullScreen {
-          display: inline !important;
-         }
-         .title > span {
-            display: none;
-         }
+            display: inline !important;
+            margin-right: 0;
+            float: right;
+        }
+
+        .uv .mobileFooterPanel .options {
+            width: auto !important;
+        }
     </style>
     <script type="text/javascript">
-    window.addEventListener('uvLoaded', function(e) {
+        window.addEventListener('uvLoaded', function (e) {
             urlDataProvider = new UV.URLDataProvider(true);
             var formattedLocales;
             var locales = urlDataProvider.get('locales', '');
@@ -32,7 +37,7 @@
                 formattedLocales = [];
                 for (var i in names) {
                     var nameparts = String(names[i]).split(':');
-                    formattedLocales[i] = {name: nameparts[0], label: nameparts[1]};
+                    formattedLocales[i] = { name: nameparts[0], label: nameparts[1] };
                 }
             } else {
                 formattedLocales = [
@@ -58,27 +63,29 @@
         }, false);
     </script>
 </head>
+
 <body>
 
-<div id="uv" class="uv"></div>
+    <div id="uv" class="uv"></div>
 
-<script>
-    $(function() {
-        var $UV = $('#uv');
-        function resize() {
-            var windowWidth = window.innerWidth;
-            var windowHeight = window.innerHeight;
-            $UV.width(windowWidth);
-            $UV.height(windowHeight);
-        }
-        $(window).on('resize' ,function() {
+    <script>
+        $(function () {
+            var $UV = $('#uv');
+            function resize() {
+                var windowWidth = window.innerWidth;
+                var windowHeight = window.innerHeight;
+                $UV.width(windowWidth);
+                $UV.height(windowHeight);
+            }
+            $(window).on('resize', function () {
+                resize();
+            });
             resize();
         });
-        resize();
-    });
-</script>
+    </script>
 
-<script type="text/javascript" src="uv.js"></script>
+    <script type="text/javascript" src="uv.js"></script>
 
 </body>
+
 </html>


### PR DESCRIPTION
# Ticket
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/114

# Story
When I'm viewing a multipage work, I would like a thumbnail view of all the pages, so that I can quickly scan and jump through long works, instead of having to navigate one page at at time.

# Expected Behavior
- user's see thumbnails of all images in the left pane **when the browser window is 1200px or wider**
- user's can click the gallery view option in the top pane

# Demo
![Screen Shot 2020-05-14 at 9 48 34 AM](https://user-images.githubusercontent.com/29032869/81963014-64c7c400-95c9-11ea-8839-7378982ac2c5.png)

# Resources
- https://github.com/emory-libraries/dlp-lux/pull/93
- https://forum.omeka.org/t/universal-viewer-config-json/9451