### PR TITLE
Facet styling

### DIFF
--- a/app/assets/stylesheets/customOverrides/facets.scss
+++ b/app/assets/stylesheets/customOverrides/facets.scss
@@ -1,0 +1,40 @@
+/********************************************************
+DEFAULT MOBILE STYLING
+********************************************************/
+
+a.facet-select {
+  color: $light_blue;
+  font-size: 12px;
+}
+
+div.card {
+  margin-bottom: 5px;
+}
+
+.facet-limit .card-body {
+  padding-bottom: 5px;
+  padding-top: 5px;
+}
+
+#facet-panel-collapse {
+  font-family: $mallory_medium;
+  line-height: 1.69;
+}
+
+.facet-values .facet-label {
+  padding-right: 0px;
+  padding-bottom: 0px;
+  padding-left: 10px;
+}
+
+.facet-values .facet-count {
+  font-size: 12px;
+  color: $medium_grey;
+}
+
+h2.facets-heading {
+  font-family: $mallory_medium;
+  font-size: 0.9rem;
+  font-weight: 900;
+  line-height: 1.71;
+}


### PR DESCRIPTION
# Ticket
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/428

# Expected Behavior
- 'Limit your search' has a font weight of 900, but is not as bold as in the design because we don't have the Mallory Black font
- 'Limit your search' is in the Mallory Medium font
- Facet headers are in the Mallory Medium font
- The facet titles and drop down items match the look of the design, but aren't the exact font-sizes in the design. If they were, they'd be too small
- Reduced the space between facet headers. It isn't exactly 16px between them though because the styles that were inherited from the blacklight app are set with `!important` so they can't be overridden.

# Demo
![image](https://user-images.githubusercontent.com/29032869/90196434-9dba3500-dd80-11ea-8fde-4d2e165ca41a.png)