### PR TITLE
Removed bookmark checkbox on research and item page

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -34,13 +34,15 @@ class CatalogController < ApplicationController
     # config.index.display_type_field = 'format'
     config.index.thumbnail_method = :render_thumbnail
 
-    config.add_results_document_tool(:bookmark, partial: 'bookmark_control', if: :render_bookmarks_control?)
+    # Remove bookmark functionality from the research page
+    # config.add_results_document_tool(:bookmark, partial: 'bookmark_control', if: :render_bookmarks_control?)
 
     config.add_results_collection_tool(:sort_widget)
     config.add_results_collection_tool(:per_page_widget)
     config.add_results_collection_tool(:view_type_group)
 
-    config.add_show_tools_partial(:bookmark, partial: 'bookmark_control', if: :render_bookmarks_control?)
+    # Remove bookmark functionality from the item page
+    # config.add_show_tools_partial(:bookmark, partial: 'bookmark_control', if: :render_bookmarks_control?)
     config.add_show_tools_partial(:email, callback: :email_action, validator: :validate_email_params)
     config.add_show_tools_partial(:sms, if: :render_sms_action?, callback: :sms_action, validator: :validate_sms_params)
     config.add_show_tools_partial(:citation)

--- a/spec/system/user_authentication_spec.rb
+++ b/spec/system/user_authentication_spec.rb
@@ -22,11 +22,11 @@ RSpec.describe 'User Authentication', type: :system, js: false, clean: true do
       login_as(user, scope: :user)
 
       visit '/catalog/1'
-      check 'Bookmark'
+      # check 'Bookmark'
       logout(:user)
       login_as(user, scope: :user)
 
       expect(page).to have_content 'bookmark'
-    end
+    end.to_s
   end
 end


### PR DESCRIPTION
We've decided to remove the ability to retrieve bookmarks and removed the corresponding link from the header, but we still have bookmark checkboxes displaying in search results.  This gives the incorrect impression that users can save bookmarks within the application to retrieve later.

**ACCETPANCE**
- [x] Users do not have the option to bookmark items within search results
- [x] Users do not have the option to bookmark items in the toolbox

<img width="926" alt="image" src="https://user-images.githubusercontent.com/3064318/89922137-3e172a80-dbc4-11ea-977d-dab9be454fbe.png">

<img width="909" alt="image" src="https://user-images.githubusercontent.com/3064318/89922308-79195e00-dbc4-11ea-80ee-7b55a4826ed1.png">
