### PR TITLE
Enable selection of UV settings

### DIFF
--- a/app/assets/stylesheets/customOverrides/main.scss
+++ b/app/assets/stylesheets/customOverrides/main.scss
@@ -87,6 +87,11 @@ a {
 	color: $light_blue !important;
 }
 
+.universal-viewer-iframe {
+	position: relative;
+	z-index: 1;
+}
+
 @media screen and (min-width: $medium_device) {
 }
 

--- a/app/views/catalog/_show_main_content.html.erb
+++ b/app/views/catalog/_show_main_content.html.erb
@@ -29,3 +29,14 @@
 <%= render 'show_tools' %>
 
 <%= render 'show_links' %>
+
+<% unless @document.more_like_this.empty? %>
+  <div class="card">
+    <div class="card-header">More Like This</div>
+    <div class="card-body">
+    <%= render collection: document.more_like_this,
+                partial: 'show_more_like_this',
+                as: :document %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/catalog/_show_sidebar.html.erb
+++ b/app/views/catalog/_show_sidebar.html.erb
@@ -1,10 +1,4 @@
-<% unless document.more_like_this.empty? %>
-  <div class="card">
-    <div class="card-header">More Like This</div>
-    <div class="card-body">
-      <%= render collection: document.more_like_this,
-                 partial: 'show_more_like_this',
-                 as: :document %>
-    </div>
-  </div>
-<% end %>
+<!--
+sidebar content moved to below main content
+find in _show_main_content.html.erb
+-->


### PR DESCRIPTION
# Summary
The tools in the sidebar were moved below the main content but a bug was introduced - the settings, gallery, and more information elements in the UV viewer were unable to be selected because the sidebar was still covering that section.

# Expected Behavior
A user can now select the UV settings that were previously unable to be selected.

# Screenshots
On hover now that the elements are able to be selected again a user can see the gallery and settings options for the UV viewer.
<img width="231" alt="image" src="https://user-images.githubusercontent.com/36549923/90431611-29340e80-e07e-11ea-8aaf-538d14d7ec9f.png">
<img width="205" alt="image" src="https://user-images.githubusercontent.com/36549923/90431643-35b86700-e07e-11ea-8df1-2a6d32804ad4.png">
