### PR TITLE
i145-identifiers-on-single-item-view

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -142,6 +142,17 @@ class CatalogController < ApplicationController
     config.add_show_field 'sourceCreated_ssim', label: 'Source Created'
     config.add_show_field 'publisher_ssim', label: 'Publisher'
     config.add_show_field 'copyrightDate_ssim', label: 'Copyright Date'
+    config.add_show_field 'oid_ssim', label: 'OID'
+    config.add_show_field 'identifierMfhd_ssim', label: 'Identifier MFHD'
+    config.add_show_field 'identifierShelfMark_ssim', label: 'Identifier Shelf Mark'
+    config.add_show_field 'box_ssim', label: 'Box'
+    config.add_show_field 'folder_ssim', label: 'Folder'
+    config.add_show_field 'orbisBibId_ssim', label: 'Orbis Bib ID'
+    config.add_show_field 'orbisBarcode_ssim', label: 'Orbis Bar Code'
+    config.add_show_field 'findingAid_ssim', label: 'Finding Aid'
+    config.add_show_field 'collectionId_ssim', label: 'Collection ID'
+    config.add_show_field 'edition_ssim', label: 'Edition'
+    config.add_show_field 'uri_ssim', label: 'URI'
 
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields

--- a/spec/system/view_fields_in_display_spec.rb
+++ b/spec/system/view_fields_in_display_spec.rb
@@ -40,7 +40,18 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       publicationPlace_ssim: "this is the publication place",
       sourceCreated_ssim: "this is the source created",
       publisher_ssim: "this is the publisher",
-      copyrightDate_ssim: "this is the copyright date"
+      copyrightDate_ssim: "this is the copyright date",
+      oid_ssim: 'this is the OID',
+      identifierMfhd_ssim: 'this is the identifier MFHD',
+      identifierShelfMark_ssim: 'this is the identifier shelf mark',
+      box_ssim: 'this is the box',
+      folder_ssim: 'this is the folder',
+      orbisBibId_ssim: 'this is the orbis bib ID',
+      orbisBarcode_ssim: 'this is the orbis bar code',
+      findingAid_ssim: 'this is the finding aid',
+      collectionId_ssim: 'this is the collection ID',
+      edition_ssim: 'this is the edition',
+      uri_ssim: 'this is the URI'
     }
   end
 
@@ -112,5 +123,38 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
   end
   it 'displays the Copyright Date in results' do
     expect(page).to have_content("this is the copyright date")
+  end
+  it 'displays the OID in results' do
+    expect(page).to have_content("this is the OID")
+  end
+  it 'displays the Identifier MFHD in results' do
+    expect(page).to have_content("this is the identifier MFHD")
+  end
+  it 'displays the Identifier Shelf Mark in results' do
+    expect(page).to have_content("this is the identifier shelf mark")
+  end
+  it 'displays the Box in results' do
+    expect(page).to have_content("this is the box")
+  end
+  it 'displays the Folder in results' do
+    expect(page).to have_content("this is the folder")
+  end
+  it 'displays the Orbis Bib ID in results' do
+    expect(page).to have_content("this is the orbis bib ID")
+  end
+  it 'displays the Orbis Bar Code in results' do
+    expect(page).to have_content("this is the orbis bar code")
+  end
+  it 'displays the Finding Aid in results' do
+    expect(page).to have_content("this is the finding aid")
+  end
+  it 'displays the Collection ID in results' do
+    expect(page).to have_content("this is the collection ID")
+  end
+  it 'displays the Edition in results' do
+    expect(page).to have_content("this is the edition")
+  end
+  it 'displays the URI in results' do
+    expect(page).to have_content("this is the URI")
   end
 end


### PR DESCRIPTION
# Ticket
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/145

# Summary
As a scholar, I would like to see all the available descriptive metadata about a work, so that I can better understand the work's context.

# Expected behavior
When viewing a work that has the fields below, they will show up on the page:
- oid
- identifierMfhd
- identifierShelfMark
- box
- folder
- orbisBibId
- orbisBarcode
- findingAid
- collectionId
- edition
- uri

# Demo
![image](https://user-images.githubusercontent.com/29032869/82940576-ea446000-9f49-11ea-8102-25188630b6c0.png)
