### PR TITLE
Add font-family fallbacks

### DIFF
--- a/app/assets/stylesheets/customOverrides/facets.scss
+++ b/app/assets/stylesheets/customOverrides/facets.scss
@@ -17,7 +17,7 @@ div.card {
 }
 
 #facet-panel-collapse {
-  font-family: $mallory_medium;
+  font-family: $mallory_mp_medium, $mallory_medium, Arial, Helvetica, sans-serif;
   line-height: 1.69;
 }
 
@@ -33,7 +33,7 @@ div.card {
 }
 
 h2.facets-heading {
-  font-family: $mallory_medium;
+  font-family: $mallory_mp_black, $mallory_medium, Arial, Helvetica, sans-serif;
   font-size: 0.9rem;
   font-weight: 900;
   line-height: 1.71;

--- a/app/assets/stylesheets/customOverrides/footer.scss
+++ b/app/assets/stylesheets/customOverrides/footer.scss
@@ -11,7 +11,7 @@ DEFAULT MOBILE STYLING
 
 .footer-container {
   background-color: $yale_blue;
-  font-family: $mallory_medium !important;
+  font-family: $mallory_mp_medium, $mallory_medium, Arial, Helvetica, sans-serif !important;
   margin-top: 15px;
   position: relative;
   display: flex;

--- a/app/assets/stylesheets/customOverrides/header.scss
+++ b/app/assets/stylesheets/customOverrides/header.scss
@@ -70,7 +70,6 @@ DEFAULT MOBILE STYLING
 
 .secondary-nav {
   background-color: $yale_blue;
-  // font-family: $mallory_medium !important;
   color: $white !important;
   font-size: small;
   border-top: $white thin solid;

--- a/app/assets/stylesheets/customOverrides/header.scss
+++ b/app/assets/stylesheets/customOverrides/header.scss
@@ -32,7 +32,7 @@ DEFAULT MOBILE STYLING
 .nav-link {
   margin-left: 5px;
   margin-right: 5px;
-  font-family: $mallory_medium !important;
+  font-family: $mallory_mp_medium, $mallory_medium, Arial, Helvetica, sans-serif !important;
   font-weight: 500;
   font-stretch: normal;
   font-style: normal;
@@ -70,7 +70,7 @@ DEFAULT MOBILE STYLING
 
 .secondary-nav {
   background-color: $yale_blue;
-  font-family: $mallory_medium !important;
+  // font-family: $mallory_medium !important;
   color: $white !important;
   font-size: small;
   border-top: $white thin solid;
@@ -88,7 +88,7 @@ DEFAULT MOBILE STYLING
 .secondary-nav a {
   color: $white !important;
   font-size: 16px;
-  font-family: $yale_roman !important;
+  font-family: $yale_roman, 'Times New Roman', Times, serif !important;
 }
 
 

--- a/app/assets/stylesheets/customOverrides/pagination.scss
+++ b/app/assets/stylesheets/customOverrides/pagination.scss
@@ -5,7 +5,7 @@ DEFAULT MOBILE STYLING
 // Pagination at the top of the page
 #sortAndPerPage .page-links,
 #sortAndPerPage .page-links a {
-  font-family: $mallory_medium;
+  font-family: $mallory_mp_medium, $mallory_medium, Arial, Helvetica, sans-serif;
   font-size: 12px;
   color: $light_blue;
 }
@@ -17,7 +17,7 @@ DEFAULT MOBILE STYLING
 
 // Pagination at the bottom of the page
 .page-item .page-link {
-  font-family: $mallory_medium;
+  font-family: $mallory_medium, Arial, Helvetica, sans-serif;
   font-size: 15px;
   color: $light_blue;
   border: none;

--- a/app/assets/stylesheets/theme/typography.scss
+++ b/app/assets/stylesheets/theme/typography.scss
@@ -25,9 +25,22 @@
   src:  url(https://www.yale.edu/sites/all/themes/yale_blue/fonts_new/Mallory/Mallory/Mallory-Medium.woff);
 }
 
+// TODO: update the 2 fonts below with the correct url once we have them
+@font-face {
+  font-family: 'MalloryMP-Medium';
+  src:  url(https://www.yale.edu/sites/all/themes/yale_blue/fonts_new/Mallory/Mallory/Mallory-Medium.woff);
+}
+
+@font-face {
+  font-family: 'MalloryMP-Black';
+  src:  url(https://www.yale.edu/sites/all/themes/yale_blue/fonts_new/Mallory/Mallory/Mallory-Medium.woff);
+}
+
 
 $yale_roman: YaleNew-Roman;
 $yale_italic: YaleNew-Italic;
 $mallory_light: Mallory-Light;
 $mallory_light_italic: Mallory-LightItalic;
 $mallory_medium: Mallory-Medium;
+$mallory_mp_medium: MalloryMP-Medium;
+$mallory_mp_black: MalloryMP-Black;


### PR DESCRIPTION
# Ticket
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/472

# Expected behavior
- Add placeholders for the MalloryMP-Medium and MalloryMP-Black fonts
- The above two fonts currently point at the Mallory-Medium font
- Updated the all Mallory versioned fonts in use to fallback to Arial then Helvetica then sans-serif
- Updated the Yale fonts in use to fallback to Times New Roman then Times then serif