### PR TITLE
Specify solr test index url

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
             POSTGRES_DB: blacklight_yul_test
             POSTGRES_USER: postgres
             POSTGRES_PASSWORD: password
-            SOLR_CORE: blacklight-core
+            SOLR_CORE: blacklight-test
             SOLR_URL: http://localhost:8983/solr/blacklight-core
             SOLR_TEST_URL: http://localhost:8983/solr/blacklight-test
       - image: yalelibraryit/dc-solr:79a71ec

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,9 +35,8 @@ jobs:
             POSTGRES_DB: blacklight_yul_test
             POSTGRES_USER: postgres
             POSTGRES_PASSWORD: password
-            SOLR_CORE: blacklight-test
+            SOLR_CORE: blacklight-core
             SOLR_URL: http://localhost:8983/solr/blacklight-core
-            SOLR_TEST_URL: http://localhost:8983/solr/blacklight-test
       - image: yalelibraryit/dc-solr:79a71ec
         command: bash -c 'precreate-core blacklight-core /opt/config; exec solr -f'
       - image: circleci/postgres:9.5-alpine-ram

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,7 @@ jobs:
             POSTGRES_PASSWORD: password
             SOLR_CORE: blacklight-core
             SOLR_URL: http://localhost:8983/solr/blacklight-core
+            SOLR_TEST_URL: http://localhost:8983/solr/blacklight-test
       - image: yalelibraryit/dc-solr:79a71ec
         command: bash -c 'precreate-core blacklight-core /opt/config; exec solr -f'
       - image: circleci/postgres:9.5-alpine-ram

--- a/config/blacklight.yml
+++ b/config/blacklight.yml
@@ -3,7 +3,7 @@ development:
   url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/blacklight-development" %>
 test: &test
   adapter: solr
-  url: <%= ENV['SOLR_TEST_URL'] || "http://solr:8983/solr/blacklight-test" %>
+  url: <%= "http://solr:8983/solr/blacklight-test" %>
 production:
   adapter: solr
   url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/blacklight-core" %>

--- a/config/blacklight.yml
+++ b/config/blacklight.yml
@@ -3,7 +3,7 @@ development:
   url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/blacklight-development" %>
 test: &test
   adapter: solr
-  url: <%= ENV['SOLR_URL'] || "http://solr:8983/solr/blacklight-test" %>
+  url: <%= ENV['SOLR_TEST_URL'] || "http://solr:8983/solr/blacklight-test" %>
 production:
   adapter: solr
   url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/blacklight-core" %>


### PR DESCRIPTION
WIP- until circle ci is passing.

Prior to this edit running tests locally would hit the development index in Solr not the test index.  The change in this PR specifies which solr core to use when testing by adding an environment variable to the circleci configuration.