### PR TITLE
Fix ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ jobs:
             POSTGRES_DB: blacklight_yul_test
             POSTGRES_USER: postgres
             POSTGRES_PASSWORD: password
+            POSTGRES_HOST: localhost
       - image: yalelibraryit/dc-solr:79a71ec
         command: bash -c 'precreate-core blacklight-test /opt/config; exec solr -f'
       - image: circleci/postgres:9.5-alpine-ram

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ jobs:
             POSTGRES_USER: postgres
             POSTGRES_PASSWORD: password
             POSTGRES_HOST: localhost
+            SOLR_URL: http://localhost:8983/solr/blacklight-test
       - image: yalelibraryit/dc-solr:79a71ec
         command: bash -c 'precreate-core blacklight-test /opt/config; exec solr -f'
       - image: circleci/postgres:9.5-alpine-ram


### PR DESCRIPTION
Fix CI by adding CI overrides for environment variables that would be different for local development.

In the CI build, the postgres and solr containers are on localhost.