### PR TITLE
Further automate generating release notes

### DIFF
--- a/.github_changelog_generator
+++ b/.github_changelog_generator
@@ -1,2 +1,9 @@
 unreleased=true
-future-release=v1.6.1
+future-release=v1.6.2
+enhancement-labels=Features
+bug-labels=Bugs
+pr-label=**Technical Enhancements:**
+enhancement_prefix=**New Features:**
+security-labels=dependencies
+user=yalelibrary
+project=yul-dc-blacklight

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,32 @@
 # Changelog
 
+## [v1.6.2](https://github.com/yalelibrary/yul-dc-blacklight/tree/v1.6.2) (2020-07-01)
+
+[Full Changelog](https://github.com/yalelibrary/yul-dc-blacklight/compare/v1.6.1...v1.6.2)
+
+No user facing changes in this release.
+
+**Fixed bugs:**
+
+- Syntax fix for coveralls coverage reporting [\#151](https://github.com/yalelibrary/yul-dc-blacklight/pull/151) ([bess](https://github.com/bess))
+
+**Technical Enhancements:**
+
+- Update readme with test coverage info [\#154](https://github.com/yalelibrary/yul-dc-blacklight/pull/154) ([bess](https://github.com/bess))
+- Use only one name for the coveralls token [\#153](https://github.com/yalelibrary/yul-dc-blacklight/pull/153) ([fnibbit](https://github.com/fnibbit))
+- Add specs for search\_history\_controller.rb [\#152](https://github.com/yalelibrary/yul-dc-blacklight/pull/152) ([alishaevn](https://github.com/alishaevn))
+
 ## [v1.6.1](https://github.com/yalelibrary/yul-dc-blacklight/tree/v1.6.1) (2020-06-26)
 
 [Full Changelog](https://github.com/yalelibrary/yul-dc-blacklight/compare/v1.6.0...v1.6.1)
 
-**Merged pull requests:**
+**Security fixes:**
 
 - Update gems to latest - bug fix [\#149](https://github.com/yalelibrary/yul-dc-blacklight/pull/149) ([maxkadel](https://github.com/maxkadel))
+
+**Technical Enhancements:**
+
+- Prep for v1.6.1 [\#150](https://github.com/yalelibrary/yul-dc-blacklight/pull/150) ([FCRodriguez7](https://github.com/FCRodriguez7))
 - Run rspec in parallel to speed up CI runs [\#146](https://github.com/yalelibrary/yul-dc-blacklight/pull/146) ([bess](https://github.com/bess))
 - Calculate and report code coverage metrics  [\#145](https://github.com/yalelibrary/yul-dc-blacklight/pull/145) ([bess](https://github.com/bess))
 - Segregate automated tests to use their own solr index [\#144](https://github.com/yalelibrary/yul-dc-blacklight/pull/144) ([bess](https://github.com/bess))
@@ -15,18 +35,21 @@
 
 [Full Changelog](https://github.com/yalelibrary/yul-dc-blacklight/compare/v1.5.0...v1.6.0)
 
-**Merged pull requests:**
+**New Features:**
+
+- Add link in "Sign In" page to authenticate using Yale CAS [\#139](https://github.com/yalelibrary/yul-dc-blacklight/pull/139) ([edejesusyale](https://github.com/edejesusyale))
+- Sort search results by date from newest to oldest and oldest to newest [\#137](https://github.com/yalelibrary/yul-dc-blacklight/pull/137) ([tilthouse](https://github.com/tilthouse))
+
+**Technical Enhancements:**
 
 - Prep for v1.6.0 release [\#142](https://github.com/yalelibrary/yul-dc-blacklight/pull/142) ([maxkadel](https://github.com/maxkadel))
 - Don't set hosts, breaks production, can re-add for security once runn… [\#141](https://github.com/yalelibrary/yul-dc-blacklight/pull/141) ([maxkadel](https://github.com/maxkadel))
-- Add link in "Sign In" page to authenticate using Yale CAS [\#139](https://github.com/yalelibrary/yul-dc-blacklight/pull/139) ([edejesusyale](https://github.com/edejesusyale))
-- Sort search results by date from newest to oldest and oldest to newest [\#137](https://github.com/yalelibrary/yul-dc-blacklight/pull/137) ([tilthouse](https://github.com/tilthouse))
 
 ## [v1.5.0](https://github.com/yalelibrary/yul-dc-blacklight/tree/v1.5.0) (2020-06-19)
 
 [Full Changelog](https://github.com/yalelibrary/yul-dc-blacklight/compare/v1.4.0...v1.5.0)
 
-**Merged pull requests:**
+**Technical Enhancements:**
 
 - Add changelog for release v1.5.0 [\#138](https://github.com/yalelibrary/yul-dc-blacklight/pull/138) ([mark-dce](https://github.com/mark-dce))
 - Add Honeybadger for execption reporting in production [\#136](https://github.com/yalelibrary/yul-dc-blacklight/pull/136) ([mark-dce](https://github.com/mark-dce))
@@ -42,7 +65,11 @@
 
 [Full Changelog](https://github.com/yalelibrary/yul-dc-blacklight/compare/v1.3.1...v1.4.0)
 
-**Merged pull requests:**
+**New Features:**
+
+- Add suggestive MLA and APA citations for records [\#114](https://github.com/yalelibrary/yul-dc-blacklight/pull/114) ([edejesusyale](https://github.com/edejesusyale))
+
+**Technical Enhancements:**
 
 - Release v1.4.0 [\#125](https://github.com/yalelibrary/yul-dc-blacklight/pull/125) ([FCRodriguez7](https://github.com/FCRodriguez7))
 - Add thumbnails for public works in search [\#123](https://github.com/yalelibrary/yul-dc-blacklight/pull/123) ([edejesusyale](https://github.com/edejesusyale))
@@ -51,60 +78,68 @@
 - We have moved docker image building to CI, remove legacy Makefile [\#120](https://github.com/yalelibrary/yul-dc-blacklight/pull/120) ([orangewolf](https://github.com/orangewolf))
 - Dockerfile Consolidation [\#118](https://github.com/yalelibrary/yul-dc-blacklight/pull/118) ([orangewolf](https://github.com/orangewolf))
 - CI Image Tag instead of Rebuild for Branches and Image Tag on Releases [\#117](https://github.com/yalelibrary/yul-dc-blacklight/pull/117) ([orangewolf](https://github.com/orangewolf))
-- Add suggestive MLA and APA citations for records [\#114](https://github.com/yalelibrary/yul-dc-blacklight/pull/114) ([edejesusyale](https://github.com/edejesusyale))
+- Remove DataStructure field and replaced with Date field [\#110](https://github.com/yalelibrary/yul-dc-blacklight/pull/110) ([FCRodriguez7](https://github.com/FCRodriguez7))
 
 ## [v1.3.1](https://github.com/yalelibrary/yul-dc-blacklight/tree/v1.3.1) (2020-06-12)
 
 [Full Changelog](https://github.com/yalelibrary/yul-dc-blacklight/compare/v1.3.0...v1.3.1)
 
-**Merged pull requests:**
+**Technical Enhancements:**
 
 - Prep for v1.3.1 [\#116](https://github.com/yalelibrary/yul-dc-blacklight/pull/116) ([FCRodriguez7](https://github.com/FCRodriguez7))
 - Replace credentials.yml.enc with new file encoded with a known key [\#115](https://github.com/yalelibrary/yul-dc-blacklight/pull/115) ([mark-dce](https://github.com/mark-dce))
+- Remove duplicate author facet [\#111](https://github.com/yalelibrary/yul-dc-blacklight/pull/111) ([K8Sewell](https://github.com/K8Sewell))
 
 ## [v1.3.0](https://github.com/yalelibrary/yul-dc-blacklight/tree/v1.3.0) (2020-06-11)
 
 [Full Changelog](https://github.com/yalelibrary/yul-dc-blacklight/compare/v1.2.2...v1.3.0)
 
-**Merged pull requests:**
+**New Features:**
+
+- Replace the default blacklight logo with a Yale logo [\#106](https://github.com/yalelibrary/yul-dc-blacklight/pull/106) ([mark-dce](https://github.com/mark-dce))
+- Add date slider facet [\#105](https://github.com/yalelibrary/yul-dc-blacklight/pull/105) ([FCRodriguez7](https://github.com/FCRodriguez7))
+- Make finding aid a link [\#103](https://github.com/yalelibrary/yul-dc-blacklight/pull/103) ([K8Sewell](https://github.com/K8Sewell))
+- Link the Orbis Bib ID to the Orbis catalog record [\#95](https://github.com/yalelibrary/yul-dc-blacklight/pull/95) ([alishaevn](https://github.com/alishaevn))
+
+**Technical Enhancements:**
 
 - Releasing version 1.3.0 [\#112](https://github.com/yalelibrary/yul-dc-blacklight/pull/112) ([alishaevn](https://github.com/alishaevn))
-- Remove duplicate author facet [\#111](https://github.com/yalelibrary/yul-dc-blacklight/pull/111) ([K8Sewell](https://github.com/K8Sewell))
-- Remove DataStructure field and replaced with Date field [\#110](https://github.com/yalelibrary/yul-dc-blacklight/pull/110) ([FCRodriguez7](https://github.com/FCRodriguez7))
 - Revert "Use a different date Solr field" [\#109](https://github.com/yalelibrary/yul-dc-blacklight/pull/109) ([FCRodriguez7](https://github.com/FCRodriguez7))
 - Align management version with previous changes to docker-compose [\#108](https://github.com/yalelibrary/yul-dc-blacklight/pull/108) ([maxkadel](https://github.com/maxkadel))
 - Use a different date Solr field [\#107](https://github.com/yalelibrary/yul-dc-blacklight/pull/107) ([FCRodriguez7](https://github.com/FCRodriguez7))
-- Replace the default blacklight logo with a Yale logo [\#106](https://github.com/yalelibrary/yul-dc-blacklight/pull/106) ([mark-dce](https://github.com/mark-dce))
-- Add date slider facet [\#105](https://github.com/yalelibrary/yul-dc-blacklight/pull/105) ([FCRodriguez7](https://github.com/FCRodriguez7))
 - Align style with latest samvera expectations [\#104](https://github.com/yalelibrary/yul-dc-blacklight/pull/104) ([bess](https://github.com/bess))
-- Make finding aid a link [\#103](https://github.com/yalelibrary/yul-dc-blacklight/pull/103) ([K8Sewell](https://github.com/K8Sewell))
 - Change field used by author facet [\#101](https://github.com/yalelibrary/yul-dc-blacklight/pull/101) ([K8Sewell](https://github.com/K8Sewell))
 - Update solr docker config for 1.4.0 release of mgmt app [\#98](https://github.com/yalelibrary/yul-dc-blacklight/pull/98) ([K8Sewell](https://github.com/K8Sewell))
 - Remove unused code [\#97](https://github.com/yalelibrary/yul-dc-blacklight/pull/97) ([bess](https://github.com/bess))
-- Link the Orbis Bib ID to the Orbis catalog record [\#95](https://github.com/yalelibrary/yul-dc-blacklight/pull/95) ([alishaevn](https://github.com/alishaevn))
 - Add a link to other items with the same call number [\#94](https://github.com/yalelibrary/yul-dc-blacklight/pull/94) ([edejesusyale](https://github.com/edejesusyale))
 
 ## [v1.2.2](https://github.com/yalelibrary/yul-dc-blacklight/tree/v1.2.2) (2020-06-08)
 
 [Full Changelog](https://github.com/yalelibrary/yul-dc-blacklight/compare/v1.2.1...v1.2.2)
 
-**Merged pull requests:**
+**Security fixes:**
+
+- Bump websocket-extensions from 0.1.3 to 0.1.4 [\#90](https://github.com/yalelibrary/yul-dc-blacklight/pull/90) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump websocket-extensions from 0.1.4 to 0.1.5 [\#89](https://github.com/yalelibrary/yul-dc-blacklight/pull/89) ([dependabot[bot]](https://github.com/apps/dependabot))
+
+**Technical Enhancements:**
 
 - Prep for v1.2.2 release [\#93](https://github.com/yalelibrary/yul-dc-blacklight/pull/93) ([bess](https://github.com/bess))
 - Silence deprecations from Blacklight [\#92](https://github.com/yalelibrary/yul-dc-blacklight/pull/92) ([tilthouse](https://github.com/tilthouse))
 - Add a link for Language on the show page [\#91](https://github.com/yalelibrary/yul-dc-blacklight/pull/91) ([FCRodriguez7](https://github.com/FCRodriguez7))
-- Bump websocket-extensions from 0.1.3 to 0.1.4 [\#90](https://github.com/yalelibrary/yul-dc-blacklight/pull/90) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Bump websocket-extensions from 0.1.4 to 0.1.5 [\#89](https://github.com/yalelibrary/yul-dc-blacklight/pull/89) ([dependabot[bot]](https://github.com/apps/dependabot))
 - 190 add author facet [\#88](https://github.com/yalelibrary/yul-dc-blacklight/pull/88) ([K8Sewell](https://github.com/K8Sewell))
 
 ## [v1.2.1](https://github.com/yalelibrary/yul-dc-blacklight/tree/v1.2.1) (2020-06-05)
 
 [Full Changelog](https://github.com/yalelibrary/yul-dc-blacklight/compare/v1.2.0...v1.2.1)
 
-**Merged pull requests:**
+**New Features:**
+
+- Put the blacklight version in the footer [\#86](https://github.com/yalelibrary/yul-dc-blacklight/pull/86) ([bess](https://github.com/bess))
+
+**Technical Enhancements:**
 
 - Release prep for 1.2.1 [\#87](https://github.com/yalelibrary/yul-dc-blacklight/pull/87) ([bess](https://github.com/bess))
-- Put the blacklight version in the footer [\#86](https://github.com/yalelibrary/yul-dc-blacklight/pull/86) ([bess](https://github.com/bess))
 - Collapse chrome installation into a single docker layer [\#85](https://github.com/yalelibrary/yul-dc-blacklight/pull/85) ([bess](https://github.com/bess))
 - Autogenerate changelog and release notes [\#84](https://github.com/yalelibrary/yul-dc-blacklight/pull/84) ([bess](https://github.com/bess))
 
@@ -112,17 +147,20 @@
 
 [Full Changelog](https://github.com/yalelibrary/yul-dc-blacklight/compare/v1.1.1...v1.2.0)
 
-**Merged pull requests:**
+**New Features:**
+
+- For Yale-only objects, require auth for image display [\#81](https://github.com/yalelibrary/yul-dc-blacklight/pull/81) ([bess](https://github.com/bess))
+- adds Genre Facet [\#77](https://github.com/yalelibrary/yul-dc-blacklight/pull/77) ([FCRodriguez7](https://github.com/FCRodriguez7))
+- Only display public visibility for unauthenticated users [\#72](https://github.com/yalelibrary/yul-dc-blacklight/pull/72) ([bess](https://github.com/bess))
+
+**Technical Enhancements:**
 
 - i197-resource-type-link [\#83](https://github.com/yalelibrary/yul-dc-blacklight/pull/83) ([alishaevn](https://github.com/alishaevn))
-- For Yale-only objects, require auth for image display [\#81](https://github.com/yalelibrary/yul-dc-blacklight/pull/81) ([bess](https://github.com/bess))
 - adds publication place facet and spec [\#79](https://github.com/yalelibrary/yul-dc-blacklight/pull/79) ([K8Sewell](https://github.com/K8Sewell))
 - i192-resource-type-facet [\#78](https://github.com/yalelibrary/yul-dc-blacklight/pull/78) ([alishaevn](https://github.com/alishaevn))
-- adds Genre Facet [\#77](https://github.com/yalelibrary/yul-dc-blacklight/pull/77) ([FCRodriguez7](https://github.com/FCRodriguez7))
 - 194 Added link on format to its facet [\#76](https://github.com/yalelibrary/yul-dc-blacklight/pull/76) ([edejesusyale](https://github.com/edejesusyale))
 - I189 remove deprecated indexing [\#74](https://github.com/yalelibrary/yul-dc-blacklight/pull/74) ([K8Sewell](https://github.com/K8Sewell))
 - Add YARD documentation [\#73](https://github.com/yalelibrary/yul-dc-blacklight/pull/73) ([bess](https://github.com/bess))
-- Only display public visibility for unauthenticated users [\#72](https://github.com/yalelibrary/yul-dc-blacklight/pull/72) ([bess](https://github.com/bess))
 - Fix local mount [\#71](https://github.com/yalelibrary/yul-dc-blacklight/pull/71) ([bess](https://github.com/bess))
 - Upgrade to ruby-2.6.6 [\#70](https://github.com/yalelibrary/yul-dc-blacklight/pull/70) ([bess](https://github.com/bess))
 - i179-remove-title-label-from-search-results [\#69](https://github.com/yalelibrary/yul-dc-blacklight/pull/69) ([alishaevn](https://github.com/alishaevn))
@@ -133,7 +171,7 @@
 
 [Full Changelog](https://github.com/yalelibrary/yul-dc-blacklight/compare/v1.1.0...v1.1.1)
 
-**Merged pull requests:**
+**Technical Enhancements:**
 
 - Remove pivot field from facets [\#66](https://github.com/yalelibrary/yul-dc-blacklight/pull/66) ([bess](https://github.com/bess))
 
@@ -141,11 +179,14 @@
 
 [Full Changelog](https://github.com/yalelibrary/yul-dc-blacklight/compare/v1.0.0...v1.1.0)
 
-**Merged pull requests:**
+**Security fixes:**
 
 - Apply security upgrades [\#65](https://github.com/yalelibrary/yul-dc-blacklight/pull/65) ([bess](https://github.com/bess))
 - Bump kaminari from 1.2.0 to 1.2.1 [\#64](https://github.com/yalelibrary/yul-dc-blacklight/pull/64) ([dependabot[bot]](https://github.com/apps/dependabot))
 - Bump puma from 4.3.3 to 4.3.5 [\#63](https://github.com/yalelibrary/yul-dc-blacklight/pull/63) ([dependabot[bot]](https://github.com/apps/dependabot))
+
+**Technical Enhancements:**
+
 - Enables HTTP basic auth for the blacklight site [\#62](https://github.com/yalelibrary/yul-dc-blacklight/pull/62) ([fnibbit](https://github.com/fnibbit))
 - Display language codes in English [\#61](https://github.com/yalelibrary/yul-dc-blacklight/pull/61) ([tilthouse](https://github.com/tilthouse))
 - docker-hub-tagging-readme-instructions [\#60](https://github.com/yalelibrary/yul-dc-blacklight/pull/60) ([alishaevn](https://github.com/alishaevn))
@@ -157,12 +198,16 @@
 
 [Full Changelog](https://github.com/yalelibrary/yul-dc-blacklight/compare/b5ac2c54de3920737d1510881631814e83327e0a...v1.0.0)
 
+**New Features:**
+
+- restrict access to non public records [\#31](https://github.com/yalelibrary/yul-dc-blacklight/pull/31) ([K8Sewell](https://github.com/K8Sewell))
+
 **Closed issues:**
 
 - Rails config.hosts when deploying [\#18](https://github.com/yalelibrary/yul-dc-blacklight/issues/18)
 - .env Solr references blacklight-core [\#6](https://github.com/yalelibrary/yul-dc-blacklight/issues/6)
 
-**Merged pull requests:**
+**Technical Enhancements:**
 
 - Tag :master when master branch is re-built [\#56](https://github.com/yalelibrary/yul-dc-blacklight/pull/56) ([bess](https://github.com/bess))
 - I146 add extent single item view [\#55](https://github.com/yalelibrary/yul-dc-blacklight/pull/55) ([FCRodriguez7](https://github.com/FCRodriguez7))
@@ -185,7 +230,6 @@
 - add format to Solr indexing for tickets 128-130 [\#35](https://github.com/yalelibrary/yul-dc-blacklight/pull/35) ([FCRodriguez7](https://github.com/FCRodriguez7))
 - add version info footer [\#33](https://github.com/yalelibrary/yul-dc-blacklight/pull/33) ([K8Sewell](https://github.com/K8Sewell))
 - Set up blacklight to use standalone Solr image [\#32](https://github.com/yalelibrary/yul-dc-blacklight/pull/32) ([maxkadel](https://github.com/maxkadel))
-- restrict access to non public records [\#31](https://github.com/yalelibrary/yul-dc-blacklight/pull/31) ([K8Sewell](https://github.com/K8Sewell))
 - Config hosts [\#30](https://github.com/yalelibrary/yul-dc-blacklight/pull/30) ([mlooney](https://github.com/mlooney))
 - ecs .env file, dev .env file [\#29](https://github.com/yalelibrary/yul-dc-blacklight/pull/29) ([mlooney](https://github.com/mlooney))
 - Support .env.development for overrides [\#28](https://github.com/yalelibrary/yul-dc-blacklight/pull/28) ([geekscruff](https://github.com/geekscruff))

--- a/README.md
+++ b/README.md
@@ -113,17 +113,10 @@ For the image instance to properly access images, you must also create a .secret
 
 1. Decide on a new version number. We use [semantic versioning](https://semver.org/).
 2. Update the version number in `.github_changelog_generator`
-3. github_changelog_generator --user yalelibrary --project yul-dc-blacklight --token $YOUR_GITHUB_TOKEN
-4. Commit and merge the changes you just made.
-5. Once those changes are merged to the `master` branch, in the github web UI go to `Releases` and tag a new release with the right version number. Paste in the release notes for this version from the changelog you generated. In the release notes, split out `Features`, `Bug Fixes`, and `Other`
-6. Once the CI build has completed for `master`, tag and push a docker hub image with the same release number:
-
-  ```
-  docker pull yalelibraryit/dc-blacklight:f93089f70e18d6c6d77ee1a6b3b4866b6d284078 <-- the tag created by circleci
-  docker tag yalelibraryit/dc-blacklight:f93089f70e18d6c6d77ee1a6b3b4866b6d284078 yalelibraryit/dc-blacklight:v1.2.1 <-- the new, semantically versioned tag
-  docker push yalelibraryit/dc-blacklight:v1.2.1 <-- now our semantically versioned tag will be available from docker hub
-  ```
-
+3. Go through all PRs since the last release and ensure that any **features** and **bug fixes** have been tagged with the appropriate label. No need to label it unless it is a feature or a bug fix.
+4. Run this command: `github_changelog_generator --token $YOUR_GITHUB_TOKEN`. This will re-generate `CHANGELOG.md`.
+5. Commit and merge the changes you just made with a message like "Prep for vX.Y.Z release"
+6. Once those changes are merged to the `master` branch, in the github web UI go to `Releases` and tag a new release with the right version number. Paste in the release notes for this release from the top of `CHANGELOG.md`
 7. Update `yul-dc-camerata` with the new version of blacklight and submit a PR.
 
 ## Using a New Release of the Management App or other microservices


### PR DESCRIPTION
* By tagging PRs with Feature and Bug labels, we can automate marking them as such in the release notes.
* This will shorten and simplify the release process.
* Update README to reflect updated practice.

Connected to https://github.com/yalelibrary/YUL-DC/issues/296