### PR TITLE
190 add author facet

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -88,6 +88,7 @@ class CatalogController < ApplicationController
     config.add_facet_field 'subject_era_ssim', label: 'Era'
     config.add_facet_field 'genre_ssim', label: 'Genre'
     config.add_facet_field 'resourceType_ssim', label: 'Resource Type'
+    config.add_facet_field 'author_tsim', label: 'Author', limit: true, sort: 'index'
 
     config.add_facet_field 'example_query_facet_field', label: 'Publish Date', query: {
       years_5: { label: 'within 5 Years', fq: "pub_date_ssim:[#{Time.zone.now.year - 5} TO *]" },

--- a/spec/system/view_facet_spec.rb
+++ b/spec/system/view_facet_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe 'Facets should display', type: :system, js: :true, clean: true do
       language_ssim: 'la',
       visibility_ssi: 'Public',
       publicationPlace_ssim: 'Spain',
-      resourceType_ssim: 'Maps, Atlases & Globes'
+      resourceType_ssim: 'Maps, Atlases & Globes',
+      author_tsim: ['Anna Elizabeth Dewdney']
     }
   end
 
@@ -32,7 +33,8 @@ RSpec.describe 'Facets should display', type: :system, js: :true, clean: true do
       language_ssim: 'en',
       visibility_ssi: 'Public',
       publicationPlace_ssim: 'New Haven',
-      resourceType_ssim: 'Books, Journals & Pamphlets'
+      resourceType_ssim: 'Books, Journals & Pamphlets',
+      author_tsim: ['Andy Graves']
     }
   end
 
@@ -44,7 +46,8 @@ RSpec.describe 'Facets should display', type: :system, js: :true, clean: true do
       language_ssim: 'it',
       visibility_ssi: 'Public',
       publicationPlace_ssim: 'White-Hall, printed upon the ice, on the River Thames',
-      resourceType_ssim: 'Archives or Manuscripts'
+      resourceType_ssim: 'Archives or Manuscripts',
+      author_tsim: ['Andrew Norriss']
     }
   end
 
@@ -56,7 +59,8 @@ RSpec.describe 'Facets should display', type: :system, js: :true, clean: true do
       language_ssim: 'fr',
       visibility_ssi: 'Public',
       publicationPlace_ssim: 'Constantinople or southern Italy',
-      resourceType_ssim: 'Archives or Manuscripts'
+      resourceType_ssim: 'Archives or Manuscripts',
+      author_tsim: ['Paulo Coelho']
     }
   end
 
@@ -90,5 +94,13 @@ RSpec.describe 'Facets should display', type: :system, js: :true, clean: true do
     expect(page).to have_content('Aquila Eccellenza')
     expect(page).not_to have_content('Amor Llama')
     expect(page).not_to have_content('HandsomeDan Bulldog')
+  end
+
+  it 'can filter results with author facets' do
+    click_on 'Author'
+    click_on 'andy'
+    expect(page).to have_content('HandsomeDan Bulldog')
+    expect(page).not_to have_content('Aquila Eccellenza')
+    expect(page).not_to have_content('Amor Llama')
   end
 end


### PR DESCRIPTION
# Related Ticket
Related to Ticket #190, Add Author facet
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/190

# In This PR
* [x] User can facet search on Author field

# Current Screenshots

<img width="1433" alt="Screen Shot 2020-06-05 at 10 21 44 AM" src="https://user-images.githubusercontent.com/36549923/83905590-ca195b80-a716-11ea-99c8-387423ed87c1.png">

<img width="1434" alt="Screen Shot 2020-06-05 at 10 22 15 AM" src="https://user-images.githubusercontent.com/36549923/83905595-cdace280-a716-11ea-9ed6-9cf9b356f303.png">


# WIP
Testing needs to be done w/ the new management app code to fully ensure functionality with the new author_ssim field.  An additional PR will be needed to update the facet field for author full name. After adding the author_ssim field the search will look like this.

<img width="1423" alt="Screen Shot 2020-06-03 at 4 06 08 PM" src="https://user-images.githubusercontent.com/36549923/83698388-2a44bc00-a5b6-11ea-8fd6-ae0d2045b2bf.png">

<img width="1428" alt="Screen Shot 2020-06-03 at 4 07 57 PM" src="https://user-images.githubusercontent.com/36549923/83698395-2fa20680-a5b6-11ea-90d3-3eccee02a08d.png">