### PR TITLE
Fix header content height on condensed view

### DIFF
--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -370,25 +370,33 @@
         var oldAddClass = $.fn.addClass;
         $.fn.addClass = function() {
             for (var i in arguments) {
-                var arg = arguments[i];
+                var arg = arguments[i]
                 if (!!(arg && arg.constructor && arg.call && arg.apply)) {
-                    setTimeout(arg.bind(this));
-                    delete arguments[i];
+                    setTimeout(arg.bind(this))
+                    delete arguments[i]
                 }
             }
-            return oldAddClass.apply(this, arguments);
+            return oldAddClass.apply(this, arguments)
         }
 
-    })(jQuery);
+    })(jQuery)
 
     // show and hide the dropdown links properly
     $(document).ready(function() {
         $('.secondary-nav .nav-link-title').click(function(e) {
+            const width = window.innerWidth
+                || document.documentElement.clientWidth
+                || document.body.clientWidth
+
             $('.secondary-nav .content-yul').addClass('content-show', function() {
                 const contentBlock = $('.secondary-nav .dropdown.show .menu-block-wrapper')[0]
 
                 if (contentBlock) {
-                    $('.content-yul').height(contentBlock.offsetHeight + 20)
+                    if (width >= 1200) {
+                        $('.content-yul').height(contentBlock.offsetHeight + 20)
+                    } else {
+                        $('.secondary-nav .dropdown.show .content-yul').height(contentBlock.offsetHeight + 20)
+                    }
                 } else {
                     $('.content-yul').height(0)
                 }

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -367,10 +367,10 @@
 <script>
     // override the addClass method so that a callback can be used
     (function($) {
-        var oldAddClass = $.fn.addClass;
+        let oldAddClass = $.fn.addClass;
         $.fn.addClass = function() {
-            for (var i in arguments) {
-                var arg = arguments[i]
+            for (let i in arguments) {
+                let arg = arguments[i]
                 if (!!(arg && arg.constructor && arg.call && arg.apply)) {
                     setTimeout(arg.bind(this))
                     delete arguments[i]
@@ -395,7 +395,9 @@
                     if (width >= 1200) {
                         $('.content-yul').height(contentBlock.offsetHeight + 20)
                     } else {
+                        // on devices smaller than 1200px wide, only show the item that was clicked on
                         $('.secondary-nav .dropdown.show .content-yul').height(contentBlock.offsetHeight + 20)
+                        $('.secondary-nav .dropdown:not(.show) .content-yul').height(0)
                     }
                 } else {
                     $('.content-yul').height(0)


### PR DESCRIPTION
# Ticket 
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/414

# Summary
- When a user clicks on a submenu link on devices smaller than 1200px wide, it only displays a blue box underneath the selected menu item
- When a user clicks on a submenu item on devices 1200px wide and greater, it still displays a blue box underneath all links

# Demo
![i414](https://user-images.githubusercontent.com/29032869/89580671-8f9d6f00-d7ea-11ea-9c74-1a2b14206321.gif)