### PR TITLE
i147-extent-of-digitization-facet

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -1,0 +1,53 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build and push Docker images
+      uses: docker/build-push-action@v1.1.0
+      with:
+        # Username used to log in to a Docker registry. If not set then no login will occur
+        username: ${{ secrets.DOCKER_USER}}
+        # Password or personal access token used to log in to a Docker registry. If not set then no login will occur
+        password: ${{ secrets.DOCKER_PW}}
+        # Server address of Docker registry. If not set then will default to Docker Hub
+        registry: # optional
+        # Docker repository to tag the image with
+        repository: yalelibraryit/dc-blacklight
+        # Comma-delimited list of tags. These will be added to the registry/repository to form the image's tags
+        tags: # optional
+        # Automatically tags the built image with the git reference as per the readme
+        tag_with_ref: true
+        # Automatically tags the built image with the git short SHA as per the readme
+        tag_with_sha: true
+        # Path to the build context
+        path: .
+        # Path to the Dockerfile (Default is '{path}/Dockerfile')
+        dockerfile: # optional
+        # Sets the target stage to build
+        target: # optional
+        # Always attempt to pull a newer version of the image
+        always_pull: # optional
+        # Comma-delimited list of build-time variables
+        build_args: # optional
+        # Comma-delimited list of images to consider as cache sources
+        cache_froms: yalelibraryit/dc-blacklight:latest
+        # Comma-delimited list of labels to add to the built image
+        labels: test_workflow
+        # Adds labels with git repository information to the built image
+        add_git_labels: # optional
+        # Whether to push the image
+        push: true

--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ IIIF_MANIFESTS_BASE_URL=http://localhost/manifests/
     ```
     bundle exec rake yale:load_voyager_sample_data
     ```
+  - Run rubocop
+    ```
+    bundle exec rubocop -a
+    ```
+  - Run rspec
+    ```
+    bundle exec rspec
+    ```
 
 # Customizing Blacklight:
 

--- a/README.md
+++ b/README.md
@@ -1,22 +1,24 @@
-[![CircleCI](https://circleci.com/gh/yalelibrary/yul-dc-blacklight/tree/master.svg?style=svg)](https://circleci.com/gh/yalelibrary/yul-dc-blacklight/tree/master)
+[![CircleCI](https://circleci.com/gh/yalelibrary/yul-dc-blacklight/tree/master.svg?style=svg)](https://circleci.com/gh/yalelibrary/yul-dc-blacklight/tree/master) ![Docker Image CI](https://github.com/yalelibrary/yul-dc-management/workflows/Docker%20Image%20CI/badge.svg)
 
 # Prerequisites
+
 - Download [Docker Desktop](https://www.docker.com/products/docker-desktop) and log in
 
-
 # Docker Development Setup
-### If this is your first time working in this repo, build the base service (dependencies, etc. that don't change)
-  ``` bash
+
+## If this is your first time working in this repo, build the base service (dependencies, etc. that don't change)
+
+```bash
   docker-compose build base
-  ```
+```
 
-### If this is your first time working in this repo or the Dockerfile has been updated you will need to (re)build your services
-  ``` bash
+## If this is your first time working in this repo or the Dockerfile has been updated you will need to (re)build your services
+
+```bash
   docker-compose build web
+```
 
-  ```
-
-### Using the Makefile
+## Using the Makefile
 
 You can also use the Makefile to build an image locally, and/or push it to dockerhub:
 
@@ -27,56 +29,67 @@ make push <-push an already build image
 
 make build push <-build and then push the image up to dockerhub
 ```
-When you use make build, a new blacklight image is built, and tagged as both :latest, and the current git sha.  When
-pushing to dockerhub, only the git sha version is pushed.
+
+When you use make build, a new blacklight image is built, and tagged as both :latest, and the current git sha. When pushing to dockerhub, only the git sha version is pushed.
+
 ```
 yalelibraryit/dc-blacklight        d915b32 <-git sha   1c2d8977cf5b <- note same image id
 yalelibraryit/dc-blacklight        latest              1c2d8977cf5b
 ```
-In the case above, only  yalelibraryit/dc-blacklight:d915b32 will be available on dockerhub.
 
-### Environment Variables for Development
+In the case above, only yalelibraryit/dc-blacklight:d915b32 will be available on dockerhub.
+
+## Environment Variables for Development
 
 Create .env.development to override anything in .env. The following values must be overridden.
+
 ```
 SOLR_URL=http://solr:8983/solr/blacklight-core
 POSTGRES_HOST=db
 IIIF_MANIFESTS_BASE_URL=http://localhost/manifests/
 ```
 
+## Starting the app
 
-### Starting the app
 - Start the web service
-  ``` bash
+
+  ```bash
   docker-compose up web
   ```
+
 - Access the web app at `http://localhost:3000`
 - Access the solr instance at `http://localhost:8983`
 - Access the image instance at `http://localhost:8182`
 - Access the manifests instance at `http://localhost`
 
-##### Accessing the web container
+### Accessing the web container
+
 - Navigate to the app root directory in another tab and run:
-  ``` bash
+
+  ```bash
   docker-compose exec web bash
   ```
+
 - You will need to be inside the container to:
+
   - Run migrations
   - Access the seed file
   - Access the rails console for debugging
+
     ```
     bundle exec rails c
     ```
+
   - Index sample data (if you press "search" and don't have data, run this command)
+
     ```
     bundle exec rake yale:load_voyager_sample_data
     ```
 
-
 # Customizing Blacklight:
+
 There are many ways to override specific behaviors and views in Blacklight. Because Blacklight is distributed as a Rails engine-based gem, all customization of Blacklight behavior should be done within your application by overriding Blacklight-provided behaviors with your own.
 
-- To modify this text, you need to [override the Blacklight-provided view](http://guides.rubyonrails.org/engines.html#improving-engine-functionality). You can copy this file, located in the blacklight gem: `/usr/local/rvm/gems/ruby-2.6.5/gems/blacklight-7.7.0/app/views/catalog/_home_text.html.erb`
-to your own application: `/home/app/webapp/app/views/catalog/_home_text.html.erb`
+- To modify this text, you need to [override the Blacklight-provided view](http://guides.rubyonrails.org/engines.html#improving-engine-functionality). You can copy this file, located in the blacklight gem: `/usr/local/rvm/gems/ruby-2.6.5/gems/blacklight-7.7.0/app/views/catalog/_home_text.html.erb` to your own application: `/home/app/webapp/app/views/catalog/_home_text.html.erb`
 - [Index your own data](https://github.com/projectblacklight/blacklight/wiki/Indexing-your-data-into-solr) into Solr
 - [Configure Blacklight](https://github.com/projectblacklight/blacklight/wiki#blacklight-configuration) to match your data and user-experience needs

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -81,6 +81,7 @@ class CatalogController < ApplicationController
     config.add_facet_field 'pub_date_ssim', label: 'Publication Year', single: true
     config.add_facet_field 'subject_ssim', label: 'Topic', limit: 20, index_range: 'A'..'Z'
     config.add_facet_field 'language_ssim', label: 'Language', limit: true
+    config.add_facet_field 'extentOfDigitization_ssim', label: 'Extent of Digitization'
     config.add_facet_field 'lc_1letter_ssim', label: 'Call Number'
     config.add_facet_field 'subject_geo_ssim', label: 'Region'
     config.add_facet_field 'subject_era_ssim', label: 'Era'
@@ -104,6 +105,7 @@ class CatalogController < ApplicationController
     config.add_index_field 'title_vern_ssim', label: 'Title'
     config.add_index_field 'author_tsim', label: 'Author'
     config.add_index_field 'author_vern_ssim', label: 'Author'
+    config.add_index_field 'extentOfDigitization_ssim', label: 'Extent of Digitization'
     config.add_index_field 'format', label: 'Format'
     config.add_index_field 'language_ssim', label: 'Language'
     config.add_index_field 'published_ssim', label: 'Published'

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -134,6 +134,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'resourceType_ssim', label: 'Resource Type'
     config.add_show_field 'subjectName_ssim', label: 'Subject Name'
     config.add_show_field 'subjectTopic_ssim', label: 'Subject Topic'
+    config.add_show_field 'extentOfDigitization_ssim', label: 'Extent of Digitization'
 
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields

--- a/spec/system/view_fields_in_display_spec.rb
+++ b/spec/system/view_fields_in_display_spec.rb
@@ -34,7 +34,8 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       geoSubject_ssim: "this is the geo subject",
       resourceType_ssim: "this is the resource type",
       subjectName_ssim: "this is the subject name",
-      subjectTopic_ssim: "this is the subject topic"
+      subjectTopic_ssim: "this is the subject topic",
+      extentOfDigitization_ssim: 'this is the extent of digitization'
     }
   end
 
@@ -88,5 +89,8 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
   end
   it 'displays the Subject Topic in results' do
     expect(page).to have_content("this is the subject topic")
+  end
+  it 'displays the Extend of Digitization in results' do
+    expect(page).to have_content("this is the extent of digitization")
   end
 end


### PR DESCRIPTION
Co-authored by [Frederick Rodriguez](frederick.rodriguez@yale.edu)

# Ticket
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/147

# Summary
As a scholar, I'd like to filter out results from my searches that aren't completely digitized, so that I can identify resources that I can access online in their entirety.

# Expected behavior
- There is a facet field for 'extentOfDigitization'
- Search results display the 'extentOfDigitization' when available
- Single item view pages display the 'extentOfDigitization' when available

# Demo
![image](https://user-images.githubusercontent.com/29032869/82604083-96600280-9b68-11ea-91e9-4a692b888bd1.png)

![image](https://user-images.githubusercontent.com/29032869/82604116-a4158800-9b68-11ea-9151-5431851b29c3.png)

# Note
The `extentOfDigitization_ssim:` field in `voyager_indexing_service.rb` will need to be mapped to the correct path by the management team to make this work show up in production