### PR TITLE
Add Yale branded typefaces and colors

### DIFF
--- a/app/assets/stylesheets/blacklight.scss
+++ b/app/assets/stylesheets/blacklight.scss
@@ -1,10 +1,3 @@
 @import 'bootstrap';
 
-@import 'blacklight/blacklight';
-@import 'blacklight_marc';
-
-
-.iiif-logo img {
-	height: 30px;
-}
-
+@import 'blacklight/blacklight', 'blacklight_marc';

--- a/app/assets/stylesheets/customOverrides/footer.scss
+++ b/app/assets/stylesheets/customOverrides/footer.scss
@@ -1,0 +1,14 @@
+/********************************************************
+DEFAULT MOBILE STYLING
+********************************************************/
+@import 'helpers/breakpoints';
+@import 'theme/colors', 'theme/typography';
+
+
+
+@media screen and (min-width: $tablet) {
+}
+
+
+@media screen and (min-width: $desktop) {
+}

--- a/app/assets/stylesheets/customOverrides/header.scss
+++ b/app/assets/stylesheets/customOverrides/header.scss
@@ -1,0 +1,21 @@
+/********************************************************
+DEFAULT MOBILE STYLING
+********************************************************/
+@import 'helpers/breakpoints';
+@import 'theme/colors', 'theme/typography';
+
+.iiif-logo img {
+  height: 30px;
+}
+
+.bg-dark {
+  background-color: $yale_blue !important;
+}
+
+
+@media screen and (min-width: $tablet) {
+}
+
+
+@media screen and (min-width: $desktop) {
+}

--- a/app/assets/stylesheets/helpers/breakpoints.scss
+++ b/app/assets/stylesheets/helpers/breakpoints.scss
@@ -1,0 +1,2 @@
+$tablet: '768px';
+$desktop: '1200px';

--- a/app/assets/stylesheets/theme/colors.scss
+++ b/app/assets/stylesheets/theme/colors.scss
@@ -1,0 +1,6 @@
+$black: #000000;
+$grey: #968d85;
+$light_grey: #f8f8f8;
+$white: #ffffff;
+$yale_blue: #043669;
+$light_blue: #3399ff;

--- a/app/assets/stylesheets/theme/typography.scss
+++ b/app/assets/stylesheets/theme/typography.scss
@@ -1,0 +1,33 @@
+// primary typeface
+@font-face {
+  font-family: 'YaleNew-Roman';
+  src:  url(https://www.yale.edu/sites/all/themes/yale_blue/fonts/yalenew-roman-webfont.woff2);
+}
+
+@font-face {
+  font-family: 'YaleNew-Italic';
+  src:  url(https://environment.yale.edu/assets/eye/common/webfonts/yalenew-italic-webfont.ttf);
+}
+
+// secondary typeface
+@font-face {
+  font-family: 'Mallory-Light';
+  src:  url(https://www.yale.edu/sites/all/themes/yale_blue/fonts_new/Mallory/Mallory/Mallory-Light.woff);
+}
+
+@font-face {
+  font-family: 'Mallory-LightItalic';
+  src:  url(https://www.yale.edu/sites/all/themes/yale_blue/fonts_new/Mallory/Mallory/Mallory-LightItalic.woff);
+}
+
+@font-face {
+  font-family: 'Mallory-Medium';
+  src:  url(https://www.yale.edu/sites/all/themes/yale_blue/fonts_new/Mallory/Mallory/Mallory-Medium.woff);
+}
+
+
+$yaleRoman: YaleNew-Roman;
+$yaleItalic: YaleNew-Italic;
+$malloryLight: Mallory-Light;
+$malloryLightItalic: Mallory-LightItalic;
+$malloryMedium: Mallory-Medium;


### PR DESCRIPTION
Co-authored by: Kait Sewell <kait@notch8.com>

Ticket:
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/319

# Summary 
- Adds Yale branded colors as variables
- Adds Yale branded typefaces as variable
- Adds breakpoints as variables
- Sets up the structure for mobile first design in the header and footer sass files.

# Screenshots
### Existing Yale header
![Screen Shot 2020-07-09 at 4 26 38 PM](https://user-images.githubusercontent.com/29032869/87100395-23d2e100-c201-11ea-9002-47312849773b.png)

### Updated Yale header
![image](https://user-images.githubusercontent.com/29032869/87100445-4e249e80-c201-11ea-988d-4eb59c6a8266.png)