### PR TITLE
Remove database auth config for devise

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,1 +1,2 @@
 IIIF_MANIFESTS_BASE_URL=http://localhost/manifests/
+DATABASE_AUTH=true

--- a/app/models/auth_config.rb
+++ b/app/models/auth_config.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 class AuthConfig
-    # In production, we use CAS for user authentication,
-    # but in development mode, you may want to use local database
-    # authentication instead.
-    def self.use_database_auth?
-      ENV['DATABASE_AUTH'] == 'true'
-    end
+  # In production, we use CAS for user authentication,
+  # but in development mode, you may want to use local database
+  # authentication instead.
+  def self.use_database_auth?
+    ENV['DATABASE_AUTH'] == 'true'
+  end
 end

--- a/app/models/auth_config.rb
+++ b/app/models/auth_config.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AuthConfig
+    # In production, we use CAS for user authentication,
+    # but in development mode, you may want to use local database
+    # authentication instead.
+    def self.use_database_auth?
+      ENV['DATABASE_AUTH'] == 'true'
+    end
+end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -118,7 +118,7 @@ Devise.setup do |config|
   # a value less than 10 in other environments. Note that, for bcrypt (the default
   # algorithm), the cost increases exponentially with the number of stretches (e.g.
   # a value of 20 is already extremely slow: approx. 60 seconds for 1 calculation).
-  # config.stretches = Rails.env.test? ? 1 : 11
+  config.stretches = Rails.env.test? ? 1 : 11
 
   # Set up a pepper to generate the hashed password.
   # config.pepper = '9a01798ef427b8c810116df83a73e428f7b533dd8d148d81033746689a05c82238fdf260eb2866c8d3d2828df8a9bd1a69cb3d40eec4eba9e16f71f74dcf57e3'

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -118,7 +118,7 @@ Devise.setup do |config|
   # a value less than 10 in other environments. Note that, for bcrypt (the default
   # algorithm), the cost increases exponentially with the number of stretches (e.g.
   # a value of 20 is already extremely slow: approx. 60 seconds for 1 calculation).
-  config.stretches = Rails.env.test? ? 1 : 11
+  # config.stretches = Rails.env.test? ? 1 : 11
 
   # Set up a pepper to generate the hashed password.
   # config.pepper = '9a01798ef427b8c810116df83a73e428f7b533dd8d148d81033746689a05c82238fdf260eb2866c8d3d2828df8a9bd1a69cb3d40eec4eba9e16f71f74dcf57e3'


### PR DESCRIPTION
Test PR to check if it is possible to turn off the database authentication now that CAS is enabled.

Related Ticket - https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/268