### PR TITLE
Change field used by author facet

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -88,7 +88,7 @@ class CatalogController < ApplicationController
     config.add_facet_field 'subject_era_ssim', label: 'Era'
     config.add_facet_field 'genre_ssim', label: 'Genre'
     config.add_facet_field 'resourceType_ssim', label: 'Resource Type'
-    config.add_facet_field 'author_tsim', label: 'Author', limit: true, sort: 'index'
+    config.add_facet_field 'author_ssim', label: 'Author', limit: true, sort: 'index'
 
     config.add_facet_field 'example_query_facet_field', label: 'Publish Date', query: {
       years_5: { label: 'within 5 Years', fq: "pub_date_ssim:[#{Time.zone.now.year - 5} TO *]" },

--- a/spec/system/view_facet_spec.rb
+++ b/spec/system/view_facet_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Facets should display', type: :system, js: :true, clean: true do
       visibility_ssi: 'Public',
       publicationPlace_ssim: 'Spain',
       resourceType_ssim: 'Maps, Atlases & Globes',
-      author_tsim: ['Anna Elizabeth Dewdney']
+      author_ssim: ['Anna Elizabeth Dewdney']
     }
   end
 
@@ -34,7 +34,7 @@ RSpec.describe 'Facets should display', type: :system, js: :true, clean: true do
       visibility_ssi: 'Public',
       publicationPlace_ssim: 'New Haven',
       resourceType_ssim: 'Books, Journals & Pamphlets',
-      author_tsim: ['Andy Graves']
+      author_ssim: ['Andy Graves']
     }
   end
 
@@ -47,7 +47,7 @@ RSpec.describe 'Facets should display', type: :system, js: :true, clean: true do
       visibility_ssi: 'Public',
       publicationPlace_ssim: 'White-Hall, printed upon the ice, on the River Thames',
       resourceType_ssim: 'Archives or Manuscripts',
-      author_tsim: ['Andrew Norriss']
+      author_ssim: ['Andrew Norriss']
     }
   end
 
@@ -60,7 +60,7 @@ RSpec.describe 'Facets should display', type: :system, js: :true, clean: true do
       visibility_ssi: 'Public',
       publicationPlace_ssim: 'Constantinople or southern Italy',
       resourceType_ssim: 'Archives or Manuscripts',
-      author_tsim: ['Paulo Coelho']
+      author_ssim: ['Paulo Coelho']
     }
   end
 
@@ -98,7 +98,7 @@ RSpec.describe 'Facets should display', type: :system, js: :true, clean: true do
 
   it 'can filter results with author facets' do
     click_on 'Author'
-    click_on 'andy'
+    click_on 'Andy Graves'
     expect(page).to have_content('HandsomeDan Bulldog')
     expect(page).not_to have_content('Aquila Eccellenza')
     expect(page).not_to have_content('Amor Llama')


### PR DESCRIPTION
Author facet was in place but a better UX is achieved by changing the field that the author facet uses from _tsim to _ssim because of the way the fields are rendered in the facet. By using _ssim it renders the full string, the _tsim would break the strings into separate words, and using the full string is more user friendly.