### PR TITLE
Add thumbnails for public works in search

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -32,7 +32,7 @@ class CatalogController < ApplicationController
     # solr field configuration for search results/index views
     config.index.title_field = 'title_tsim'
     # config.index.display_type_field = 'format'
-    # config.index.thumbnail_field = 'thumbnail_path_ss'
+    config.index.thumbnail_method = :render_thumbnail
 
     config.add_results_document_tool(:bookmark, partial: 'bookmark_control', if: :render_bookmarks_control?)
 

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -53,4 +53,18 @@ RSpec.describe BlacklightHelper do
       end
     end
   end
+
+  describe '#render_thumbnail' do
+    context 'with public record and oid with images' do
+      let(:valid_document) { SolrDocument.new(id: 'test', visibility_ssi: 'Public', oid_ssim: ['2055095']) }
+      let(:non_valid_document) { SolrDocument.new(id: 'test', visibility_ssi: 'Public', oid_ssim: ['2055095']) }
+
+      it 'returns an image_tag for oids that have images' do
+        expect(helper.render_thumbnail(valid_document, { alt: "" })).to eq "<img src=\"https://collections-test.curationexperts.com/iiif/2/1234822/full/,200/0/default.jpg\" />"
+      end
+      xit 'returns an image_tag pointing to image_not_found.png for oids without images' do
+        expect(helper.render_thumbnail(non_valid_document, {})).to eq 'image tag pointing to image_not_found.png'
+      end
+    end
+  end
 end

--- a/spec/system/view_images_in_search_spec.rb
+++ b/spec/system/view_images_in_search_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe 'Search results displays images', type: :system, clean: true, js: true do
+  before do
+    solr = Blacklight.default_index.connection
+    solr.add([document_with_image,
+              document_without_image])
+    solr.commit
+  end
+  let(:document_with_image) do
+    {
+      id: 'test_record_1',
+      oid_ssim: ['2055095'],
+      visibility_ssi: 'Public'
+    }
+  end
+  let(:document_without_image) do
+    {
+      id: 'test_record_2',
+      oid_ssim: [''],
+      visibility_ssi: 'Public'
+    }
+  end
+
+  context 'public records with images' do
+    it 'displays thumbnail for oids with images' do
+      visit '?q=&search_field=all_fields'
+      expect(page).to have_xpath("//img[@src = 'https://collections-test.curationexperts.com/iiif/2/1234822/full/,200/0/default.jpg']")
+    end
+
+    xit 'displays the image_not_found.png for records without images' do
+      visit '?q=&search_field=all_fields'
+      expect(page).to have_xpath("//img[@src = 'path-to-image-not-found.png']")
+    end
+  end
+end


### PR DESCRIPTION
**ACCETPANCE**
When showing search results, 
- [ ] Public access works should display a thumbnail of the first image in the manifest
- [ ] The thumbnail should fit within a 200 px x 200 px bounding box
- [ ] The thumbnail should retain the aspect ratio of the original image

**Testing**
1. Do an empty search
2. Verify that thumbnails for public works are displayed if they have images, as shown below:
![Screen Shot 2020-06-16 at 11 56 41 AM](https://user-images.githubusercontent.com/40175979/84798033-79341d80-afc8-11ea-8bc7-2410df68e370.png)
