### PR TITLE
Add highlighting to search result

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -121,9 +121,9 @@ class CatalogController < ApplicationController
     config.add_index_field 'author_vern_ssim', label: 'Author'
     config.add_index_field 'date_tsim', label: 'Date'
     config.add_index_field 'imageCount_isi', label: 'Image Count'
-    config.add_index_field 'resourceType_ssim', label: 'Resource Type'
+    config.add_index_field 'resourceType_tesim', label: 'Resource Type', highlight: true
     config.add_index_field 'partOf_ssim', label: 'Collection Name'
-    config.add_index_field 'identifierShelfMark_ssim', label: 'Identifier Shelf Mark'
+    config.add_index_field 'identifierShelfMark_tesim', label: 'Identifier Shelf Mark', highlight: true
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
@@ -206,8 +206,8 @@ class CatalogController < ApplicationController
     # config.add_search_field 'all_fields', label: 'All Fields'
 
     # Array allows for only listed Solr fields to be searched in the 'All Fields'
-    search_fields = ['abstract_ssim', 'author_tsim', 'alternativeTitle_ssim', 'orbisBidId_ssim', 'description_tesim',
-                     'publicatonPlace_ssim', 'publisher_ssim', 'sourceCreated_ssim', 'geo_subject_ssim',
+    search_fields = ['abstract_ssim', 'author_tsim', 'alternativeTitle_ssim', 'description_tesim', 'geo_subject_ssim',
+                     'orbisBidId_ssim','publicatonPlace_ssim', 'publisher_ssim', 'sourceCreated_ssim',
                      'subjectName_ssim', 'subject_topic_tsim', 'title_tsim']
 
     config.add_search_field('all_fields', label: 'All Fields') do |field|

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -207,7 +207,7 @@ class CatalogController < ApplicationController
 
     # Array allows for only listed Solr fields to be searched in the 'All Fields'
     search_fields = ['abstract_ssim', 'author_tsim', 'alternativeTitle_ssim', 'description_tesim', 'geo_subject_ssim',
-                     'orbisBidId_ssim','publicatonPlace_ssim', 'publisher_ssim', 'sourceCreated_ssim',
+                     'orbisBidId_ssim', 'publicatonPlace_ssim', 'publisher_ssim', 'sourceCreated_ssim',
                      'subjectName_ssim', 'subject_topic_tsim', 'title_tsim']
 
     config.add_search_field('all_fields', label: 'All Fields') do |field|

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -207,8 +207,8 @@ class CatalogController < ApplicationController
 
     # Array allows for only listed Solr fields to be searched in the 'All Fields'
     search_fields = ['abstract_ssim', 'author_tsim', 'alternativeTitle_ssim', 'description_tesim', 'geo_subject_ssim',
-                     'orbisBidId_ssim', 'publicatonPlace_ssim', 'publisher_ssim', 'sourceCreated_ssim',
-                     'subjectName_ssim', 'subject_topic_tsim', 'title_tsim']
+                     'identifierShelfMark_tesim', 'orbisBidId_ssim', 'publicatonPlace_ssim', 'publisher_ssim',
+                     'resourceType_tesim', 'sourceCreated_ssim', 'subjectName_ssim', 'subject_topic_tsim', 'title_tsim']
 
     config.add_search_field('all_fields', label: 'All Fields') do |field|
       field.qt = 'search'

--- a/spec/system/highlight_in_search_spec.rb
+++ b/spec/system/highlight_in_search_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe 'Search results displays field', type: :system, clean: true do
       published_vern_ssim: "1997",
       lc_callnum_ssim: "123213213",
       language_ssim: ['en', 'eng', 'zz'],
+      resourceType_tesim: "Music (Printed & Manuscript)",
+      identifierShelfMark_tesim: "Osborn Music MS 4",
       visibility_ssi: 'Public'
     }
   end
@@ -27,6 +29,16 @@ RSpec.describe 'Search results displays field', type: :system, clean: true do
     it 'highlights author when a term is queried' do
       visit '/?search_field=all_fields&q=You'
       expect(page.html).to include "Me and <span class='search-highlight'>You</span>"
+    end
+
+    it 'highlights the resource type when a term is queried' do
+      visit '/?search_field=all_fields&q=Music'
+      expect(page.html).to include "<span class='search-highlight'>Music</span> (Printed & Manuscript)"
+    end
+
+    it 'highlights the call number when a term is queried' do
+      visit '/?search_field=all_fields&q=Music'
+      expect(page.html).to include "Osborn <span class='search-highlight'>Music</span> MS 4"
     end
   end
 end

--- a/spec/system/highlight_in_search_spec.rb
+++ b/spec/system/highlight_in_search_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'Search results displays field', type: :system, clean: true do
     end
 
     it 'highlights the call number when a term is queried' do
-      visit '/?search_field=all_fields&q=music'
+      visit '/?search_field=all_fields&q=Music'
       expect(page.html).to include "Osborn <span class='search-highlight'>Music</span> MS 4"
     end
   end

--- a/spec/system/highlight_in_search_spec.rb
+++ b/spec/system/highlight_in_search_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'Search results displays field', type: :system, clean: true do
     end
 
     it 'highlights the call number when a term is queried' do
-      visit '/?search_field=all_fields&q=Music'
+      visit '/?search_field=all_fields&q=music'
       expect(page.html).to include "Osborn <span class='search-highlight'>Music</span> MS 4"
     end
   end

--- a/spec/system/highlight_in_search_spec.rb
+++ b/spec/system/highlight_in_search_spec.rb
@@ -13,12 +13,12 @@ RSpec.describe 'Search results displays field', type: :system, clean: true do
       id: '111',
       author_tsim: 'Me and You',
       format: 'three dimensional object',
+      identifierShelfMark_tesim: 'Osborn Music MS 4',
       published_ssim: "1997",
       published_vern_ssim: "1997",
       lc_callnum_ssim: "123213213",
       language_ssim: ['en', 'eng', 'zz'],
       resourceType_tesim: "Music (Printed & Manuscript)",
-      identifierShelfMark_tesim: "Osborn Music MS 4",
       visibility_ssi: 'Public'
     }
   end

--- a/spec/system/view_fields_in_search_spec.rb
+++ b/spec/system/view_fields_in_search_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Search results displays field', type: :system, clean: true do
       date_tsim: '1999',
       resourceType_ssim: 'Archives or Manuscripts',
       partOf_ssim: 'Beinecke Library',
-      identifierShelfMark_ssim: 'Beinecke MS 801',
+      identifierShelfMark_tesim: 'Beinecke MS 801',
       imageCount_isi: '23',
       visibility_ssi: 'Public'
     }


### PR DESCRIPTION
Co-authored-by: Eric DeJesus <eric.dejesus@yale.com>

**STORY**
The current [Beinecke site](https://brbl-dl.library.yale.edu/vufind/Search/Results?lookfor=baldwin&type=AllFields&submit=Find&limit=16&sort=relevance) site provide match highlighting.  We want the new system to have this capability too.

**ACCETPANCE**
Highlight search matches when they occur on the following fields:
- [x] Title (see #338) 
- [x] Creator
- [x] ~Date~ *uses facets not search*
- [x] Resource type
- [x] Call Number


-----

We were able to implement the highlighting for resource type and identifier shelfmark.  

![Screen Shot 2020-08-04 at 2.59.33 AM.png](https://images.zenhubusercontent.com/5e6013c029e314c92afd4769/2292095b-d115-469d-af93-183fd8071308)