### PR TITLE
Remove excess whitespace in Safari

### DIFF
--- a/app/assets/stylesheets/customOverrides/search_result.scss
+++ b/app/assets/stylesheets/customOverrides/search_result.scss
@@ -28,4 +28,17 @@ DEFAULT MOBILE STYLING
 
 
 @media screen and (min-width: $xlarge_device) {
+
+  .dl-invert dt {
+    position: absolute;
+  }
+
+  .col-md-9{
+    padding-left: 25%;
+  }
+
+  .document-metadata{
+    max-width: 55%;
+    margin-bottom: 3%;
+  }
 }

--- a/app/assets/stylesheets/customOverrides/search_result.scss
+++ b/app/assets/stylesheets/customOverrides/search_result.scss
@@ -2,6 +2,10 @@
 DEFAULT MOBILE STYLING
 ********************************************************/
 
+.document-metadata {
+  position: absolute;
+}
+
 .search-highlight {
   background-color: yellow;
 }

--- a/app/assets/stylesheets/customOverrides/search_result.scss
+++ b/app/assets/stylesheets/customOverrides/search_result.scss
@@ -26,6 +26,28 @@ DEFAULT MOBILE STYLING
 @media screen and (min-width: $medium_device) {
   .dl-invert dt {
     position: absolute;
+    width: 100%;
+    padding-right: 15px;
+    padding-left: 0px!important;
+  }
+
+  .document-metadata {
+    max-width: 55%;
+    margin-bottom: 3%;
+  }
+
+  .col-md-9 {
+    padding-left: 25%;
+  }
+}
+
+@media screen and (min-width: $large_device) {
+
+  .dl-invert dt {
+    position: absolute;
+    width: 100%;
+    padding-right: 15px;
+    padding-left: 0px!important;
   }
 
   .document-metadata {

--- a/app/assets/stylesheets/customOverrides/search_result.scss
+++ b/app/assets/stylesheets/customOverrides/search_result.scss
@@ -2,16 +2,16 @@
 DEFAULT MOBILE STYLING
 ********************************************************/
 
-.dt{
-  position: relative;
-}
-
-.dd{
+.dd {
   margin-left:  22%;
   text-align: justify;
 }
 
-.document-metadata{
+.dt {
+  position: relative;
+}
+
+.document-metadata {
   display: contents;
   position: static;
   max-width: 55%;
@@ -24,8 +24,19 @@ DEFAULT MOBILE STYLING
 
 
 @media screen and (min-width: $medium_device) {
-}
+  .dl-invert dt {
+    position: absolute;
+  }
 
+  .document-metadata {
+    max-width: 55%;
+    margin-bottom: 3%;
+  }
+
+  .col-md-9 {
+    padding-left: 25%;
+  }
+}
 
 @media screen and (min-width: $xlarge_device) {
 
@@ -33,12 +44,12 @@ DEFAULT MOBILE STYLING
     position: absolute;
   }
 
-  .col-md-9{
-    padding-left: 25%;
-  }
-
-  .document-metadata{
+  .document-metadata {
     max-width: 55%;
     margin-bottom: 3%;
+  }
+
+  .col-md-9 {
+    padding-left: 25%;
   }
 }

--- a/app/assets/stylesheets/customOverrides/search_result.scss
+++ b/app/assets/stylesheets/customOverrides/search_result.scss
@@ -4,6 +4,8 @@ DEFAULT MOBILE STYLING
 
 .document-metadata {
   position: absolute;
+  flex: 0 0 75%;
+  max-width: 75%;
 }
 
 .search-highlight {

--- a/app/assets/stylesheets/customOverrides/search_result.scss
+++ b/app/assets/stylesheets/customOverrides/search_result.scss
@@ -2,10 +2,20 @@
 DEFAULT MOBILE STYLING
 ********************************************************/
 
-.document-metadata {
-  position: absolute;
-  flex: 0 0 75%;
-  max-width: 75%;
+.dt{
+  position: relative;
+}
+
+.dd{
+  margin-left:  22%;
+  text-align: justify;
+}
+
+.document-metadata{
+  display: contents;
+  position: static;
+  max-width: 55%;
+  margin-bottom: 3%;
 }
 
 .search-highlight {

--- a/spec/system/search_result_spec.rb
+++ b/spec/system/search_result_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rails_helper'
 
 RSpec.describe 'search result', type: :system do

--- a/spec/system/search_result_spec.rb
+++ b/spec/system/search_result_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe 'search result', type: :system do
   end
 
   it 'has expected css' do
+    expect(page).to have_css '.dl-invert'
     expect(page).to have_css '.document-metadata'
   end
 end

--- a/spec/system/search_result_spec.rb
+++ b/spec/system/search_result_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe 'search result', type: :system do
+  before do
+    visit '/?search_field=all_fields&q='
+  end
+
+  it 'has expected css' do
+    expect(page).to have_css '.document-metadata'
+  end
+end


### PR DESCRIPTION
In Safari, there is excess whitespace between the title and the metadata on the search results screen

- [x] The whitespace between the header and the metadata in the search results screen should look the same as it does in firefox and chrome

![Screen Shot 2020-08-04 at 1.24.34 PM.png](https://images.zenhubusercontent.com/5ca3a84155cfe32f2f66b74c/cf28a524-2ba9-4fbe-9fd0-607a9ae2a610)