### PR TITLE
Add names and labels to elements for accessibility

### DIFF
--- a/app/views/catalog/_show_links.html.erb
+++ b/app/views/catalog/_show_links.html.erb
@@ -7,7 +7,7 @@
     <li class="list-group-item manifest">
       <div class='nav-link'>
         <% oid = @document.id %>
-        <%= link_to image_tag('iiif.png'), manifest_url(oid), target: '_blank', class: 'iiif-logo' %>
+        <%= link_to image_tag('iiif.png', alt: 'IIIF Logo'), manifest_url(oid), target: '_blank', class: 'iiif-logo', rel: 'external' %>
         <%= link_to t('blacklight.sidebar.manifest'), manifest_url(oid), target: '_blank', id: 'manifestLink'%> 
       <div>
     </li>

--- a/app/views/catalog/_uv.html.erb
+++ b/app/views/catalog/_uv.html.erb
@@ -3,6 +3,7 @@
 <div class="uv-container">
 <iframe
     class="universal-viewer-iframe"
+    title="Universal Viewer"
     src="<%= request&.base_url %>/uv/uv.html#?manifest=<%= manifest_url(oid) %>"
     width="924"
     height="668"


### PR DESCRIPTION
Adds an alt tag for the IIIF logo image.  Adds an external relation to the IIIF logo link.  Adds a title to the UV iframe.  Relates to ticket #332 - adding names and labels to elements that were failing accessibility testing.  