### PR TITLE
Adds BugHerd user feedback tracking

### DIFF
--- a/app/views/catalog/_show_main_content.html.erb
+++ b/app/views/catalog/_show_main_content.html.erb
@@ -1,3 +1,7 @@
+<!-- For BugHerd user feedback issue tracking -->
+<script type="text/javascript" src="https://www.bugherd.com/sidebarv2.js?apikey=1ws6agf4j61dyolkgxnxaa" async="true"></script>
+<!-- end of BugHerd customization -->
+
 <%= render 'previous_next_doc' if @search_context %>
 
 <% @page_title = t('blacklight.search.show.title', :document_title => document_show_html_title, :application_name => application_name).html_safe %>

--- a/app/views/layouts/blacklight.html.erb
+++ b/app/views/layouts/blacklight.html.erb
@@ -1,0 +1,22 @@
+<% content_for(:content) do %>
+
+	<!-- For BugHerd user feedback issue tracking -->
+	<script type="text/javascript" src="https://www.bugherd.com/sidebarv2.js?apikey=1ws6agf4j61dyolkgxnxaa" async="true"></script>
+  <!-- end of BugHerd customization -->
+
+	<% if content_for? :sidebar %>
+    <section id="content" class="<%= main_content_classes %> order-last" aria-label="<%= t('blacklight.search.documents.aria.search_results') %>">
+      <%= yield %>
+    </section>
+
+    <section id="sidebar" class="<%= sidebar_classes %> order-first" aria-label="<%= t('blacklight.search.documents.aria.limit_search') %>">
+      <%= content_for(:sidebar) %>
+    </section>
+  <% else %>
+    <section class="col-md-12">
+      <%= yield %>
+    </section>
+  <% end %>
+<% end %>
+
+<%= render template: "layouts/blacklight/base" %>


### PR DESCRIPTION
# Summary 
Adds JavaScript snippet for use of BugHerd in tracking user feedback.

# Related Ticket
#453 - [ZenHub Link](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/453)

# Screenshots
### Home Page
<img width="861" alt="image" src="https://user-images.githubusercontent.com/36549923/90806059-604e2e00-e2d1-11ea-9462-7513ca8dfce2.png">

### Search Results Page
<img width="860" alt="image" src="https://user-images.githubusercontent.com/36549923/90806129-72c86780-e2d1-11ea-98ae-1b91301fb37a.png">

### Single Item Show Page
<img width="861" alt="image" src="https://user-images.githubusercontent.com/36549923/90806189-84117400-e2d1-11ea-8504-f76aefeffaa9.png">
