### PR TITLE
Modify auth redirect and add tests

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -18,7 +18,8 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     end
 
     if @user
-      sign_in_and_redirect @user, event: :authentication # this will throw if @user is not activated
+      sign_in @user, event: :authentication # this will throw if @user is not activated
+      redirect_to request.env['omniauth.origin'] || root_path
       set_flash_message(:notice, :success, kind: "CAS") if is_navigational_format?
     else
       redirect_to new_user_registration_url

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe OmniauthCallbacksController do
+  include Devise::Test::ControllerHelpers
+
+  before do
+    User.create(provider: 'cas',
+                uid: '8783401',
+                email: "8783401@yale.edu",
+                password: Devise.friendly_token[0, 20])
+    request.env["devise.mapping"] = Devise.mappings[:user]
+    request.env["omniauth.auth"] = OmniAuth.config.mock_auth[:cas]
+  end
+  OmniAuth.config.mock_auth[:cas] =
+    OmniAuth::AuthHash.new(
+      provider: 'cas',
+      uid: "8783401",
+      email: "8783401@yale.edu",
+      password: Devise.friendly_token[0, 20]
+    )
+
+  # If a user logs in and we can tell what page they were on before logging in it will redirect them to the page they were previously on
+  context "when origin is present" do
+    before do
+      request.env["omniauth.origin"] = '/yale-only-map-of-china'
+    end
+
+    it "redirects to origin" do
+      post :cas
+      expect(response.redirect_url).to eq 'http://test.host/yale-only-map-of-china'
+    end
+  end
+
+  # If a user logs in and we cannot tell what page they were on before logging in it will redirect them to the home page
+  context "when origin is missing" do
+    it "redirects to dashboard" do
+      post :cas
+      expect(response.redirect_url).to include "http://test.host/"
+    end
+  end
+end


### PR DESCRIPTION
Purpose is to modify the redirect after a user logs in to either direct them to the page they were on before logging in or to redirect to the home page when that information is not available.  Also adds spec file for the omniauth callbacks controller.

This should be deployed and tested with CAS authentication before merging this code in.