### PR TITLE
Silence deprecations from Blacklight

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -375,7 +375,7 @@ GEM
       railties (>= 4.2)
     websocket-driver (0.7.2)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.4)
+    websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     yard (0.9.25)

--- a/config/initializers/deprecation.rb
+++ b/config/initializers/deprecation.rb
@@ -1,0 +1,1 @@
+Deprecation.default_deprecation_behavior = :silence

--- a/config/initializers/deprecation.rb
+++ b/config/initializers/deprecation.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 Deprecation.default_deprecation_behavior = :silence


### PR DESCRIPTION
Looked further at Shopify’s `deprecation_toolkit` gem with another senior dev. We could not get it to write out its recorded config files. Also it’s very tied to tests, as opposed to a more general case of “all output”.
The reason turns out to be that Blacklight uses it’s own gem for generating deprecations, not the ActiveSupport one. So the Shopify gem doesn’t work here.
BUT there is a configuration option for the Blacklight `deprecation` gem that silences all of them. So I’ve done that. Please note:

1. It’s all or nothing, at least with respect to deprecations generated from Blacklight.
2. It doesn’t affect non-Blacklight deprecations
3. It’s can’t silence anything that is thrown before the initializer is loaded to configure it.