### PR TITLE
Add an aria label to search form

### DIFF
--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -1,0 +1,27 @@
+<%= form_tag search_action_url, method: :get, class: 'search-query-form', role: 'search', 'aria-label' => t('blacklight.search.form.submit') do %>
+  <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:q, :search_field, :qt, :page, :utf8)) %>
+  <% if search_fields.length > 1 %>
+    <label for="search_field" class="sr-only"><%= t('blacklight.search.form.search_field.label') %></label>
+  <% end %>
+  <div class="input-group">
+    <% if search_fields.length > 1 %>
+        <%= select_tag(:search_field,
+                       options_for_select(search_fields, h(params[:search_field])),
+                       title: t('blacklight.search.form.search_field.title'),
+                       id: "search_field",
+                       class: "custom-select search-field") %>
+    <% elsif search_fields.length == 1 %>
+      <%= hidden_field_tag :search_field, search_fields.first.last %>
+    <% end %>
+
+    <label for="q" class="sr-only"><%= t('blacklight.search.form.search.label') %></label>
+    <%= text_field_tag :q, params[:q], placeholder: t('blacklight.search.form.search.placeholder'), class: "search-q q form-control rounded-#{search_fields.length > 1 ? '0' : 'left'}", id: "q", aria: { label: 'search' }, autocomplete: presenter.autocomplete_enabled? ? "off" : "", autofocus: presenter.autofocus?, data: { autocomplete_enabled: presenter.autocomplete_enabled?, autocomplete_path: search_action_path(action: :suggest) }  %>
+
+    <span class="input-group-append">
+      <button type="submit" class="btn btn-primary search-btn" id="search">
+        <span class="submit-search-text"><%= t('blacklight.search.form.submit') %></span>
+        <%= blacklight_icon :search, aria_hidden: true %>
+      </button>
+    </span>
+  </div>
+<% end %>


### PR DESCRIPTION
# Summary
Add an aria label on the search form

# Related Ticket
[#391](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/391)

# Screenshot
<img width="729" alt="image" src="https://user-images.githubusercontent.com/36549923/89558364-fad64980-d7c8-11ea-9f31-fcc0ee21610c.png">
