### PR TITLE
Add alt tags to social media icons

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -15,19 +15,19 @@
   </div>
   <div class="footer-socmedia">
     <a href="http://yaleuniversity.tumblr.com/" target="_blank">
-      <%= image_tag("soc_media/icon_tumblr.png", {id: 'tumblr'})%>
+      <%= image_tag("soc_media/icon_tumblr.png", {id: 'tumblr', alt: 'Yale University Tumblr'})%>
       <span class="sr-only">Yale University Library on Tumblr</span>
     </a>
     <a href="https://www.instagram.com/yalelibrary" target="_blank">
-      <%= image_tag("soc_media/icon_instagram.png", {id: 'instagram'})%>
+      <%= image_tag("soc_media/icon_instagram.png", {id: 'instagram', alt: 'Yale Library Instagram'})%>
       <span class="sr-only">Yale University Library on Instagram</span>
     </a>
     <a href="https://twitter.com/yalelibrary" target="_blank">
-      <%= image_tag("soc_media/icon_twitter.png", {id: 'twitter'})%>
+      <%= image_tag("soc_media/icon_twitter.png", {id: 'twitter', alt: 'Yale Library Twitter'})%>
     <span class="sr-only">Yale University Library on Twitter</span>
     </a>
     <a href="https://www.facebook.com/yalelibrary" target="_blank">
-      <%= image_tag("soc_media/icon_facebook.png", {id: 'facebook'}) %>
+      <%= image_tag("soc_media/icon_facebook.png", {id: 'facebook', alt: 'Yale Library Facebook'}) %>
       <span class="sr-only">Yale University Library Facebook Page</span>
     </a>
 

--- a/spec/system/footer_spec.rb
+++ b/spec/system/footer_spec.rb
@@ -36,9 +36,9 @@ RSpec.describe 'footer', type: :system do
   end
 
   it 'has expected social media icons images' do
-    expect(page.html).to include('<img id="tumblr" src="/assets/soc_media/icon_tumblr-')
-    expect(page.html).to include('<img id="instagram" src="/assets/soc_media/icon_instagram-')
-    expect(page.html).to include('<img id="twitter" src="/assets/soc_media/icon_twitter-')
-    expect(page.html).to include('<img id="facebook" src="/assets/soc_media/icon_facebook-')
+    expect(page.html).to include('<img id="tumblr" alt="Yale University Tumblr" src="/assets/soc_media/icon_tumblr-')
+    expect(page.html).to include('<img id="instagram" alt="Yale Library Instagram" src="/assets/soc_media/icon_instagram-')
+    expect(page.html).to include('<img id="twitter" alt="Yale Library Twitter" src="/assets/soc_media/icon_twitter-')
+    expect(page.html).to include('<img id="facebook" alt="Yale Library Facebook" src="/assets/soc_media/icon_facebook-')
   end
 end


### PR DESCRIPTION
# Summary
Add alt tags to social media icons in footer.

# Related Ticket
[#400](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/400)

# Screenshot
<img width="507" alt="image" src="https://user-images.githubusercontent.com/36549923/89560034-4853b600-d7cb-11ea-8272-9a19ac429a8f.png">
