### PR TITLE
i144-title-and-keywords-fields

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,8 @@ jobs:
             POSTGRES_DB: blacklight_yul_test
             POSTGRES_USER: postgres
             POSTGRES_PASSWORD: password
+            POSTGRES_HOST: localhost
+            SOLR_URL: http://localhost:8983/solr/blacklight-test
       - image: yalelibraryit/dc-solr:79a71ec
         command: bash -c 'precreate-core blacklight-test /opt/config; exec solr -f'
       - image: circleci/postgres:9.5-alpine-ram

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -127,6 +127,13 @@ class CatalogController < ApplicationController
     config.add_show_field 'lc_callnum_ssim', label: 'Call number'
     config.add_show_field 'isbn_ssim', label: 'ISBN'
     config.add_show_field 'description_tesim', label: 'Description'
+    config.add_show_field 'abstract_ssim', label: 'Abstract'
+    config.add_show_field 'alternativeTitle_ssim', label: 'Alternative Title'
+    config.add_show_field 'genre_ssim', label: 'Genre'
+    config.add_show_field 'geoSubject_ssim', label: 'Geo Subject'
+    config.add_show_field 'resourceType_ssim', label: 'Resource Type'
+    config.add_show_field 'subjectName_ssim', label: 'Subject Name'
+    config.add_show_field 'subjectTopic_ssim', label: 'Subject Topic'
 
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields

--- a/app/services/voyager_indexing_service.rb
+++ b/app/services/voyager_indexing_service.rb
@@ -64,7 +64,16 @@ class VoyagerIndexingService
         author_tsim: data_hash["creator"],
         bib_id_ssm: orbis_bib_id,
         public_bsi: data_hash["public"].presence || 0,
-        format: format_hash[oid]
+        format: format_hash[oid],
+
+        # psuedocoded the ssim properties
+        # abstract_ssim: "this is an abstract",
+        # alternativeTitle_ssim: "this is an alternative title",
+        # genre_ssim: "this is the genre",
+        # geoSubject_ssim: "this is the geo subject",
+        # resourceType_ssim: "this is the resource type",
+        # subjectName_ssim: "this is the subject name",
+        # subjectTopic_ssim: "this is the subject topic"
       }
       solr = Blacklight.default_index.connection
       solr.add([solr_doc])

--- a/app/services/voyager_indexing_service.rb
+++ b/app/services/voyager_indexing_service.rb
@@ -64,16 +64,7 @@ class VoyagerIndexingService
         author_tsim: data_hash["creator"],
         bib_id_ssm: orbis_bib_id,
         public_bsi: data_hash["public"].presence || 0,
-        format: format_hash[oid],
-
-        # psuedocoded the ssim properties
-        # abstract_ssim: "this is an abstract",
-        # alternativeTitle_ssim: "this is an alternative title",
-        # genre_ssim: "this is the genre",
-        # geoSubject_ssim: "this is the geo subject",
-        # resourceType_ssim: "this is the resource type",
-        # subjectName_ssim: "this is the subject name",
-        # subjectTopic_ssim: "this is the subject topic"
+        format: format_hash[oid]
       }
       solr = Blacklight.default_index.connection
       solr.add([solr_doc])

--- a/spec/system/view_fields_in_display_spec.rb
+++ b/spec/system/view_fields_in_display_spec.rb
@@ -27,7 +27,14 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       language_ssim: 'en',
       isbn_ssim: '2321321389',
       description_tesim: "Handsome Dan is a bulldog who serves as Yale Univeristy's mascot.",
-      public_bsi: 1
+      public_bsi: 1,
+      abstract_ssim: "this is an abstract",
+      alternativeTitle_ssim: "this is an alternative title",
+      genre_ssim: "this is the genre",
+      geoSubject_ssim: "this is the geo subject",
+      resourceType_ssim: "this is the resource type",
+      subjectName_ssim: "this is the subject name",
+      subjectTopic_ssim: "this is the subject topic"
     }
   end
 
@@ -60,5 +67,26 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
   end
   it 'displays description in results' do
     expect(page).to have_content("Handsome Dan is a bulldog who serves as Yale Univeristy's mascot.")
+  end
+  it 'displays the Abstract in results' do
+    expect(page).to have_content("this is an abstract")
+  end
+  it 'displays the Alternative Title in results' do
+    expect(page).to have_content("this is an alternative title")
+  end
+  it 'displays the Genre in results' do
+    expect(page).to have_content("this is the genre")
+  end
+  it 'displays the Geo Subject in results' do
+    expect(page).to have_content("this is the geo subject")
+  end
+  it 'displays the Resource Type in results' do
+    expect(page).to have_content("this is the resource type")
+  end
+  it 'displays the Subject Name in results' do
+    expect(page).to have_content("this is the subject name")
+  end
+  it 'displays the Subject Topic in results' do
+    expect(page).to have_content("this is the subject topic")
   end
 end


### PR DESCRIPTION
# Ticket
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/144

# Summary
As a scholar, I would like to see all the available descriptive metadata about a work, so that I can better understand the work's context.

# Expected behavior
When viewing a work that has the fields below, they will show up on the page:
- abstract
- alternativeTitle
- genre
- geoSubject
- resourceType
- subjectName
- subjectTopic

# Demo
![Screen Shot 2020-05-20 at 11 38 17 AM](https://user-images.githubusercontent.com/29032869/82485551-752be300-9a90-11ea-8fc2-436112efc804.png)
