### PR TITLE
Search filters display user friendly names

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -98,6 +98,10 @@ class CatalogController < ApplicationController
                                                   }
     config.add_facet_field 'author_ssim', label: 'Author', limit: true, sort: 'index'
 
+    # the facets below are set to false because we aren't filtering on them from the main search page
+    # but we need to be able to provide a label when they are filtered upon from an individual show page
+    config.add_facet_field 'identifierShelfMark_ssim', label: 'Identifier Shelf Mark', show: false
+
     # This was example code after running rails generate blacklight_range_limit:install
     # config.add_facet_field 'example_query_facet_field', label: 'Publish Date', query: {
     #    years_5: { label: 'within 5 Years', fq: "pub_date_ssim:[#{Time.zone.now.year - 5} TO *]" },

--- a/spec/system/view_facet_spec.rb
+++ b/spec/system/view_facet_spec.rb
@@ -103,4 +103,8 @@ RSpec.describe 'Facets should display', type: :system, js: :true, clean: true do
     expect(page).not_to have_content('Aquila Eccellenza')
     expect(page).not_to have_content('Amor Llama')
   end
+
+  it 'does not show the Identifier Shelf Mark facet' do
+    expect(page).not_to have_content('Identifier Shelf Mark')
+  end
 end


### PR DESCRIPTION
# Ticket
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/238

# Story
Sometimes when you click the link on an individual show page it shows a human readable string and sometimes it shows the solr field label

# Research
Some of the values on an individual show page are created as links by using the `link_to_facet` field. When this link is clicked it does a search based off of that value. If the value is not listed as a facet, then you'll see the solr field label as the search result

# Expected Behavior
- All filtered fields, whether it's a facet from the main search page or a link from the individual show page, have the ability to be shown as a human readable string
- As we convert more values into searchable fields, a corresponding facet will need to be created with a `show: false` value

# Demo
![238](https://user-images.githubusercontent.com/29032869/85077511-55630a00-b177-11ea-9f84-217f37945cd8.gif)

# Resources
- https://github.com/projectblacklight/blacklight/wiki/Configuration---Facet-Fields