### PR TITLE
Added the Blacklight Gallery view

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ ruby '2.6.6'
 gem "actionpack", ">= 6.0.3.1"
 gem 'awesome_print'
 gem 'blacklight'
+gem 'blacklight-gallery'
 gem 'blacklight-marc', '>= 7.0.0.rc1', '< 8'
 gem 'blacklight_range_limit'
 gem 'bootsnap', '>= 1.4.2', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,11 @@ GEM
       kaminari (>= 0.15)
       rails (>= 5.1, < 7)
       view_component
+    blacklight-gallery (2.1.0)
+      blacklight (~> 7.7)
+      bootstrap (~> 4.0)
+      openseadragon (>= 0.2.0)
+      rails (>= 5.1, < 7)
     blacklight-marc (7.0.0.rc1)
       blacklight (> 7.0.0.a, < 8.a)
       library_stdnums
@@ -258,6 +263,8 @@ GEM
       addressable (~> 2.3)
       nokogiri (~> 1.5)
       omniauth (~> 1.2)
+    openseadragon (0.5.0)
+      rails (> 3.2.0)
     orm_adapter (0.5.0)
     parallel (1.19.1)
     parser (2.7.1.3)
@@ -475,6 +482,7 @@ DEPENDENCIES
   axe-matchers
   bixby (~> 3.0.0)
   blacklight
+  blacklight-gallery
   blacklight-marc (>= 7.0.0.rc1, < 8)
   blacklight_range_limit
   bootsnap (>= 1.4.2)

--- a/app/assets/javascripts/blacklight_gallery.js
+++ b/app/assets/javascripts/blacklight_gallery.js
@@ -1,0 +1,1 @@
+//= require blacklight_gallery/default

--- a/app/assets/javascripts/openseadragon.js
+++ b/app/assets/javascripts/openseadragon.js
@@ -1,0 +1,2 @@
+//= require openseadragon/openseadragon
+//= require openseadragon/rails

--- a/app/assets/stylesheets/blacklight_gallery.css.scss
+++ b/app/assets/stylesheets/blacklight_gallery.css.scss
@@ -1,0 +1,3 @@
+/*
+ *= require blacklight_gallery/default
+ */

--- a/app/assets/stylesheets/openseadragon.css
+++ b/app/assets/stylesheets/openseadragon.css
@@ -1,0 +1,3 @@
+/*
+ *= require openseadragon/openseadragon
+ */

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  helper Openseadragon::OpenseadragonHelper
   # Adds a few additional behaviors into the application controller
   include Blacklight::Controller
   include HttpAuthConcern

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -5,6 +5,10 @@ class CatalogController < ApplicationController
   include Blacklight::Marc::Catalog
 
   configure_blacklight do |config|
+    config.view.gallery.partials = [:index_header]
+    config.show.tile_source_field = :content_metadata_image_iiif_info_ssm
+    config.show.partials.insert(1, :openseadragon)
+
     ## Class for sending and receiving requests from a search index
     # config.repository_class = Blacklight::Solr::Repository
     #

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -3,7 +3,6 @@ class SolrDocument
   include Blacklight::Solr::Document
   include Blacklight::Gallery::OpenseadragonSolrDocument
 
-
   # # The following shows how to setup this blacklight document to display marc documents
   # extension_parameters[:marc_source_field] = :marc_ss
   # extension_parameters[:marc_format_type] = :marcxml

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 class SolrDocument
   include Blacklight::Solr::Document
+  include Blacklight::Gallery::OpenseadragonSolrDocument
+
 
   # # The following shows how to setup this blacklight document to display marc documents
   # extension_parameters[:marc_source_field] = :marc_ss


### PR DESCRIPTION
Co-authored-by: Alisha Evans <alisha@notch8.com>


As a scholar, I'm interested in the visual characteristics of works, and would like to be able to view search results in a way that allows me to see more thumbnails on the screen at one time

**DEVELOPER HINT**
Implemented the [Blacklight Gallery](https://github.com/projectblacklight/blacklight-gallery#blacklightgallery) gem.

**ACCEPTANCE**
- [x] I can toggle search results between list and gallery views
  - [x] If using blacklight-gallery, remove slide-show and mortar view options
- [x] Gallery views should include
  - [x] The thumbnail for the work (as a link to the work)
  - [x] The item title (as a link to the work)

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/41123693/90679795-b1f1ac80-e22e-11ea-8189-18876c20519f.gif)
