### PR TITLE
i179-remove-title-label-from-search-results

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM yalelibraryit/dc-blacklight-base:v1.0.5
+FROM yalelibraryit/dc-blacklight-base:v1.0.6
 
 ADD https://time.is/just build-time
 COPY ops/nginx.sh /etc/service/nginx/run

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.6.5'
+ruby '2.6.6'
 
 gem "actionpack", ">= 6.0.3.1"
 gem 'awesome_print'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -405,7 +405,7 @@ DEPENDENCIES
   webpacker (~> 4.0)
 
 RUBY VERSION
-   ruby 2.6.5p114
+   ruby 2.6.6p146
 
 BUNDLED WITH
    2.1.4

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -110,8 +110,6 @@ class CatalogController < ApplicationController
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
-    config.add_show_field 'title_tsim', label: 'Title'
-    config.add_show_field 'title_vern_ssim', label: 'Title'
     config.add_show_field 'subtitle_tsim', label: 'Subtitle'
     config.add_show_field 'subtitle_vern_ssim', label: 'Subtitle'
     config.add_show_field 'author_tsim', label: 'Author'

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -99,8 +99,6 @@ class CatalogController < ApplicationController
 
     # solr fields to be displayed in the index (search results) view
     #   The ordering of the field names is the order of the display
-    config.add_index_field 'title_tsim', label: 'Title'
-    config.add_index_field 'title_vern_ssim', label: 'Title'
     config.add_index_field 'author_tsim', label: 'Author'
     config.add_index_field 'author_vern_ssim', label: 'Author'
     config.add_index_field 'extentOfDigitization_ssim', label: 'Extent of Digitization'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     ports:
       - '3000:3000'
     volumes:
-      - blacklight:/home/app/webapp
+      - .:/home/app/webapp
     command: bash -c "echo $$(date -u +%FT%TZ) > DEPLOYED_AT && /sbin/my_init"
     # Keep the stdin open, so we can attach to our app container's process
     # and do things such as byebug, etc:

--- a/spec/system/view_fields_in_display_spec.rb
+++ b/spec/system/view_fields_in_display_spec.rb
@@ -12,8 +12,6 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
   let(:test_record) do
     {
       id: '111',
-      title_tsim: ['HandsomeDan Bulldog'],
-      title_vern_ssim: ['HandsomeDan Bulldog'],
       subtitle_tsim: "He's handsome",
       subtitle_vern_ssim: "He's handsome",
       author_tsim: 'Eric & Frederick',
@@ -77,9 +75,6 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
 
     it 'displays Author in results' do
       expect(document).to have_content("Eric & Frederick").twice
-    end
-    it 'displays Title in results' do
-      expect(document).to have_content("HandsomeDan Bulldog", count: 3)
     end
     it 'displays Subtitle in results' do
       expect(document).to have_content("He's handsome").twice

--- a/spec/system/view_fields_in_search_spec.rb
+++ b/spec/system/view_fields_in_search_spec.rb
@@ -12,8 +12,6 @@ RSpec.describe 'Search results displays field', type: :system, clean: true do
   let(:dog) do
     {
       id: '111',
-      title_tsim: ['HandsomeDan Bulldog'],
-      title_vern_ssim: ['HandsomeDan Bulldog'],
       author_tsim: 'Me and You',
       author_vern_ssim: 'Me and You',
       format: 'three dimensional object',

--- a/spec/system/view_fields_in_search_spec.rb
+++ b/spec/system/view_fields_in_search_spec.rb
@@ -34,9 +34,6 @@ RSpec.describe 'Search results displays field', type: :system, clean: true do
     it 'displays Author in results' do
       expect(content).to have_content("Me and You").twice
     end
-    it 'displays Title in results' do
-      expect(content).to have_content("HandsomeDan Bulldog", count: 3)
-    end
     it 'displays Publishing in results' do
       expect(content).to have_content("1997").twice
     end


### PR DESCRIPTION
# Ticket
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/179

# Story
The "Title" label for each search result is redundant

# Expected Behavior
- The "Title" label and text on the search results page is gone
- The "Title" label and text on the individual result page is gone
- Users can still search according to the "Title" when you click the "All Fields" dropdown
- Tests for the "Title" field have been removed

# Demo
- search results page
![image](https://user-images.githubusercontent.com/29032869/83577034-087d0380-a4e8-11ea-9f28-363322a817d8.png)

- individual result page
![image](https://user-images.githubusercontent.com/29032869/83577266-a53fa100-a4e8-11ea-882d-fba373654d9c.png)