### PR TITLE
Link the Orbis Bib ID to the Orbis catalog record

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This is one of the microservices applications that form the Yale digital library
 - If this is your first time working in this repo or the Dockerfile has been updated you will need to (re)build those services
 
   ```bash
-    docker-compose build
+    docker-compose build blacklight
   ```
 
 ### Starting the app

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -157,7 +157,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'identifierShelfMark_ssim', label: 'Identifier Shelf Mark'
     config.add_show_field 'box_ssim', label: 'Box'
     config.add_show_field 'folder_ssim', label: 'Folder'
-    config.add_show_field 'orbisBibId_ssim', label: 'Orbis Bib ID'
+    config.add_show_field 'orbisBibId_ssim', label: 'Orbis Bib ID', helper_method: :link_to_orbis_bib_id
     config.add_show_field 'orbisBarcode_ssim', label: 'Orbis Bar Code'
     config.add_show_field 'findingAid_ssim', label: 'Finding Aid'
     config.add_show_field 'collectionId_ssim', label: 'Collection ID'

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -36,6 +36,13 @@ module BlacklightHelper
     language_code_to_english(language_value)
   end
 
+  def link_to_orbis_bib_id(arg)
+    bib_id = arg[:document][arg[:field]]
+    link = "http://hdl.handle.net/10079/bibid/#{bib_id[0]}"
+
+    link_to(bib_id[0], link)
+  end
+
   private
 
     def language_code_to_english(language_code)

--- a/spec/system/view_fields_in_display_spec.rb
+++ b/spec/system/view_fields_in_display_spec.rb
@@ -243,5 +243,8 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       expect(page).to have_link('English (eng)', href: '/?f%5Blanguage_ssim%5D%5B%5D=English (eng)')
       expect(page).to have_link('zz', href: '/?f%5Blanguage_ssim%5D%5B%5D=zz')
     end
+    it 'contains a link on the Orbis Bib ID to the Orbis catalog record' do
+      expect(page).to have_link('this is the orbis bib ID', href: 'http://hdl.handle.net/10079/bibid/this is the orbis bib ID')
+    end
   end
 end


### PR DESCRIPTION
# Ticket
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/210

# Story
As a researcher, I'd like an easy way to get to the catalog record for the work I'm looking at. There's a link that takes me to Orbis from the Orbis Bib ID field. The link points to a handle that redirects to the correct catalog record in Orbis

# Demo
![i210](https://user-images.githubusercontent.com/29032869/84213003-5fe51b80-aa74-11ea-870a-be0544eba463.gif)