### PR TITLE
Make the header responsive

### DIFF
--- a/app/assets/stylesheets/customOverrides/footer.scss
+++ b/app/assets/stylesheets/customOverrides/footer.scss
@@ -56,7 +56,7 @@ DEFAULT MOBILE STYLING
   font-size: xx-small;
 }
 
-@media screen and (min-width: $desktop) {
+@media screen and (min-width: $xlarge_device) {
   .footer-container {
       display: grid;
       grid-template-columns: 15% 20% 50% 15%;
@@ -69,9 +69,9 @@ DEFAULT MOBILE STYLING
 }
 
 
-@media screen and (min-width: $tablet) {
+@media screen and (min-width: $medium_device) {
 }
 
 
-@media screen and (min-width: $desktop) {
+@media screen and (min-width: $xlarge_device) {
 }

--- a/app/assets/stylesheets/customOverrides/header.scss
+++ b/app/assets/stylesheets/customOverrides/header.scss
@@ -17,7 +17,7 @@ DEFAULT MOBILE STYLING
   font-weight: 500;
   font-stretch: normal;
   font-style: normal;
-  font-size: small;
+  font-size: x-small;
   line-height: 2.25;
   letter-spacing: normal;
   text-align: right;
@@ -30,16 +30,26 @@ DEFAULT MOBILE STYLING
 
 .navbar-logo{
   background-image: url(yul_logo/yul_logo3x.png);
-  background-size: 341.25px 37.5px;
-  margin-top: 10px;
-  margin-bottom: 15px;
-  flex: auto;
-  text-indent: 0px;
+  flex: 0 1 50%;
+  background-size: contain;
+  background-position-y: center;
 }
 
-@media screen and (min-width: $tablet) {
+@media screen and (min-width: $medium_device) {
+  .navbar > .container {
+    flex-direction: column;
+    align-items: start;
+  }
+  .navbar-logo {
+    width: 45%;
+  }
 }
 
-
-@media screen and (min-width: $desktop) {
+@media screen and (min-width: $xlarge_device) {
+  .navbar > .container {
+    flex-direction: initial;
+  }
+  .navbar-logo {
+    flex: 0 1 25%;
+  }
 }

--- a/app/assets/stylesheets/customOverrides/main.scss
+++ b/app/assets/stylesheets/customOverrides/main.scss
@@ -9,7 +9,7 @@ a {
 .btn {
 	border-radius: 0;
 }
-  
+
 .btn-primary {
 	color: $yale_blue;
 	background-color: $white;
@@ -21,7 +21,7 @@ a {
 	background-color: $light_grey;
 	border-color: $medium_grey;
 }
-  
+
 .btn-outline-secondary {
 	color: $dark_grey;
 	border-color: $medium_grey;
@@ -32,7 +32,7 @@ a {
 	background-color: $dark_grey;
 	border-color: $medium_grey;
 }
-	
+
 #citationLink {
 	color: $yale_blue !important;
 }
@@ -41,7 +41,7 @@ a {
 	color: $yale_blue !important;
 }
 
-.page-link { 
+.page-link {
 	color: $yale_blue;
 }
 
@@ -49,9 +49,9 @@ a {
 	color: $yale_blue !important;
 }
 
-@media screen and (min-width: $tablet) {
+@media screen and (min-width: $medium_device) {
 }
 
 
-@media screen and (min-width: $desktop) {
+@media screen and (min-width: $xlarge_device) {
 }

--- a/app/assets/stylesheets/customOverrides/search_result.scss
+++ b/app/assets/stylesheets/customOverrides/search_result.scss
@@ -7,9 +7,9 @@ DEFAULT MOBILE STYLING
 }
 
 
-@media screen and (min-width: $tablet) {
+@media screen and (min-width: $medium_device) {
 }
 
 
-@media screen and (min-width: $desktop) {
+@media screen and (min-width: $xlarge_device) {
 }

--- a/app/assets/stylesheets/helpers/breakpoints.scss
+++ b/app/assets/stylesheets/helpers/breakpoints.scss
@@ -1,2 +1,4 @@
-$tablet: '768px';
-$desktop: '1200px';
+$small_device: '567px';
+$medium_device: '768px';
+$large_device: '900px';
+$xlarge_device: '1200px';


### PR DESCRIPTION
Co-authored by: Frederick Rodriguez <frederick.rodriguez@yale.edu>

# Ticket
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/402

# Summary
The new, longer Yale logo gets chopped off when the screen is between 768 px and 1200 px.

# Expected Behavior
- The header image is properly sized across screen from 375 px wide and up
- The additional header links convert to a hamburger menu on x-small and small devices
- The additional header links drop beneath the logo on medium and large devices
- The additional header links show inline on x-large devices

# Demo
![402](https://user-images.githubusercontent.com/29032869/88841870-6b5ee400-d193-11ea-8c5c-29b025aa6a50.gif)
