### PR TITLE
Remove duplicate author facet

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -89,7 +89,6 @@ class CatalogController < ApplicationController
     config.add_facet_field 'subject_era_ssim', label: 'Era'
     config.add_facet_field 'genre_ssim', label: 'Genre'
     config.add_facet_field 'resourceType_ssim', label: 'Resource Type'
-    config.add_facet_field 'author_tsim', label: 'Author', limit: true, sort: 'index'
     config.add_facet_field 'dateStructured_ssim', label: 'Publication Year',
                                                   range: {
                                                     num_segments: 6,


### PR DESCRIPTION
During merge the author_tsim was retained.  This was not the desired effect and has been removed and fully replaced by the author_ssim field for the author facet.  The author_tsim field is retained only for the show field and will remain indexable so each word in the author field is able to be searched for.  