### PR TITLE
Add suggestive MLA and APA citations for records

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,8 @@ gem 'blacklight-marc', '>= 7.0.0.rc1', '< 8'
 gem 'blacklight_range_limit'
 gem 'bootsnap', '>= 1.4.2', require: false
 gem 'bootstrap', '~> 4.0'
+gem 'citeproc-ruby'
+gem 'csl-styles'
 gem 'devise'
 gem 'devise-guests', '~> 0.6'
 gem 'dotenv-rails', groups: [:development, :test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,8 +102,17 @@ GEM
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
     childprocess (3.0.0)
+    citeproc (1.0.10)
+      namae (~> 1.0)
+    citeproc-ruby (1.1.12)
+      citeproc (~> 1.0, >= 1.0.9)
+      csl (~> 1.5)
     concurrent-ruby (1.1.6)
     crass (1.0.6)
+    csl (1.5.1)
+      namae (~> 1.0)
+    csl-styles (1.0.1.10)
+      csl (~> 1.0)
     deprecation (1.0.0)
       activesupport
     devise (4.7.1)
@@ -207,6 +216,7 @@ GEM
     msgpack (1.3.3)
     multi_json (1.14.1)
     multipart-post (2.1.1)
+    namae (1.0.1)
     nio4r (2.5.2)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
@@ -399,6 +409,8 @@ DEPENDENCIES
   bootstrap (~> 4.0)
   byebug
   capybara (>= 2.15)
+  citeproc-ruby
+  csl-styles
   devise
   devise-guests (~> 0.6)
   dotenv-rails

--- a/app/helpers/citation_helper.rb
+++ b/app/helpers/citation_helper.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+require './lib/yale/citation_formatter.rb'
+
+module CitationHelper
+  def mla_citation_txt(document)
+    generator = Yale::CitationFormatter.new(document)
+    generator.citation_for('modern-language-association')
+  end
+
+  def apa_citation_txt(document)
+    generator = Yale::CitationFormatter.new(document)
+    generator.citation_for('apa')
+  end
+end

--- a/app/views/catalog/_citation.html.erb
+++ b/app/views/catalog/_citation.html.erb
@@ -1,0 +1,19 @@
+<div class="modal-header">
+  <h1><%= t('blacklight.tools.citation') %></h1>
+  <button type="button" class="blacklight-modal-close close" data-dismiss="modal" aria-label="<%= t('blacklight.modal.close') %>">
+    <span aria-hidden="true">&times;</span>
+</button>
+</div>
+<div class="modal-body">
+  <% @documents&.each do |document| %>
+    <h1 class="modal-title"><%= document_heading(document) %></h1>
+    <div id="mla-citation">
+      <h2><%= t('blacklight.citation.mla') %></h2>
+      <%= mla_citation_txt(document).html_safe %><br/><br/>
+    </div>
+    <div id="apa-citation">
+      <h2><%= t('blacklight.citation.apa') %></h2>
+      <%= apa_citation_txt(document).html_safe %><br/><br/>
+    </div>
+  <% end %>
+</div>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -4,3 +4,6 @@ en:
     sidebar:
       links: Links 
       manifest: Manifest Link
+    citation:
+      apa: 'APA, 6th edition'
+      modern-language-association: 'MLA'

--- a/lib/yale/citation_formatter.rb
+++ b/lib/yale/citation_formatter.rb
@@ -1,0 +1,79 @@
+require 'citeproc'
+require 'csl/styles'
+require './lib/yale/citation_string_processor.rb'
+
+module Yale
+  class CitationFormatter
+    include CitationStringProcessor
+    attr_accessor :obj, :default_citations
+
+    def initialize(obj)
+      @obj = obj
+      @default_citations = {
+          "apa": apa_default_citation,
+          "modern-language-association": mla_default_citation
+      }
+    end
+
+    def citation_for(style)
+      sanitized_citation(CiteProc::Processor.new(style: style, format: 'html').import(item).render(:bibliography, id: :item).first)
+    rescue CiteProc::Error, TypeError, ArgumentError
+      @default_citations[style.to_sym]
+    end
+
+    private
+
+    def item
+      CiteProc::Item.new(key_value_chunk_1.merge(key_value_chunk_2).merge(key_value_chunk_3))
+    end
+
+    def mla_url_test
+      [
+          obj[:partOf_ssim],
+          obj[:edition_tesim],
+          obj[:publisher_ssim],
+          obj[:date_tsim]
+      ].any?(&:present?)
+    end
+
+    def abnormal_chars?
+      obj[:author_ssim]&.any? { |a| a.match(/[^\p{L}\s]+/) }
+    end
+
+    def key_value_chunk_1
+      {
+          id: :item,
+          abstract: obj[:abstract_ssim]&.join(', '),
+          archive_location: obj[:sublocation_tesim]&.join(', '),
+          author: obj[:author_ssim]&.join(', '),
+          "call-number": obj[:identifierShelfMark_ssim]&.join(', '),
+          edition: obj[:edition_tesim]&.join(', '),
+          institution: obj[:institution_tesim]&.join(', ')
+      }
+    end
+
+    def key_value_chunk_2
+      {
+          archive: obj[:holding_repository_tesim]&.join(', '),
+          publisher: obj[:publisher_ssim]&.join(', '),
+          title: obj[:title_tsim]&.join(', '),
+          "collection-title": obj[:member_of_collections_ssim]&.join(', '),
+          type: [obj[:format]&.first&.downcase]&.join(', '),
+          url: url,
+          issued: (obj[:date_tsim] || obj[:year_issued_isim] || obj[:year_created_isim] || [0])&.first&.to_i
+      }
+    end
+
+    def key_value_chunk_3
+      {
+          dimensions: obj[:extent_ssim]&.join(', '),
+          event: obj[:conference_name_tesim]&.join(', '),
+          genre: obj[:genre_ssim]&.join(', '),
+          ISBN: obj[:isbn_tesim]&.join(', '),
+          ISSN: obj[:issn_tesim]&.join(', '),
+          keyword: obj[:keywords_tesim]&.join(', '),
+          "publisher-place": obj[:publicationPlace_ssim]&.join(', ')
+      }
+    end
+  end
+end

--- a/lib/yale/citation_string_processor.rb
+++ b/lib/yale/citation_string_processor.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+module CitationStringProcessor
+  def url
+    "http://collections-demo.curationexperts.com/catalog/#{obj[:id]}" if obj[:id].present?
+  end
+
+  def append_string_with_comma(field)
+    "#{field&.first}, " if field.present?
+  end
+
+  def append_string_with_period(field)
+    "#{field&.first}. " if field.present?
+  end
+
+  def apa_edition
+    ", #{obj[:edition_tesim].first}" if obj[:edition_tesim].present?
+  end
+
+  def apa_box
+    " (#{obj[:box_ssim]})" if obj[:box_ssim].present?
+  end
+
+  def sanitized_citation(citation)
+    if !citation.include?(url) && citation.last != "."
+      citation << ". #{url}."
+    elsif !citation.include?(url) && citation.last == "."
+      citation << " #{url}."
+    else
+      citation
+    end
+  end
+
+  def author_name_no_period
+    return obj[:author_ssim].map { |a| a.first(a.size - 1) } if obj[:author_ssim]&.any? { |a| a&.split('')&.last == '.' }
+    obj[:author_ssim]
+  end
+
+  def formatted_apa_author
+    return joined_apa_author_names unless abnormal_chars? || obj[:author_ssim].blank?
+    "#{author_name_no_period&.join(', & ')}. " unless obj[:author_ssim].blank?
+  end
+
+  def formatted_mla_author
+    return joined_mla_author_names unless abnormal_chars? || obj[:author_ssim].blank?
+    "#{author_name_no_period&.join(', ')}. " unless obj[:author_ssim].blank?
+  end
+
+  def apa_default_citation
+    [
+      formatted_apa_author,
+      apa_box,
+      ("(#{obj[:date_tsim]&.first})" unless obj[:date_tsim].nil?),
+      ("[#{obj[:title_tsim]&.first}#{apa_edition}]. " unless obj[:title_tsim].nil?),
+      append_string_with_period(obj[:partOf_ssim]),
+      url,
+      "."
+    ].join('')
+  end
+
+  def mla_default_citation
+    [
+      formatted_mla_author,
+      append_string_with_period(obj[:title_tsim]),
+      append_string_with_period(obj[:box_ssim]),
+      append_string_with_period(obj[:date_tsim]),
+      append_string_with_period(obj[:partOf_ssim]),
+      url,
+      "."
+    ].join('')
+  end
+
+  def joined_apa_author_names
+    "#{obj[:author_ssim].map { |f| f.split(' ').last + ', ' + f.split(' ').first(f.split.size - 1)&.map(&:first)&.join('. ') }&.join(', & ')}. "
+  end
+
+  def joined_mla_author_names
+    "#{obj[:author_ssim].map { |f| f.split(' ').last + ', ' + f.split(' ').first(f.split.size - 1).join(' ') }&.join(', ')}. "
+  end
+end

--- a/spec/helpers/citation_helper_spec.rb
+++ b/spec/helpers/citation_helper_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.feature "Citation Helper", clean: true, system: true do
+  before do
+    solr = Blacklight.default_index.connection
+    solr.add([test_record])
+    solr.commit
+    visit '/catalog/111'
+  end
+
+  let(:test_record) do
+    {
+      id: '111',
+      subtitle_tsim: "He's handsome",
+      subtitle_vern_ssim: "He's handsome",
+      author_tsim: 'Eric & Frederick',
+      author_ssim: 'Eric & Frederick',
+      format: 'three dimensional object',
+      url_fulltext_ssim: 'http://0.0.0.0:3000/catalog/111',
+      url_suppl_ssim: 'http://0.0.0.0:3000/catalog/111',
+      published_ssim: "1997",
+      published_vern_ssim: "1997",
+      lc_callnum_ssim: "123213213",
+      language_ssim: ['en', 'eng', 'zz'],
+      isbn_ssim: '2321321389',
+      description_tesim: "Handsome Dan is a bulldog who serves as Yale Univeristy's mascot.",
+      visibility_ssi: 'Public',
+      abstract_ssim: "this is an abstract",
+      alternativeTitle_ssim: "this is an alternative title",
+      genre_ssim: "this is the genre",
+      geoSubject_ssim: "this is the geo subject",
+      resourceType_ssim: "this is the resource type",
+      subjectName_ssim: "this is the subject name",
+      subjectTopic_ssim: "this is the subject topic",
+      extentOfDigitization_ssim: 'this is the extent of digitization',
+      rights_ssim: "these are the rights",
+      publicationPlace_ssim: "this is the publication place",
+      sourceCreated_ssim: "this is the source created",
+      publisher_ssim: "this is the publisher",
+      copyrightDate_ssim: "this is the copyright date",
+      source_ssim: "this is the source",
+      recordType_ssim: "this is the record type",
+      sourceTitle_ssim: "this is the source title",
+      sourceDate_ssim: "this is the source date",
+      sourceNote_ssim: "this is the source note",
+      references_ssim: "these are the references",
+      date_tsim: "this is the date",
+      children_ssim: "these are the children",
+      importUrl_ssim: "this is the import URL",
+      illustrativeMatter_ssim: "this is the illustrative matter",
+      oid_ssim: 'this is the OID',
+      identifierMfhd_ssim: 'this is the identifier MFHD',
+      identifierShelfMark_ssim: 'this is the identifier shelf mark',
+      box_ssim: 'this is the box',
+      folder_ssim: 'this is the folder',
+      orbisBibId_ssim: 'this is the orbis bib ID',
+      orbisBarcode_ssim: 'this is the orbis bar code',
+      findingAid_ssim: 'this is the finding aid',
+      collectionId_ssim: 'this is the collection ID',
+      edition_ssim: 'this is the edition',
+      uri_ssim: 'this is the URI',
+      partOf_ssim: "this is the part of, using ssim",
+      numberOfPages_ssim: "this is the number of pages, using ssim",
+      material_ssim: "this is the material, using ssim",
+      scale_ssim: "this is the scale, using ssim",
+      digital_ssim: "this is the digital, using ssim",
+      coordinates_ssim: "this is the coordinates, using ssim",
+      projection_ssim: "this is the projection, using ssim",
+      extent_ssim: "this is the extent, using ssim"
+    }
+  end
+
+  context 'Clicking on cite' do
+    it 'displays correct MLA citation' do
+      click_on "Cite"
+      expect(page).to have_css('#mla-citation')
+      within('#mla-citation') do
+        expect(page).to have_content("Eric, and Frederick. this is the publisher, 0AD. http://collections-demo.curationexperts.com/catalog/111.")
+      end
+    end
+    it 'displays correct APA citation' do
+      click_on "Cite"
+      expect(page).to have_css('#mla-citation')
+      within('#apa-citation') do
+        expect(page).to have_content("E., & F. (0 C.E.). [This is the genre]. this is the publisher. http://collections-demo.curationexperts.com/catalog/111.")
+      end
+    end
+  end
+end


### PR DESCRIPTION
**STORY**
As an undergraduate writing a paper, I would like the system to provide properly formatted citations, so that I'm less likely to make errors transcribing or formatting my citations.

**ACCEPTANCE**
Go to any record's display/item page.
Click on the "Cite" link in the Tools box on a single item show view and verify:
- [ ]You get a pop-up window with the citations for the work
  - [ ] Citation in MLA (Modern Language Association) format
  - [ ] Citation in APA (American Phycological Association) format