### PR TITLE
Change displayed search result fields

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -119,13 +119,10 @@ class CatalogController < ApplicationController
     #   The ordering of the field names is the order of the display
     config.add_index_field 'author_tsim', label: 'Author', highlight: true
     config.add_index_field 'author_vern_ssim', label: 'Author'
-    config.add_index_field 'extentOfDigitization_ssim', label: 'Extent of Digitization'
-    config.add_index_field 'format', label: 'Format'
-    config.add_index_field 'language_ssim', label: 'Language', helper_method: :language_codes
-    config.add_index_field 'published_ssim', label: 'Published'
-    config.add_index_field 'published_vern_ssim', label: 'Published'
-    config.add_index_field 'lc_callnum_ssim', label: 'Call number'
-    config.add_index_field 'genre_ssim', label: 'Genre'
+    config.add_index_field 'date_tsim', label: 'Date'
+    config.add_index_field 'resourceType_ssim', label: 'Resource Type'
+    config.add_index_field 'partOf_ssim', label: 'Collection Name'
+    config.add_index_field 'identifierShelfMark_ssim', label: 'Identifier Shelf Mark'
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -120,6 +120,7 @@ class CatalogController < ApplicationController
     config.add_index_field 'author_tsim', label: 'Author', highlight: true
     config.add_index_field 'author_vern_ssim', label: 'Author'
     config.add_index_field 'date_tsim', label: 'Date'
+    config.add_index_field 'imageCount_isi', label: 'Image Count'
     config.add_index_field 'resourceType_ssim', label: 'Resource Type'
     config.add_index_field 'partOf_ssim', label: 'Collection Name'
     config.add_index_field 'identifierShelfMark_ssim', label: 'Identifier Shelf Mark'

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -174,13 +174,13 @@ class CatalogController < ApplicationController
     config.add_show_field 'collectionId_ssim', label: 'Collection ID'
     config.add_show_field 'edition_ssim', label: 'Edition'
     config.add_show_field 'uri_ssim', label: 'URI'
-    config.add_show_field 'partOf_ssim', label: 'this is the part of'
-    config.add_show_field 'numberOfPages_ssim', label: 'this is the number of pages'
-    config.add_show_field 'material_ssim', label: 'this is the material'
-    config.add_show_field 'scale_ssim', label: 'this is the scale'
-    config.add_show_field 'digital_ssim', label: 'this is the digital'
-    config.add_show_field 'coordinates_ssim', label: 'this is the coordinates'
-    config.add_show_field 'projection_ssim', label: 'this is the projection'
+    config.add_show_field 'partOf_ssim', label: 'Collection Name'
+    config.add_show_field 'numberOfPages_ssim', label: 'Number of Pages'
+    config.add_show_field 'material_ssim', label: 'Material'
+    config.add_show_field 'scale_ssim', label: 'Scale'
+    config.add_show_field 'digital_ssim', label: 'Digital'
+    config.add_show_field 'coordinates_ssim', label: 'Coordinates'
+    config.add_show_field 'projection_ssim', label: 'Projection'
 
     config.add_field_configuration_to_solr_request!
     # "fielded" search configuration. Used by pulldown among other places.

--- a/spec/system/view_fields_in_search_spec.rb
+++ b/spec/system/view_fields_in_search_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe 'Search results displays field', type: :system, clean: true do
       resourceType_ssim: 'Archives or Manuscripts',
       partOf_ssim: 'Beinecke Library',
       identifierShelfMark_ssim: 'Beinecke MS 801',
+      imageCount_isi: '23',
       visibility_ssi: 'Public'
     }
   end
@@ -39,6 +40,9 @@ RSpec.describe 'Search results displays field', type: :system, clean: true do
     end
     it 'displays Call Number in results' do
       expect(content).to have_content('Beinecke MS 801')
+    end
+    it 'displays Image Count in results' do
+      expect(content).to have_content('23')
     end
   end
 end

--- a/spec/system/view_fields_in_search_spec.rb
+++ b/spec/system/view_fields_in_search_spec.rb
@@ -14,34 +14,31 @@ RSpec.describe 'Search results displays field', type: :system, clean: true do
       id: '111',
       author_tsim: 'Me and You',
       author_vern_ssim: 'Me and You',
-      format: 'three dimensional object',
-      published_ssim: "1997",
-      published_vern_ssim: "1997",
-      lc_callnum_ssim: "123213213",
-      language_ssim: ['en', 'eng', 'zz'],
+      date_tsim: '1999',
+      resourceType_ssim: 'Archives or Manuscripts',
+      partOf_ssim: 'Beinecke Library',
+      identifierShelfMark_ssim: 'Beinecke MS 801',
       visibility_ssi: 'Public'
     }
   end
 
   context 'Within search results' do
-    subject(:content) { find(:css, '#content') }
+    subject(:content) { find(:css, '#main-container') }
 
-    it 'displays language in results' do
-      expect(content).to have_content("English (en)")
-      expect(content).to have_content("English (eng)")
-      expect(content).to have_content("zz")
+    it 'displays Date in results' do
+      expect(content).to have_content('1999')
     end
     it 'displays Author in results' do
-      expect(content).to have_content("Me and You").twice
+      expect(content).to have_content('Me and You').twice
     end
-    it 'displays Publishing in results' do
-      expect(content).to have_content("1997").twice
+    it 'displays Resource Type in results' do
+      expect(content).to have_content('Archives or Manuscripts')
     end
-    it 'displays format in results' do
-      expect(content).to have_content("three dimensional object")
+    it 'displays Collection Name in results' do
+      expect(content).to have_content('Beinecke Library')
     end
-    it 'displays call number in results' do
-      expect(content).to have_content("123213213")
+    it 'displays Call Number in results' do
+      expect(content).to have_content('Beinecke MS 801')
     end
   end
 end


### PR DESCRIPTION
# Summary
Add fields to and remove fields from the displayed fields in the search results view.

# Related Ticket
[#384](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/384)

# Acceptance Criteria
Search results should display the following fields (when they have data):
- [ ] Title
- [ ] Creator
- [ ] Date
- [ ] Image Count (new field - need to agree on a name with the management team) - see note below
- [ ] Resource type
- [ ] Call Number
- [ ] Part Of (i.e. the collection name a work belongs to)
- [ ] remove any other fields (Extent of Digitization, Format, Language, Genre)
- [ ] suppress an fields that don't have data

# Screenshot
![image](https://user-images.githubusercontent.com/36549923/88328136-d95f6300-ccdc-11ea-9853-519cde45fa62.png)

# Note  
Image Count field is added but not viewable as it is a new field and not yet present in the indexed metadata.  