### PR TITLE
Improve color contrast for accessibility

### DIFF
--- a/app/assets/stylesheets/customOverrides/header.scss
+++ b/app/assets/stylesheets/customOverrides/header.scss
@@ -21,7 +21,7 @@ DEFAULT MOBILE STYLING
   line-height: 2.25;
   letter-spacing: normal;
   text-align: right;
-  color: $light_grey !important;
+  color: $lightest_grey !important;
 }
 
 @media screen and (min-width: $tablet) {

--- a/app/assets/stylesheets/customOverrides/main.scss
+++ b/app/assets/stylesheets/customOverrides/main.scss
@@ -1,0 +1,57 @@
+/********************************************************
+DEFAULT MOBILE STYLING
+********************************************************/
+
+a {
+  color: $yale_blue;
+}
+
+.btn {
+	border-radius: 0;
+}
+  
+.btn-primary {
+	color: $yale_blue;
+	background-color: $white;
+	border-color: $medium_grey;
+}
+
+.btn-primary:hover {
+	color: $yale_blue;
+	background-color: $light_grey;
+	border-color: $medium_grey;
+}
+  
+.btn-outline-secondary {
+	color: $dark_grey;
+	border-color: $medium_grey;
+}
+
+.btn-outline-secondary:hover {
+	color: $white;
+	background-color: $dark_grey;
+	border-color: $medium_grey;
+}
+	
+#citationLink {
+	color: $yale_blue !important;
+}
+
+#emailLink {
+	color: $yale_blue !important;
+}
+
+.page-link { 
+	color: $yale_blue;
+}
+
+#smsLink {
+	color: $yale_blue !important;
+}
+
+@media screen and (min-width: $tablet) {
+}
+
+
+@media screen and (min-width: $desktop) {
+}

--- a/app/assets/stylesheets/theme/colors.scss
+++ b/app/assets/stylesheets/theme/colors.scss
@@ -1,6 +1,9 @@
 $black: #000000;
-$grey: #968d85;
-$light_grey: #f8f8f8;
+$darkest_grey: #222222;
+$dark_grey: #4a4a4a;
+$medium_grey: #978d85;
+$light_grey: #dddddd;
+$lightest_grey: #f9f9f9;
 $white: #ffffff;
 $yale_blue: #043669;
 $light_blue: #3399ff;


### PR DESCRIPTION
# Summary
Improve the default color contrast to include the Yale color palette and to improve accessibility.

# Related Issue
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/331

# Screenshots
## Zero failing elements for color contrast
### Home Page
<img width="1434" alt="image" src="https://user-images.githubusercontent.com/36549923/87976983-d49f7280-ca82-11ea-865c-1d403a406830.png">

### Search Results Page
<img width="1429" alt="image" src="https://user-images.githubusercontent.com/36549923/87976486-06640980-ca82-11ea-8c2d-4f1cdfec0b66.png">

### Object Show Page
<img width="1433" alt="image" src="https://user-images.githubusercontent.com/36549923/87976627-4b883b80-ca82-11ea-89ad-bbbcf63dcabe.png">

