### PR TITLE
Pull master image down during CI run to speed up builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,10 +19,11 @@ jobs:
     executor: docker/docker
     steps:
       - setup_remote_docker
+          docker_layer_caching: true 
       - checkout
       - docker/check
       - docker/pull:
-          images: yalelibraryit/dc-blacklight:master
+          images: yalelibraryit/dc-blacklight:eb43a170ae513c81e5aaa9533bd5ea4482e0b1a8
       - docker/build:
           image: yalelibraryit/dc-blacklight
       - docker/push:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
       - checkout
       - docker/check
       - docker/pull:
-          images: yalelibraryit/dc-blacklight:eb43a170ae513c81e5aaa9533bd5ea4482e0b1a8
+          images: yalelibraryit/dc-blacklight:447ef4db1878656af89de323ad1c1f117c7301a4
       - docker/build:
           image: yalelibraryit/dc-blacklight
       - docker/push:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,10 +21,9 @@ jobs:
       - setup_remote_docker
       - checkout
       - docker/check
-      - docker/pull:
-          images: yalelibraryit/dc-blacklight:447ef4db1878656af89de323ad1c1f117c7301a4
       - docker/build:
           image: yalelibraryit/dc-blacklight
+          cache_from: yalelibraryit/dc-blacklight:447ef4db1878656af89de323ad1c1f117c7301a4
       - docker/push:
           image: yalelibraryit/dc-blacklight
   run-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
       - docker/check
       - docker/pull:
           images: yalelibraryit/dc-blacklight:master
-       - docker/build:
+      - docker/build:
           image: yalelibraryit/dc-blacklight
       - docker/push:
           image: yalelibraryit/dc-blacklight

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,6 @@ jobs:
     executor: docker/docker
     steps:
       - setup_remote_docker
-          docker_layer_caching: true 
       - checkout
       - docker/check
       - docker/pull:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,9 @@ jobs:
       - setup_remote_docker
       - checkout
       - docker/check
-      - docker/build:
+      - docker/pull:
+          images: yalelibraryit/dc-blacklight:master
+       - docker/build:
           image: yalelibraryit/dc-blacklight
       - docker/push:
           image: yalelibraryit/dc-blacklight
@@ -46,7 +48,6 @@ jobs:
     executor: docker/docker
     steps:
       - setup_remote_docker
-      - checkout
       - run:
           name: Rubocop
           command: bundle exec rubocop --parallel


### PR DESCRIPTION
Also removed re-checking out the code before running specs. We already have it checked out.