### PR TITLE
Update allfields search behavior 388

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,7 +114,6 @@ No user facing changes in this release.
 - Prep for v1.6.0 release [\#142](https://github.com/yalelibrary/yul-dc-blacklight/pull/142) ([maxkadel](https://github.com/maxkadel))
 - Don't set hosts, breaks production, can re-add for security once runn… [\#141](https://github.com/yalelibrary/yul-dc-blacklight/pull/141) ([maxkadel](https://github.com/maxkadel))
 - Add link in "Sign In" page to authenticate using Yale CAS [\#139](https://github.com/yalelibrary/yul-dc-blacklight/pull/139) ([edejesusyale](https://github.com/edejesusyale))
-- Sort search results by date from newest to oldest and oldest to newest [\#137](https://github.com/yalelibrary/yul-dc-blacklight/pull/137) ([tilthouse](https://github.com/tilthouse))
 
 ## [v1.5.0](https://github.com/yalelibrary/yul-dc-blacklight/tree/v1.5.0) (2020-06-19)
 
@@ -123,6 +122,7 @@ No user facing changes in this release.
 **Technical Enhancements:**
 
 - Add changelog for release v1.5.0 [\#138](https://github.com/yalelibrary/yul-dc-blacklight/pull/138) ([mark-dce](https://github.com/mark-dce))
+- Sort search results by date from newest to oldest and oldest to newest [\#137](https://github.com/yalelibrary/yul-dc-blacklight/pull/137) ([tilthouse](https://github.com/tilthouse))
 - Add Honeybadger for execption reporting in production [\#136](https://github.com/yalelibrary/yul-dc-blacklight/pull/136) ([mark-dce](https://github.com/mark-dce))
 - Only bundle when we have to so that CI is fast again [\#135](https://github.com/yalelibrary/yul-dc-blacklight/pull/135) ([orangewolf](https://github.com/orangewolf))
 - Search filters display user friendly names [\#134](https://github.com/yalelibrary/yul-dc-blacklight/pull/134) ([alishaevn](https://github.com/alishaevn))

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -206,7 +206,7 @@ class CatalogController < ApplicationController
     # config.add_search_field 'all_fields', label: 'All Fields'
 
     # Array allows for only listed Solr fields to be searched in the 'All Fields'
-    search_fields = ['abstract_ssim', 'alternativeTitle_ssim', 'orbisBidId_ssim', 'description_tesim',
+    search_fields = ['abstract_ssim', 'author_tsim', 'alternativeTitle_ssim', 'orbisBidId_ssim', 'description_tesim',
                      'publicatonPlace_ssim', 'publisher_ssim', 'sourceCreated_ssim', 'geo_subject_ssim',
                      'subjectName_ssim', 'subject_topic_tsim', 'title_tsim']
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -202,7 +202,21 @@ class CatalogController < ApplicationController
     # solr request handler? The one set in config[:default_solr_parameters][:qt],
     # since we aren't specifying it otherwise.
 
-    config.add_search_field 'all_fields', label: 'All Fields'
+    # Blacklight 'out of box code'
+    # config.add_search_field 'all_fields', label: 'All Fields'
+
+    # Array allows for only listed Solr fields to be searched in the 'All Fields'
+    search_fields = ['abstract_ssim', 'alternativeTitle_ssim', 'orbisBidId_ssim', 'description_tesim',
+                     'publicatonPlace_ssim', 'publisher_ssim', 'sourceCreated_ssim', 'geo_subject_ssim',
+                     'subjectName_ssim', 'subject_topic_tsim', 'title_tsim']
+
+    config.add_search_field('all_fields', label: 'All Fields') do |field|
+      field.qt = 'search'
+      field.solr_parameters = {
+        qf: search_fields,
+        pf: ''
+      }
+    end
 
     # Now we see how to over-ride Solr request handler defaults, in this
     # case for a BL "search field", which is really a dismax aggregate
@@ -237,8 +251,8 @@ class CatalogController < ApplicationController
     config.add_search_field('orbisBibId_ssim', label: 'BibID') do |field|
       field.qt = 'search'
       field.solr_parameters = {
-        qf: 'orbisBibId_ssim',
-        pf: ''
+        qf: '',
+        pf: 'orbisBibId_ssim'
       }
     end
 

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe CatalogController, type: :controller do
+  describe 'facets' do
+    let(:facets) do
+      controller
+        .blacklight_config
+    end
+
+    describe 'search fields' do
+      let(:search_fields) { controller.blacklight_config.search_fields.keys }
+
+      let(:expected_search_fields) do
+        ['all_fields', 'author_tsim', 'orbisBibId_ssim', 'subjectName_ssim', 'title_tsim']
+      end
+
+      it { expect(search_fields).to contain_exactly(*expected_search_fields) }
+    end
+  end
+end


### PR DESCRIPTION
**ACCEPTANCE**
- [x] When I select "All Fields" for my search, as many of the following following fields as currently exist* should be searched:
* abstract
* alternativeTitle
* alternativeTitleDisplay
* bibId_ssim
* contents
* contributor
* contributorDisplay
* creator
* creatorDisplay
* description
* publicationPlace
* publisher
* sourceCreator
* sourceTitle
* subjectGeographic
* subjectName
* subjectOccupation
* subjectTitle
* subjectTitleDisplay
* subjectTopic
* title
* titleStatement_ssim

*NOTE: We'll do another pass on field mappings closer to release and make sure we catch anything that was in flux between the Metadata Cloud, Management App, and Discovery App - so if we don't get 100% of fields in right now, that's ok, we just want to get as many as we can so we have representative support for UI and UX design.