### PR TITLE
Remove duplicate title listing

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -125,7 +125,6 @@ class CatalogController < ApplicationController
     config.add_index_field 'imageCount_isi', label: 'Image Count'
     config.add_index_field 'partOf_ssim', label: 'Collection Name'
     config.add_index_field 'resourceType_tesim', label: 'Resource Type', highlight: true
-    config.add_index_field 'title_tesim', label: 'Title', highlight: true
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display

--- a/spec/system/highlight_in_search_spec.rb
+++ b/spec/system/highlight_in_search_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe 'Search results displays field', type: :system, clean: true do
   let(:dog) do
     {
       id: '111',
-      title_tesim: "It's All About Us!",
       author_tsim: 'Me and You',
       format: 'three dimensional object',
       identifierShelfMark_tesim: 'Osborn Music MS 4',
@@ -26,11 +25,6 @@ RSpec.describe 'Search results displays field', type: :system, clean: true do
 
   context 'Within search results' do
     subject(:content) { find(:css, '#content') }
-
-    it 'highlights title when a term is queried' do
-      visit '/?search_field=all_fields&q=All'
-      expect(page.html).to include "It's <span class='search-highlight'>All</span> About Us!"
-    end
 
     it 'highlights author when a term is queried' do
       visit '/?search_field=all_fields&q=You'


### PR DESCRIPTION
# Ticket
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/422

# Expected Behavior
- The "Title" property doesn't show up in search results
- The highlighting spec doesn't reference the "Title"

# Demo
![image](https://user-images.githubusercontent.com/29032869/90039301-4c744d80-dc7b-11ea-8099-4be12c403fe8.png)
