### PR TITLE
adds author facet and spec

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -85,6 +85,7 @@ class CatalogController < ApplicationController
     config.add_facet_field 'lc_1letter_ssim', label: 'Call Number'
     config.add_facet_field 'subject_geo_ssim', label: 'Region'
     config.add_facet_field 'subject_era_ssim', label: 'Era'
+    config.add_facet_field 'author_tsim', label: 'Author', limit: true, sort: 'index'
 
     config.add_facet_field 'example_query_facet_field', label: 'Publish Date', query: {
       years_5: { label: 'within 5 Years', fq: "pub_date_ssim:[#{Time.zone.now.year - 5} TO *]" },

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -85,7 +85,7 @@ class CatalogController < ApplicationController
     config.add_facet_field 'lc_1letter_ssim', label: 'Call Number'
     config.add_facet_field 'subject_geo_ssim', label: 'Region'
     config.add_facet_field 'subject_era_ssim', label: 'Era'
-    config.add_facet_field 'author_tsim', label: 'Author', limit: true, sort: 'index'
+    config.add_facet_field 'author_ssim', label: 'Author', limit: true, sort: 'index'
 
     config.add_facet_field 'example_query_facet_field', label: 'Publish Date', query: {
       years_5: { label: 'within 5 Years', fq: "pub_date_ssim:[#{Time.zone.now.year - 5} TO *]" },
@@ -100,7 +100,7 @@ class CatalogController < ApplicationController
 
     # solr fields to be displayed in the index (search results) view
     #   The ordering of the field names is the order of the display
-    config.add_index_field 'author_tsim', label: 'Author'
+    config.add_index_field 'author_ssim', label: 'Author'
     config.add_index_field 'author_vern_ssim', label: 'Author'
     config.add_index_field 'extentOfDigitization_ssim', label: 'Extent of Digitization'
     config.add_index_field 'format', label: 'Format'
@@ -113,7 +113,7 @@ class CatalogController < ApplicationController
     #   The ordering of the field names is the order of the display
     config.add_show_field 'subtitle_tsim', label: 'Subtitle'
     config.add_show_field 'subtitle_vern_ssim', label: 'Subtitle'
-    config.add_show_field 'author_tsim', label: 'Author'
+    config.add_show_field 'author_ssim', label: 'Author'
     config.add_show_field 'author_vern_ssim', label: 'Author'
     config.add_show_field 'extent_ssim', label: 'Extent'
     config.add_show_field 'format', label: 'Format'

--- a/app/models/marc_indexer.rb
+++ b/app/models/marc_indexer.rb
@@ -73,7 +73,7 @@ class MarcIndexer < Blacklight::Marc::Indexer
 
     # Author fields
 
-    to_field 'author_tsim', extract_marc("100abcegqu:110abcdegnu:111acdegjnqu")
+    to_field 'author_ssim', extract_marc("100abcegqu:110abcdegnu:111acdegjnqu")
     to_field 'author_addl_tsim', extract_marc("700abcegqu:710abcdegnu:711acdegjnqu")
     to_field 'author_ssm', extract_marc("100abcdq:110#{ATOZ}:111#{ATOZ}", alternate_script: false)
     to_field 'author_vern_ssm', extract_marc("100abcdq:110#{ATOZ}:111#{ATOZ}", alternate_script: :only)

--- a/app/services/voyager_indexing_service.rb
+++ b/app/services/voyager_indexing_service.rb
@@ -61,7 +61,7 @@ class VoyagerIndexingService
         title_tsim: data_hash["title"],
         language_ssim: data_hash["language"],
         description_tesim: data_hash["description"],
-        author_tsim: data_hash["creator"],
+        author_ssim: data_hash["creator"],
         bib_id_ssm: orbis_bib_id,
         public_bsi: data_hash["public"].presence || 0,
         format: format_hash[oid],

--- a/spec/support/solr_documents/metadata_cloud_with_visibility.rb
+++ b/spec/support/solr_documents/metadata_cloud_with_visibility.rb
@@ -2,7 +2,7 @@
 WORK_WITH_PUBLIC_VISIBILITY = {
   "id": "2055095",
   "title_tsim": ["A General dictionary of the English language"],
-  "author_tsim": ["Johnson, Samuel, 1709-1784"],
+  "author_ssim": ["Johnson, Samuel, 1709-1784"],
   "extent_ssim": ["1 volume",
                   "43 cm."],
   "format": ["text"],

--- a/spec/system/view_facet_spec.rb
+++ b/spec/system/view_facet_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe 'Facets should display', type: :system, js: :true, clean: true do
       title_tsim: ['Amor Llama'],
       format: 'text',
       language_ssim: 'la',
-      visibility_ssi: 'Public'
+      visibility_ssi: 'Public',
+      author_tsim: ['Anna Elizabeth Dewdney']
     }
   end
 
@@ -28,7 +29,8 @@ RSpec.describe 'Facets should display', type: :system, js: :true, clean: true do
       title_tsim: ['HandsomeDan Bulldog'],
       format: 'three dimensional object',
       language_ssim: 'en',
-      visibility_ssi: 'Public'
+      visibility_ssi: 'Public',
+      author_tsim: ['Andy Graves']
     }
   end
 
@@ -38,7 +40,8 @@ RSpec.describe 'Facets should display', type: :system, js: :true, clean: true do
       title_tsim: ['Aquila Eccellenza'],
       format: 'still image',
       language_ssim: 'it',
-      visibility_ssi: 'Public'
+      visibility_ssi: 'Public',
+      author_tsim: ['Andrew Norriss']
     }
   end
 
@@ -48,7 +51,8 @@ RSpec.describe 'Facets should display', type: :system, js: :true, clean: true do
       title_tsim: ['Rhett Lecheire'],
       format: 'text',
       language_ssim: 'fr',
-      visibility_ssi: 'Public'
+      visibility_ssi: 'Public',
+      author_tsim: ['Paulo Coelho']
     }
   end
 
@@ -66,5 +70,13 @@ RSpec.describe 'Facets should display', type: :system, js: :true, clean: true do
     expect(page).to have_content('Amor Llama')
     expect(page).not_to have_content('Aquila Eccellenza')
     expect(page).not_to have_content('HandsomeDan Bulldog')
+  end
+
+  it 'can filter results with author facets' do
+    click_on 'Author'
+    click_on 'Andy Graves'
+    expect(page).to have_content('HandsomeDan Bulldog')
+    expect(page).not_to have_content('Aquila Eccellenza')
+    expect(page).not_to have_content('Amor Llama')
   end
 end

--- a/spec/system/view_facet_spec.rb
+++ b/spec/system/view_facet_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Facets should display', type: :system, js: :true, clean: true do
       format: 'text',
       language_ssim: 'la',
       visibility_ssi: 'Public',
-      author_tsim: ['Anna Elizabeth Dewdney']
+      author_ssim: ['Anna Elizabeth Dewdney']
     }
   end
 
@@ -30,7 +30,7 @@ RSpec.describe 'Facets should display', type: :system, js: :true, clean: true do
       format: 'three dimensional object',
       language_ssim: 'en',
       visibility_ssi: 'Public',
-      author_tsim: ['Andy Graves']
+      author_ssim: ['Andy Graves']
     }
   end
 
@@ -41,7 +41,7 @@ RSpec.describe 'Facets should display', type: :system, js: :true, clean: true do
       format: 'still image',
       language_ssim: 'it',
       visibility_ssi: 'Public',
-      author_tsim: ['Andrew Norriss']
+      author_ssim: ['Andrew Norriss']
     }
   end
 
@@ -52,7 +52,7 @@ RSpec.describe 'Facets should display', type: :system, js: :true, clean: true do
       format: 'text',
       language_ssim: 'fr',
       visibility_ssi: 'Public',
-      author_tsim: ['Paulo Coelho']
+      author_ssim: ['Paulo Coelho']
     }
   end
 

--- a/spec/system/view_fields_in_display_spec.rb
+++ b/spec/system/view_fields_in_display_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       id: '111',
       subtitle_tsim: "He's handsome",
       subtitle_vern_ssim: "He's handsome",
-      author_tsim: 'Eric & Frederick',
+      author_ssim: 'Eric & Frederick',
       author_vern_ssim: 'Eric & Frederick',
       format: 'three dimensional object',
       url_fulltext_ssim: 'http://0.0.0.0:3000/catalog/111',

--- a/spec/system/view_fields_in_search_spec.rb
+++ b/spec/system/view_fields_in_search_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Search results displays field', type: :system, clean: true do
   let(:dog) do
     {
       id: '111',
-      author_tsim: 'Me and You',
+      author_ssim: 'Me and You',
       author_vern_ssim: 'Me and You',
       format: 'three dimensional object',
       published_ssim: "1997",


### PR DESCRIPTION
# Related Ticket
Related to Ticket #190, Add Author facet
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/190

# WIP
Testing needs to be done w/ the new management app code to fully ensure functionality.

# In This PR
* [ ] User can facet search on Author field

# Screenshot
<img width="1423" alt="Screen Shot 2020-06-03 at 4 06 08 PM" src="https://user-images.githubusercontent.com/36549923/83698388-2a44bc00-a5b6-11ea-8fd6-ae0d2045b2bf.png">

<img width="1428" alt="Screen Shot 2020-06-03 at 4 07 57 PM" src="https://user-images.githubusercontent.com/36549923/83698395-2fa20680-a5b6-11ea-90d3-3eccee02a08d.png">


