### PR TITLE
Relocate tools and links to bottom of page

### DIFF
--- a/app/views/catalog/_show_main_content.html.erb
+++ b/app/views/catalog/_show_main_content.html.erb
@@ -25,3 +25,7 @@
   -->
   <span class="Z3988" title="<%= @document.export_as_openurl_ctx_kev(document_partial_name(@document)) %>"></span>
 <% end %>
+
+<%= render 'show_tools' %>
+
+<%= render 'show_links' %>

--- a/app/views/catalog/_show_sidebar.html.erb
+++ b/app/views/catalog/_show_sidebar.html.erb
@@ -1,8 +1,3 @@
-<%= render 'show_tools' %>
-
-<%# override blacklight-7.7.0 show_sidebar.html.erb to add links %>
-<%= render 'show_links' %>
-
 <% unless document.more_like_this.empty? %>
   <div class="card">
     <div class="card-header">More Like This</div>


### PR DESCRIPTION
# Summary
Move the tools and links from the top right hand corner to below the metadata information on the single item show page.

# Related Ticket
#427
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/427

# Screenshot

![image](https://user-images.githubusercontent.com/36549923/89936874-2b532480-dbc9-11ea-961b-fd195eb5e73f.png)
