### PR TITLE
Fix local mount

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     ports:
       - '3000:3000'
     volumes:
-      - blacklight:/home/app/webapp
+      - .:/home/app/webapp
     command: bash -c "echo $$(date -u +%FT%TZ) > DEPLOYED_AT && /sbin/my_init"
     # Keep the stdin open, so we can attach to our app container's process
     # and do things such as byebug, etc:


### PR DESCRIPTION
We inadvertently broke the connection between the local filesystem and the running blacklight application, which prevents using a local editor for development.