### PR TITLE
Use only one name for the coveralls token

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
           path: /tmp/test-results
           destination: test-results
       - deploy:
-          command: curl -k https://coveralls.io/webhook?repo_token=$COVERALLS_API_KEY -d "payload[build_num]=$CIRCLE_BUILD_NUM&payload[status]=done"
+          command: curl -k https://coveralls.io/webhook?repo_token=$COVERALLS_REPO_TOKEN -d "payload[build_num]=$CIRCLE_BUILD_NUM&payload[status]=done"
 
   publish-latest:
     executor: docker/docker


### PR DESCRIPTION
There's built-in support for the COVERALLS_REPO_TOKEN name at the stage when tests are run. https://docs.coveralls.io/supported-ci-services