### PR TITLE
194 Added link on format to its facet

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -115,7 +115,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'author_tsim', label: 'Author'
     config.add_show_field 'author_vern_ssim', label: 'Author'
     config.add_show_field 'extent_ssim', label: 'Extent'
-    config.add_show_field 'format', label: 'Format'
+    config.add_show_field 'format', label: 'Format', link_to_facet: true
     config.add_show_field 'url_fulltext_ssim', label: 'URL'
     config.add_show_field 'url_suppl_ssim', label: 'More Information'
     config.add_show_field 'language_ssim', label: 'Language', helper_method: :language_codes

--- a/spec/system/view_fields_in_display_spec.rb
+++ b/spec/system/view_fields_in_display_spec.rb
@@ -228,5 +228,8 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
     it 'displays the URI in results' do
       expect(document).to have_content("this is the URI")
     end
+    it 'contains a link on format to its facet' do
+      expect(page).to have_link('three dimensional object', href: '/?f%5Bformat%5D%5B%5D=three+dimensional+object')
+    end
   end
 end


### PR DESCRIPTION
## Related Issue 
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/194

## ACCEPTANCE
On the show page the value in the format field is a link to the facet of works with the same format

![image](https://user-images.githubusercontent.com/3064318/83663135-0e2d2480-a58e-11ea-959c-f74df6e10b8e.png)

should link to something like 
![image](https://user-images.githubusercontent.com/3064318/83663237-36b51e80-a58e-11ea-94c8-f2bc0ba4b5be.png)

