### PR TITLE
Make the footer responsive

### DIFF
--- a/app/assets/stylesheets/customOverrides/footer.scss
+++ b/app/assets/stylesheets/customOverrides/footer.scss
@@ -3,15 +3,15 @@ DEFAULT MOBILE STYLING
 ********************************************************/
 
 .branch-name {
-  background-color:$yale_blue!important;
-  color:$white !important;
-  font-size: xx-small;
+  background-color: $yale_blue !important;
+  color: $white !important;
+  font-size: 8px;
   padding: 0px 30px 10px;
 }
 
 .footer-container {
   background-color: $yale_blue;
-  font-family: $malloryMedium!important;
+  font-family: $malloryMedium !important;
   margin-top: 15px;
   position: relative;
   display: flex;
@@ -30,20 +30,18 @@ DEFAULT MOBILE STYLING
   margin: 0px !important;
 }
 
+// hides the link and hover text of the footer logo only
+.footer-logo-wrapper a {
+  color: transparent;
+}
+
 .footer-logo {
   background-size: contain;
   background-position-y: center;
-  color: transparent;
   background-image: image-url('yul_logo/yul_logo3x.png');
   width: 150px;
   background-repeat: no-repeat;
-  display: inline-block;
   height: 50px;
-}
-
-// TODO(alishaevn): disable all hover events on this element
-.footer-logo:hover {
-  pointer-events: none;
 }
 
 .footer-logo > img {
@@ -52,9 +50,8 @@ DEFAULT MOBILE STYLING
 
 .footer-links {
   text-transform: uppercase;
-  line-break:loose;
-  font-size: x-small;
 }
+
 .footer-links a {
   color: $white !important;
   margin-left: 1rem;
@@ -92,16 +89,16 @@ DEFAULT MOBILE STYLING
     padding: 0.5rem 1rem;
   }
 
+  .footer-links li {
+    margin: 15px 0px 0px 16px;
+  }
+
   .footer-logo {
     flex: 0 1 25%;
   }
 
   .footer-logo-wrapper {
     display: flex;
-  }
-
-  .footer-links{
-    -webkit-margin-before: 2em;
-    padding-inline-start: 145px;
+    justify-content: space-between;
   }
 }

--- a/app/assets/stylesheets/customOverrides/footer.scss
+++ b/app/assets/stylesheets/customOverrides/footer.scss
@@ -2,66 +2,66 @@
 DEFAULT MOBILE STYLING
 ********************************************************/
 
+.branch-name {
+  background-color:$yale_blue!important;
+  color:$white !important;
+  font-size: xx-small;
+  padding: 0px 30px 10px;
+}
+
 .footer-container {
   background-color: $yale_blue;
-  //display: grid;
-  height:165px;
-  font-family:$malloryMedium!important;
-  color:$white !important;
-  justify-items: center;
-  padding: 8px 16px;
-
+  font-family: $malloryMedium!important;
+  margin-top: 15px;
+  position: relative;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 1rem;
 }
-.footer-logo {
-  //grid-area: logo;
-  //width: 83%;
-  ////background-size: 100%;
-  //margin-left: -6px;
-  //padding-left: 25%;
-  //margin-left: 7.75rem;
+
+.footer-links > ul {
+  padding: 0px;
+  list-style-type: none;
+}
+
+.footer-links a {
+  margin: 0px !important;
+}
+
+.footer-logo,
+.footer-logo:hover {
   background-size: contain;
   background-position-y: center;
   color: transparent;
   background-image: image-url('yul_logo/yul_logo3x.png');
-  //background-position: center;
-  //background-repeat: no-repeat;
-
+  width: 150px;
+  background-repeat: no-repeat;
+  display: inline-block;
+  height: 50px;
 }
-.footer-logo > img{
+
+.footer-logo > img {
   width: 100%;
 }
 
 .footer-links {
-  //grid-area: links;
   text-transform: uppercase;
   line-break:loose;
-  align-self: center;
-  font-size: smaller;
-  text-align: right;
+  font-size: x-small;
 }
-
-.footer-links a{
+.footer-links a {
   color: $white !important;
   margin-left: 1rem;
 }
-.footer-socmedia{
-  display:table;
-  //grid-area: sm;
-  background-position: left !important;
+
+.footer-socmedia img {
+  width: 1rem;
+  margin-right: 3px;
 }
 
-.footer-socmedia img{
-  width: 1.5rem;
-  margin-left: 0.5rem;
-  //position: relative;
-  //right: 40px;
-}
 
-.branch-name{
-  background-color:$yale_blue!important;
-  color:$white !important;
-  font-size: xx-small;
-}
 @media screen and (min-width: $small_device) {
   //.footer-container {
   //  display: grid;
@@ -73,6 +73,7 @@ DEFAULT MOBILE STYLING
   //  gap: 10px 10px;
   //}
 }
+
 
 @media screen and (min-width: $medium_device) {
   //.footer-container {
@@ -86,6 +87,7 @@ DEFAULT MOBILE STYLING
   //}
 }
 
+
 @media screen and (min-width: $large_device) {
   //.footer-container {
   //  display: grid;
@@ -98,18 +100,26 @@ DEFAULT MOBILE STYLING
   //}
 }
 
+
 @media screen and (min-width: $xlarge_device) {
+  .footer-container {
+    //    display: grid;
+    //    grid-template-columns: 35% 65%;
+    //    grid-template-rows: auto;
+    //    grid-template-areas:
+    //        " logo links . "
+    //        " sm . ";
+    //    gap: 10px 10px;
+    //  padding-left: 10px;
+    position: relative;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.5rem 1rem;
+  }
+
   .footer-logo {
     flex: 0 1 25%;
   }
-  //.footer-container {
-  //    display: grid;
-  //    grid-template-columns: 35% 65%;
-  //    grid-template-rows: auto;
-  //    grid-template-areas:
-  //        " logo links . "
-  //        " sm . ";
-  //    gap: 10px 10px;
-  //  padding-left: 10px;
-  //}
 }

--- a/app/assets/stylesheets/customOverrides/footer.scss
+++ b/app/assets/stylesheets/customOverrides/footer.scss
@@ -95,4 +95,13 @@ DEFAULT MOBILE STYLING
   .footer-logo {
     flex: 0 1 25%;
   }
+
+  .footer-logo-wrapper {
+    display: flex;
+  }
+
+  .footer-links{
+    -webkit-margin-before: 2em;
+    padding-inline-start: 145px;
+  }
 }

--- a/app/assets/stylesheets/customOverrides/footer.scss
+++ b/app/assets/stylesheets/customOverrides/footer.scss
@@ -28,6 +28,7 @@ DEFAULT MOBILE STYLING
 
 .footer-links a {
   margin: 0px !important;
+  font-size: 12px;
 }
 
 // hides the link and hover text of the footer logo only
@@ -70,7 +71,6 @@ DEFAULT MOBILE STYLING
 
   .footer-links li {
     margin-right: 16px;
-    font-size: 12px;
   }
 
   .footer-logo {

--- a/app/assets/stylesheets/customOverrides/footer.scss
+++ b/app/assets/stylesheets/customOverrides/footer.scss
@@ -4,21 +4,27 @@ DEFAULT MOBILE STYLING
 
 .footer-container {
   background-color: $yale_blue;
-  display: grid;
+  //display: grid;
   height:165px;
   font-family:$malloryMedium!important;
   color:$white !important;
   justify-items: center;
-  padding-top: 1rem;
+  padding: 8px 16px;
+
 }
 .footer-logo {
-  grid-area: logo;
-  width: 100%;
-  background-size: 341.25px 37.5px;
-  margin-left: 7.75rem;
+  //grid-area: logo;
+  //width: 83%;
+  ////background-size: 100%;
+  //margin-left: -6px;
+  //padding-left: 25%;
+  //margin-left: 7.75rem;
+  background-size: contain;
+  background-position-y: center;
+  color: transparent;
   background-image: image-url('yul_logo/yul_logo3x.png');
-  background-position: center;
-  background-repeat: no-repeat;
+  //background-position: center;
+  //background-repeat: no-repeat;
 
 }
 .footer-logo > img{
@@ -26,7 +32,7 @@ DEFAULT MOBILE STYLING
 }
 
 .footer-links {
-  grid-area: links;
+  //grid-area: links;
   text-transform: uppercase;
   line-break:loose;
   align-self: center;
@@ -40,14 +46,15 @@ DEFAULT MOBILE STYLING
 }
 .footer-socmedia{
   display:table;
-  grid-area: sm;
+  //grid-area: sm;
   background-position: left !important;
 }
 
 .footer-socmedia img{
   width: 1.5rem;
   margin-left: 0.5rem;
-  position: relative; right: 40px;
+  //position: relative;
+  //right: 40px;
 }
 
 .branch-name{
@@ -55,23 +62,54 @@ DEFAULT MOBILE STYLING
   color:$white !important;
   font-size: xx-small;
 }
-
-@media screen and (min-width: $xlarge_device) {
-  .footer-container {
-      display: grid;
-      grid-template-columns: 15% 20% 50% 15%;
-      grid-template-rows: auto;
-      grid-template-areas:
-          ". logo links ."
-          ". sm . .";
-      gap: 10px 10px;
-  }
+@media screen and (min-width: $small_device) {
+  //.footer-container {
+  //  display: grid;
+  //  grid-template-columns: 15% 20% 50% 15%;
+  //  grid-template-rows: auto;
+  //  grid-template-areas:
+  //        ". logo links ."
+  //        ". sm . .";
+  //  gap: 10px 10px;
+  //}
 }
-
 
 @media screen and (min-width: $medium_device) {
+  //.footer-container {
+  //  display: grid;
+  //  grid-template-columns: 15% 20% 50% 15%;
+  //  grid-template-rows: auto;
+  //  grid-template-areas:
+  //        ". logo links ."
+  //        ". sm . .";
+  //  gap: 10px 10px;
+  //}
 }
 
+@media screen and (min-width: $large_device) {
+  //.footer-container {
+  //  display: grid;
+  //  grid-template-columns: 15% 20% 50% 15%;
+  //  grid-template-rows: auto;
+  //  grid-template-areas:
+  //        ". logo links ."
+  //        ". sm . .";
+  //  gap: 10px 10px;
+  //}
+}
 
 @media screen and (min-width: $xlarge_device) {
+  .footer-logo {
+    flex: 0 1 25%;
+  }
+  //.footer-container {
+  //    display: grid;
+  //    grid-template-columns: 35% 65%;
+  //    grid-template-rows: auto;
+  //    grid-template-areas:
+  //        " logo links . "
+  //        " sm . ";
+  //    gap: 10px 10px;
+  //  padding-left: 10px;
+  //}
 }

--- a/app/assets/stylesheets/customOverrides/footer.scss
+++ b/app/assets/stylesheets/customOverrides/footer.scss
@@ -30,8 +30,7 @@ DEFAULT MOBILE STYLING
   margin: 0px !important;
 }
 
-.footer-logo,
-.footer-logo:hover {
+.footer-logo {
   background-size: contain;
   background-position-y: center;
   color: transparent;
@@ -40,6 +39,11 @@ DEFAULT MOBILE STYLING
   background-repeat: no-repeat;
   display: inline-block;
   height: 50px;
+}
+
+// TODO(alishaevn): disable all hover events on this element
+.footer-logo:hover {
+  pointer-events: none;
 }
 
 .footer-logo > img {
@@ -62,55 +66,24 @@ DEFAULT MOBILE STYLING
 }
 
 
-@media screen and (min-width: $small_device) {
-  //.footer-container {
-  //  display: grid;
-  //  grid-template-columns: 15% 20% 50% 15%;
-  //  grid-template-rows: auto;
-  //  grid-template-areas:
-  //        ". logo links ."
-  //        ". sm . .";
-  //  gap: 10px 10px;
-  //}
-}
-
-
 @media screen and (min-width: $medium_device) {
-  //.footer-container {
-  //  display: grid;
-  //  grid-template-columns: 15% 20% 50% 15%;
-  //  grid-template-rows: auto;
-  //  grid-template-areas:
-  //        ". logo links ."
-  //        ". sm . .";
-  //  gap: 10px 10px;
-  //}
-}
+  .footer-links > ul {
+    display: flex;
+  }
 
+  .footer-links li {
+    margin-right: 16px;
+    font-size: 12px;
+  }
 
-@media screen and (min-width: $large_device) {
-  //.footer-container {
-  //  display: grid;
-  //  grid-template-columns: 15% 20% 50% 15%;
-  //  grid-template-rows: auto;
-  //  grid-template-areas:
-  //        ". logo links ."
-  //        ". sm . .";
-  //  gap: 10px 10px;
-  //}
+  .footer-logo {
+    width: 215px;
+  }
 }
 
 
 @media screen and (min-width: $xlarge_device) {
   .footer-container {
-    //    display: grid;
-    //    grid-template-columns: 35% 65%;
-    //    grid-template-rows: auto;
-    //    grid-template-areas:
-    //        " logo links . "
-    //        " sm . ";
-    //    gap: 10px 10px;
-    //  padding-left: 10px;
     position: relative;
     display: flex;
     flex-wrap: wrap;

--- a/app/assets/stylesheets/customOverrides/header.scss
+++ b/app/assets/stylesheets/customOverrides/header.scss
@@ -13,8 +13,8 @@ DEFAULT MOBILE STYLING
 }
 
 .dropdown-menu {
-  color: $white!important;
-  text-transform: capitalize!important;
+  color: $white !important;
+  text-transform: capitalize !important;
 }
 
 .iiif-logo img {
@@ -36,7 +36,7 @@ DEFAULT MOBILE STYLING
   font-weight: 500;
   font-stretch: normal;
   font-style: normal;
-  font-size: x-small;
+  font-size: 12px;
   line-height: 2.25;
   letter-spacing: normal;
   text-align: right;
@@ -47,9 +47,9 @@ DEFAULT MOBILE STYLING
   transform: rotate(180deg);
   -ms-transform: rotate(180deg);  /*  for IE  */
   -webkit-transform: rotate(180deg); /* for browsers supporting webkit (such as chrome, firefox, safari etc.). */
-  font-size: 16px;
+  font-size: 14px;
   display: inline-block;
-  padding: 3px 3px 0px 0px;
+  padding-top: 3px;
 }
 
 .nav-link-title {
@@ -68,8 +68,8 @@ DEFAULT MOBILE STYLING
 }
 .secondary-nav {
   background-color: $yale_blue;
-  font-family:$malloryMedium!important;
-  color:$white !important;
+  font-family: $malloryMedium !important;
+  color: $white !important;
   font-size: small;
   border-top: $white thin solid;
   align-items: center;
@@ -85,9 +85,9 @@ DEFAULT MOBILE STYLING
 }
 
 .secondary-nav a {
-  color:$white !important;
-  font-size: large;
-  font-family: $yaleRoman!important;
+  color: $white !important;
+  font-size: 16px;
+  font-family: $yaleRoman !important;
 }
 
 
@@ -113,7 +113,7 @@ DEFAULT MOBILE STYLING
   }
 
   .navbar-logo {
-    width: 45%;
+    width: 215px;
   }
 
   .secondary-nav > .row {

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,35 +1,37 @@
 <div class="footer-container">
   <div class="<%= container_classes %>">
-    <%= link_to application_name, root_path, class: 'footer-logo'%>
-    <div class="footer-links">
-      <ul>
-        <li>
-          <a href="http://web.library.yale.edu/gsearch" target="_blank">Search</a>
-        </li>
-        <li>
-          <a href="http://www.library.yale.edu/librarynews" target="_blank">News</a>
-        </li>
-        <li>
-          <a href="http://status.library.yale.edu" target="_blank">Systems Status</a>
-        </li>
-        <li>
-          <a href="http://www.yale.edu/privacy.html" target="_blank">Privacy Policy</a>
-        </li>
-        <li>
-          <a href="https://guides.library.yale.edu/about/policies/access" target="_blank">Terms</a>
-        </li>
-        <!--<% url = request.path() %>-->
-        <% url = request.original_url %>
-        <li>
-          <%= link_to(:"Feedback", "http://web.library.yale.edu/form/findit-feedback?findITURL=#{url}", :target => '_blank' ) %>
-        </li>
-        <li>
-          <a href="https://web.library.yale.edu/data-use" target="_blank">Data Use</a>
-        </li>
-        <li>
-          <a href="https://usability.yale.edu/web-accessibility/accessibility-yale" target="_blank">Accessibility</a>
-        </li>
-      </ul>
+    <div class="footer-logo-wrapper">
+     <%= link_to application_name, root_path, class: 'footer-logo'%>
+      <div class="footer-links">
+        <ul>
+          <li>
+            <a href="http://web.library.yale.edu/gsearch" target="_blank">Search</a>
+          </li>
+          <li>
+            <a href="http://www.library.yale.edu/librarynews" target="_blank">News</a>
+          </li>
+          <li>
+            <a href="http://status.library.yale.edu" target="_blank">Systems Status</a>
+          </li>
+          <li>
+            <a href="http://www.yale.edu/privacy.html" target="_blank">Privacy Policy</a>
+          </li>
+          <li>
+            <a href="https://guides.library.yale.edu/about/policies/access" target="_blank">Terms</a>
+          </li>
+          <!--<% url = request.path() %>-->
+          <% url = request.original_url %>
+          <li>
+            <%= link_to(:"Feedback", "http://web.library.yale.edu/form/findit-feedback?findITURL=#{url}", :target => '_blank' ) %>
+          </li>
+          <li>
+            <a href="https://web.library.yale.edu/data-use" target="_blank">Data Use</a>
+          </li>
+          <li>
+            <a href="https://usability.yale.edu/web-accessibility/accessibility-yale" target="_blank">Accessibility</a>
+          </li>
+        </ul>
+      </div>
     </div>
     <div class="footer-socmedia">
       <a href="http://yaleuniversity.tumblr.com/" target="_blank">

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,17 +1,35 @@
 <div class="footer-container">
   <div class="<%= container_classes %>">
-    <%= link_to application_name, root_path, class: 'mb-0 footer-logo'%>
+    <%= link_to application_name, root_path, class: 'footer-logo'%>
     <div class="footer-links">
-      <span><a href="http://web.library.yale.edu/gsearch" target="_blank">Search</a></span>
-      <span><a href="http://www.library.yale.edu/librarynews" target="_blank">News</a></span>
-      <span><a href="http://status.library.yale.edu" target="_blank">Systems Status</a></span>
-      <span><a href="http://www.yale.edu/privacy.html" target="_blank">Privacy Policy</a></span>
-      <span><a href="https://guides.library.yale.edu/about/policies/access" target="_blank">Terms</a></span>
-      <!--<% url = request.path() %>-->
-      <% url = request.original_url %>
-      <span><%= link_to(:"Feedback", "http://web.library.yale.edu/form/findit-feedback?findITURL=#{url}", :target => '_blank' ) %></span>
-      <span><a href="https://web.library.yale.edu/data-use" target="_blank">Data Use</a></span>
-      <span><a href="https://usability.yale.edu/web-accessibility/accessibility-yale" target="_blank">Accessibility</a></span>
+      <ul>
+        <li>
+          <a href="http://web.library.yale.edu/gsearch" target="_blank">Search</a>
+        </li>
+        <li>
+          <a href="http://www.library.yale.edu/librarynews" target="_blank">News</a>
+        </li>
+        <li>
+          <a href="http://status.library.yale.edu" target="_blank">Systems Status</a>
+        </li>
+        <li>
+          <a href="http://www.yale.edu/privacy.html" target="_blank">Privacy Policy</a>
+        </li>
+        <li>
+          <a href="https://guides.library.yale.edu/about/policies/access" target="_blank">Terms</a>
+        </li>
+        <!--<% url = request.path() %>-->
+        <% url = request.original_url %>
+        <li>
+          <%= link_to(:"Feedback", "http://web.library.yale.edu/form/findit-feedback?findITURL=#{url}", :target => '_blank' ) %>
+        </li>
+        <li>
+          <a href="https://web.library.yale.edu/data-use" target="_blank">Data Use</a>
+        </li>
+        <li>
+          <a href="https://usability.yale.edu/web-accessibility/accessibility-yale" target="_blank">Accessibility</a>
+        </li>
+      </ul>
     </div>
     <div class="footer-socmedia">
       <a href="http://yaleuniversity.tumblr.com/" target="_blank">

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,36 +1,36 @@
 <div class="footer-container">
-  <div class="footer-logo">
-  </div>
-  <div class="footer-links">
-    <span><a href="http://web.library.yale.edu/gsearch" target="_blank">Search</a></span>
-    <span><a href="http://www.library.yale.edu/librarynews" target="_blank">News</a></span>
-    <span><a href="http://status.library.yale.edu" target="_blank">Systems Status</a></span>
-    <span><a href="http://www.yale.edu/privacy.html" target="_blank">Privacy Policy</a></span>
-    <span><a href="https://guides.library.yale.edu/about/policies/access" target="_blank">Terms</a></span>
-    <!--<% url = request.path() %>-->
-    <% url = request.original_url %>
-    <span><%= link_to(:"Feedback", "http://web.library.yale.edu/form/findit-feedback?findITURL=#{url}", :target => '_blank' ) %></span>
-    <span><a href="https://web.library.yale.edu/data-use" target="_blank">Data Use</a></span>
-    <span><a href="https://usability.yale.edu/web-accessibility/accessibility-yale" target="_blank">Accessibility</a></span>
-  </div>
-  <div class="footer-socmedia">
-    <a href="http://yaleuniversity.tumblr.com/" target="_blank">
-      <%= image_tag("soc_media/icon_tumblr.png", {id: 'tumblr'})%>
-      <span class="sr-only">Yale University Library on Tumblr</span>
-    </a>
-    <a href="https://www.instagram.com/yalelibrary" target="_blank">
-      <%= image_tag("soc_media/icon_instagram.png", {id: 'instagram'})%>
-      <span class="sr-only">Yale University Library on Instagram</span>
-    </a>
-    <a href="https://twitter.com/yalelibrary" target="_blank">
-      <%= image_tag("soc_media/icon_twitter.png", {id: 'twitter'})%>
-    <span class="sr-only">Yale University Library on Twitter</span>
-    </a>
-    <a href="https://www.facebook.com/yalelibrary" target="_blank">
-      <%= image_tag("soc_media/icon_facebook.png", {id: 'facebook'}) %>
-      <span class="sr-only">Yale University Library Facebook Page</span>
-    </a>
-
+  <div class="<%= container_classes %>">
+    <%= link_to application_name, root_path, class: 'mb-0 footer-logo'%>
+    <div class="footer-links">
+      <span><a href="http://web.library.yale.edu/gsearch" target="_blank">Search</a></span>
+      <span><a href="http://www.library.yale.edu/librarynews" target="_blank">News</a></span>
+      <span><a href="http://status.library.yale.edu" target="_blank">Systems Status</a></span>
+      <span><a href="http://www.yale.edu/privacy.html" target="_blank">Privacy Policy</a></span>
+      <span><a href="https://guides.library.yale.edu/about/policies/access" target="_blank">Terms</a></span>
+      <!--<% url = request.path() %>-->
+      <% url = request.original_url %>
+      <span><%= link_to(:"Feedback", "http://web.library.yale.edu/form/findit-feedback?findITURL=#{url}", :target => '_blank' ) %></span>
+      <span><a href="https://web.library.yale.edu/data-use" target="_blank">Data Use</a></span>
+      <span><a href="https://usability.yale.edu/web-accessibility/accessibility-yale" target="_blank">Accessibility</a></span>
+    </div>
+    <div class="footer-socmedia">
+      <a href="http://yaleuniversity.tumblr.com/" target="_blank">
+        <%= image_tag("soc_media/icon_tumblr.png", {id: 'tumblr'})%>
+        <span class="sr-only">Yale University Library on Tumblr</span>
+      </a>
+      <a href="https://www.instagram.com/yalelibrary" target="_blank">
+        <%= image_tag("soc_media/icon_instagram.png", {id: 'instagram'})%>
+        <span class="sr-only">Yale University Library on Instagram</span>
+      </a>
+      <a href="https://twitter.com/yalelibrary" target="_blank">
+        <%= image_tag("soc_media/icon_twitter.png", {id: 'twitter'})%>
+      <span class="sr-only">Yale University Library on Twitter</span>
+      </a>
+      <a href="https://www.facebook.com/yalelibrary" target="_blank">
+        <%= image_tag("soc_media/icon_facebook.png", {id: 'facebook'}) %>
+        <span class="sr-only">Yale University Library Facebook Page</span>
+      </a>
+    </div>
   </div>
 </div>
 <div class="branch-name">

--- a/spec/system/footer_spec.rb
+++ b/spec/system/footer_spec.rb
@@ -7,13 +7,14 @@ RSpec.describe 'footer', type: :system do
   end
 
   it 'has css' do
+    expect(page).to have_css '.branch-name'
     expect(page).to have_css '.footer-container'
     expect(page).to have_css '.footer-logo'
     expect(page).to have_css '.footer-links'
     expect(page).to have_css '.footer-links a'
     expect(page).to have_css '.footer-socmedia'
     expect(page).to have_css '.footer-socmedia img'
-    expect(page).to have_css '.branch-name'
+    expect(page).to have_css '.footer-logo-wrapper a'
   end
 
   it 'has links' do


### PR DESCRIPTION
Co-authored by: Frederick Rodriguez <frederick.rodriguez@yale.edu>

# Story
The footer logo, links and social media icons don't display correctly on any screens smaller than 1700 px wide. The details either overlap, or are cut off

# Expected Behavior
- on devices 767px and smaller, all footer elements are stacked vertically, including the footer links
- on devices 768 px to 1199 px wide, the footer elements are stacked vertically but the links are in a row
- on devices 1200px and wider, the yale logo and links are in the same row. the social media links are beneath the yale logo
- the "branch" info isn't always aligned with the other content to keep it out of the way since it will be deleted
- clicking the yale logo in the footer redirects to the home page
- hovering over the yale logo in the footer doesn't display the yale text

# Demo
![i403](https://user-images.githubusercontent.com/29032869/89564308-a84d5b00-d7d1-11ea-8caf-fc140265e6ba.gif)
