### PR TITLE
Upgrade to ruby-2.6.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM yalelibraryit/dc-blacklight-base:v1.0.5
+FROM yalelibraryit/dc-blacklight-base:v1.0.6
 
 ADD https://time.is/just build-time
 COPY ops/nginx.sh /etc/service/nginx/run

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.6.5'
+ruby '2.6.6'
 
 gem "actionpack", ">= 6.0.3.1"
 gem 'awesome_print'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -405,7 +405,7 @@ DEPENDENCIES
   webpacker (~> 4.0)
 
 RUBY VERSION
-   ruby 2.6.5p114
+   ruby 2.6.6p146
 
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
At some point when we re-built the base image we seem to have grabbed an updated version of phusion/passenger-ruby26, which included an upgrade from ruby-2.6.5 to ruby-2.6.6 and now we're getting a ruby version mis-match. Let's upgrade our application to ruby-2.6.6 to match the expectations of the base image.