### PR TITLE
adds publication place facet and spec

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -83,6 +83,7 @@ class CatalogController < ApplicationController
     config.add_facet_field 'language_ssim', label: 'Language', limit: true, helper_method: :language_code
     config.add_facet_field 'extentOfDigitization_ssim', label: 'Extent of Digitization'
     config.add_facet_field 'lc_1letter_ssim', label: 'Call Number'
+    config.add_facet_field 'publicationPlace_ssim', label: 'Publication Place', limit: true, sort: 'index'
     config.add_facet_field 'subject_geo_ssim', label: 'Region'
     config.add_facet_field 'subject_era_ssim', label: 'Era'
 

--- a/spec/system/view_facet_spec.rb
+++ b/spec/system/view_facet_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe 'Facets should display', type: :system, js: :true, clean: true do
       title_tsim: ['Amor Llama'],
       format: 'text',
       language_ssim: 'la',
-      visibility_ssi: 'Public'
+      visibility_ssi: 'Public',
+      publicationPlace_ssim: 'Spain'
     }
   end
 
@@ -28,7 +29,8 @@ RSpec.describe 'Facets should display', type: :system, js: :true, clean: true do
       title_tsim: ['HandsomeDan Bulldog'],
       format: 'three dimensional object',
       language_ssim: 'en',
-      visibility_ssi: 'Public'
+      visibility_ssi: 'Public',
+      publicationPlace_ssim: 'New Haven'
     }
   end
 
@@ -38,7 +40,8 @@ RSpec.describe 'Facets should display', type: :system, js: :true, clean: true do
       title_tsim: ['Aquila Eccellenza'],
       format: 'still image',
       language_ssim: 'it',
-      visibility_ssi: 'Public'
+      visibility_ssi: 'Public',
+      publicationPlace_ssim: 'White-Hall, printed upon the ice, on the River Thames'
     }
   end
 
@@ -48,7 +51,8 @@ RSpec.describe 'Facets should display', type: :system, js: :true, clean: true do
       title_tsim: ['Rhett Lecheire'],
       format: 'text',
       language_ssim: 'fr',
-      visibility_ssi: 'Public'
+      visibility_ssi: 'Public',
+      publicationPlace_ssim: 'Constantinople or southern Italy'
     }
   end
 
@@ -66,5 +70,13 @@ RSpec.describe 'Facets should display', type: :system, js: :true, clean: true do
     expect(page).to have_content('Amor Llama')
     expect(page).not_to have_content('Aquila Eccellenza')
     expect(page).not_to have_content('HandsomeDan Bulldog')
+  end
+
+  it 'can filter results with publication place facets' do
+    click_on 'Publication Place'
+    click_on 'New Haven'
+    expect(page).to have_content('HandsomeDan Bulldog')
+    expect(page).not_to have_content('Amor Llama')
+    expect(page).not_to have_content('Aquila Eccellenza')
   end
 end


### PR DESCRIPTION
# Related Ticket
Related to ticket # 193, Add Publication Place facet.
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/193

# In This PR
* [x] Adds publication place facet and accompanying spec

# Expected Behavior
* [x] I can narrow my search results based on Publication Place

# Screenshots
<img width="1421" alt="Screen Shot 2020-06-04 at 9 28 12 AM" src="https://user-images.githubusercontent.com/36549923/83785651-7b9c8c00-a646-11ea-9559-f33928c53c41.png">

<img width="1426" alt="Screen Shot 2020-06-04 at 9 28 29 AM" src="https://user-images.githubusercontent.com/36549923/83785661-7fc8a980-a646-11ea-92dc-33295d284ae4.png">


