### PR TITLE
Setup Solr Highlighting for show fields

### DIFF
--- a/app/assets/stylesheets/blacklight.scss
+++ b/app/assets/stylesheets/blacklight.scss
@@ -1,3 +1,7 @@
 @import 'bootstrap';
 
 @import 'blacklight/blacklight', 'blacklight_marc';
+
+.search-highlight {
+  background-color: yellow;
+}

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -116,7 +116,7 @@ class CatalogController < ApplicationController
 
     # solr fields to be displayed in the index (search results) view
     #   The ordering of the field names is the order of the display
-    config.add_index_field 'author_tsim', label: 'Author'
+    config.add_index_field 'author_tsim', label: 'Author', highlight: true
     config.add_index_field 'author_vern_ssim', label: 'Author'
     config.add_index_field 'extentOfDigitization_ssim', label: 'Extent of Digitization'
     config.add_index_field 'format', label: 'Format'
@@ -184,6 +184,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'coordinates_ssim', label: 'this is the coordinates'
     config.add_show_field 'projection_ssim', label: 'this is the projection'
 
+    config.add_field_configuration_to_solr_request!
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields
     #

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -17,6 +17,7 @@ class SearchBuilder < Blacklight::SearchBuilder
 
   # Add the `show_only_public_records` method to the processor chain
   self.default_processor_chain += [:show_only_public_records]
+  self.default_processor_chain += [:highlight_fields]
 
   ##
   # Use the solr fq (filter query) parameter to limit search results to only those items
@@ -27,5 +28,17 @@ class SearchBuilder < Blacklight::SearchBuilder
     # add a new solr facet query ('fq') parameter that limits results to those with a 'public_b' field of 1
     solr_parameters[:fq] ||= []
     solr_parameters[:fq] << '((visibility_ssi:Public) OR (visibility_ssi:"Yale Community Only"))'
+  end
+
+  def highlight_fields(solr_parameters)
+    solr_parameters[:hl] ||= []
+    solr_parameters['hl.fl'] ||= []
+
+    solr_parameters[:hl] = true
+    #solr_parameters['hl.usePhraseHighlighter'] = false
+    solr_parameters['hl.preserveMulti'] = true
+    solr_parameters['hl.fl'] << "*"
+    solr_parameters["hl.simple.pre"] = "<span class='search-highlight'>"
+    solr_parameters["hl.simple.post"] = "</span>"
   end
 end

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -35,7 +35,7 @@ class SearchBuilder < Blacklight::SearchBuilder
     solr_parameters['hl.fl'] ||= []
 
     solr_parameters[:hl] = true
-    #solr_parameters['hl.usePhraseHighlighter'] = false
+    # solr_parameters['hl.usePhraseHighlighter'] = false
     solr_parameters['hl.preserveMulti'] = true
     solr_parameters['hl.fl'] << "*"
     solr_parameters["hl.simple.pre"] = "<span class='search-highlight'>"

--- a/spec/system/highlight_in_search_spec.rb
+++ b/spec/system/highlight_in_search_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe 'Search results displays field', type: :system, clean: true do
+  before do
+    solr = Blacklight.default_index.connection
+    solr.add([dog])
+    solr.commit
+  end
+
+  let(:dog) do
+    {
+      id: '111',
+      author_tsim: 'Me and You',
+      format: 'three dimensional object',
+      published_ssim: "1997",
+      published_vern_ssim: "1997",
+      lc_callnum_ssim: "123213213",
+      language_ssim: ['en', 'eng', 'zz'],
+      visibility_ssi: 'Public'
+    }
+  end
+
+  context 'Within search results' do
+    subject(:content) { find(:css, '#content') }
+
+    it 'highlights author when a term is queried' do
+      visit '/?search_field=all_fields&q=You'
+      expect(page.html).to include "Me and <span class='search-highlight'>You</span>"
+    end
+  end
+end


### PR DESCRIPTION
## Background
This PR adds highlighting to Solr queries. Currently the only field that is highlighted is the author field.

## Testing
Go to http://localhost:3000 and search for an author that exists (e.g. "Jane"). It has to be a full term i.e. "Jane" instead of "Ja" since author searches for full matches of terms.

Verify that the author field is highlighted as shown below: 
![Screen Shot 2020-07-10 at 11 10 45 AM](https://user-images.githubusercontent.com/40175979/87441419-1468e480-c5c1-11ea-8928-3bef3b488378.png)
