### PR TITLE
adds publication and rights fields and specs

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -137,6 +137,11 @@ class CatalogController < ApplicationController
     config.add_show_field 'subjectName_ssim', label: 'Subject Name'
     config.add_show_field 'subjectTopic_ssim', label: 'Subject Topic'
     config.add_show_field 'extentOfDigitization_ssim', label: 'Extent of Digitization'
+    config.add_show_field 'rights_ssim', label: 'Rights'
+    config.add_show_field 'publicationPlace_ssim', label: 'Publication Place'
+    config.add_show_field 'sourceCreated_ssim', label: 'Source Created'
+    config.add_show_field 'publisher_ssim', label: 'Publisher'
+    config.add_show_field 'copyrightDate_ssim', label: 'Copyright Date'
 
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields

--- a/spec/system/view_fields_in_display_spec.rb
+++ b/spec/system/view_fields_in_display_spec.rb
@@ -35,7 +35,12 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       resourceType_ssim: "this is the resource type",
       subjectName_ssim: "this is the subject name",
       subjectTopic_ssim: "this is the subject topic",
-      extentOfDigitization_ssim: 'this is the extent of digitization'
+      extentOfDigitization_ssim: 'this is the extent of digitization',
+      rights_ssim: "these are the rights",
+      publicationPlace_ssim: "this is the publication place",
+      sourceCreated_ssim: "this is the source created",
+      publisher_ssim: "this is the publisher",
+      copyrightDate_ssim: "this is the copyright date"
     }
   end
 
@@ -92,5 +97,20 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
   end
   it 'displays the Extend of Digitization in results' do
     expect(page).to have_content("this is the extent of digitization")
+  end
+  it 'displays the Rights in results' do
+    expect(page).to have_content("these are the rights")
+  end
+  it 'displays the Publication Place in results' do
+    expect(page).to have_content("this is the publication place")
+  end
+  it 'displays the Source Created in results' do
+    expect(page).to have_content("this is the source created")
+  end
+  it 'displays the Publisher in results' do
+    expect(page).to have_content("this is the publisher")
+  end
+  it 'displays the Copyright Date in results' do
+    expect(page).to have_content("this is the copyright date")
   end
 end


### PR DESCRIPTION
Relates to Ticket #148 
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/148

Adds following fields to single item view:

    rights
    publicationPlace
    sourceCreated
    publisher
    copyrightDate


Screen shot of single item view:
<img width="605" alt="image" src="https://user-images.githubusercontent.com/36549923/82926424-cc283100-9f44-11ea-95a6-d38a21a65811.png">
