### PR TITLE
Search term highlighting in title

### DIFF
--- a/app/assets/stylesheets/customOverrides/search_result.scss
+++ b/app/assets/stylesheets/customOverrides/search_result.scss
@@ -11,6 +11,22 @@ DEFAULT MOBILE STYLING
   position: relative;
 }
 
+.document-title{
+  padding-left: 10px;
+  padding-bottom: 10px;
+}
+.document-title-heading {
+  display: contents;
+  position: static;
+  max-width: 45%;
+  margin-bottom: 3%;
+}
+
+.documentHeader{
+  padding-left: 19px!important;
+  display: -webkit-box;
+}
+
 .document-metadata {
   display: contents;
   position: static;

--- a/app/views/catalog/_index_header.html.erb
+++ b/app/views/catalog/_index_header.html.erb
@@ -1,0 +1,34 @@
+<%# app/views/catalog/_index_header.html.erb -%>
+<%-
+  # Main values for an item entry on the index in a search results page.
+  doc = document ||= nil
+  return unless doc.present?
+
+  # Position of the document in search results.
+  document_counter ||= -1
+  document_counter = document_counter_with_offset(document_counter)
+
+  # Format counter number that comes before the entry title.
+  counter_class ||= nil
+  counter =
+      unless counter_class == :none
+        content_tag(:span, class: counter_class) {
+          t('blacklight.search.documents.counter', counter: document_counter)
+        }
+      end
+
+  # Main title container for document partial.
+  title_class ||= nil
+  title_class = 'title_tesim'
+  unless title_class == :none
+  end
+
+-%>
+<div class="documentHeader row">
+  <h3 class="index_title document-title-heading <%= title_class %>">
+    <%= counter %>
+    <div class="document-title">
+      <%= link_to_document document, document.highlight_field('title_tesim').try(:[],0) ||document['title_tesim'] %>
+    </div>
+  </h3>
+</div>

--- a/spec/system/highlight_in_search_spec.rb
+++ b/spec/system/highlight_in_search_spec.rb
@@ -36,8 +36,8 @@ RSpec.describe 'Search results displays field', type: :system, clean: true do
     subject(:content) { find(:css, '#content') }
 
     it 'highlights title when a term is queried' do
-      visit '/?search_field=all_fields&q=You'
-      expect(page.html).to include "Me and <span class='search-highlight'>You</span>"
+      visit '/?search_field=all_fields&q=Dan'
+      expect(page.html).to include "Jack or <span class='search-highlight'>Dan</span> the Bulldog"
     end
 
     it 'highlights abstract when a term is queried' do

--- a/spec/system/highlight_in_search_spec.rb
+++ b/spec/system/highlight_in_search_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe 'Search results displays field', type: :system, clean: true do
   let(:dog) do
     {
       id: '111',
+      title_tesim: 'Jack or Dan the Bulldog',
       author_tesim: 'Me and You',
       abstract_tesim: 'Binding: white with gold embossing.',
       alternativeTitle_tesim: 'The Yale Bulldogs',
@@ -33,6 +34,11 @@ RSpec.describe 'Search results displays field', type: :system, clean: true do
 
   context 'Within search results' do
     subject(:content) { find(:css, '#content') }
+
+    it 'highlights title when a term is queried' do
+      visit '/?search_field=all_fields&q=You'
+      expect(page.html).to include "Me and <span class='search-highlight'>You</span>"
+    end
 
     it 'highlights abstract when a term is queried' do
       visit '/?search_field=all_fields&q=white'

--- a/spec/system/sort_in_search_spec.rb
+++ b/spec/system/sort_in_search_spec.rb
@@ -14,57 +14,57 @@ RSpec.describe 'Search results should be sorted', type: :system, js: :true, clea
 
   let(:llama) do
     {
-      id: '111',
-      title_tesim: ['Amor Llama'],
-      format: 'text',
-      language_ssim: 'la',
-      visibility_ssi: 'Public',
-      publicationPlace_ssim: 'Spain',
-      resourceType_ssim: 'Maps, Atlases & Globes',
-      author_ssim: ['Anna Elizabeth Dewdney'],
-      dateStructured_ssim: '1911-1954'
+        id: '111',
+        title_tesim: ['Amor Llama'],
+        format: 'text',
+        language_ssim: 'la',
+        visibility_ssi: 'Public',
+        publicationPlace_ssim: 'Spain',
+        resourceType_ssim: 'Maps, Atlases & Globes',
+        author_ssim: ['Anna Elizabeth Dewdney'],
+        dateStructured_ssim: '1911-1954'
     }
   end
 
   let(:dog) do
     {
-      id: '222',
-      title_tesim: ['HandsomeDan Bulldog'],
-      format: 'three dimensional object',
-      language_ssim: 'en',
-      visibility_ssi: 'Public',
-      publicationPlace_ssim: 'New Haven',
-      resourceType_ssim: 'Books, Journals & Pamphlets',
-      author_ssim: ['Andy Graves'],
-      dateStructured_ssim: '1755-00-00T00:00:00Z'
+        id: '222',
+        title_tesim: ['HandsomeDan Bulldog'],
+        format: 'three dimensional object',
+        language_ssim: 'en',
+        visibility_ssi: 'Public',
+        publicationPlace_ssim: 'New Haven',
+        resourceType_ssim: 'Books, Journals & Pamphlets',
+        author_ssim: ['Andy Graves'],
+        dateStructured_ssim: '1755-00-00T00:00:00Z'
     }
   end
 
   let(:puppy) do
     {
-      id: '444',
-      title_tesim: ['Rhett Lecheire'],
-      format: 'text',
-      language_ssim: 'fr',
-      visibility_ssi: 'Public',
-      publicationPlace_ssim: 'Constantinople or southern Italy',
-      resourceType_ssim: 'Archives or Manuscripts',
-      author_ssim: ['Paulo Coelho'],
-      dateStructured_ssim: '1972200'
+        id: '444',
+        title_tesim: ['Rhett Lecheire'],
+        format: 'text',
+        language_ssim: 'fr',
+        visibility_ssi: 'Public',
+        publicationPlace_ssim: 'Constantinople or southern Italy',
+        resourceType_ssim: 'Archives or Manuscripts',
+        author_ssim: ['Paulo Coelho'],
+        dateStructured_ssim: '1972200'
     }
   end
 
   let(:eagle) do
     {
-      id: '333',
-      title_tesim: ['Aquila Eccellenza'],
-      format: 'still image',
-      language_ssim: 'it',
-      visibility_ssi: 'Public',
-      publicationPlace_ssim: 'White-Hall, printed upon the ice, on the River Thames',
-      resourceType_ssim: 'Archives or Manuscripts',
-      author_ssim: ['Andrew Norriss'],
-      dateStructured_ssim: '1699'
+        id: '333',
+        title_tesim: ['Aquila Eccellenza'],
+        format: 'still image',
+        language_ssim: 'it',
+        visibility_ssi: 'Public',
+        publicationPlace_ssim: 'White-Hall, printed upon the ice, on the River Thames',
+        resourceType_ssim: 'Archives or Manuscripts',
+        author_ssim: ['Andrew Norriss'],
+        dateStructured_ssim: '1699'
     }
   end
 
@@ -74,10 +74,10 @@ RSpec.describe 'Search results should be sorted', type: :system, js: :true, clea
     click_on 'date (oldest first)'
 
     content = find(:css, '#content')
-    expect(content).to have_content('1. Aquila Eccellenza')
-    expect(content).to have_content('2. HandsomeDan Bulldog')
-    expect(content).to have_content('3. Amor Llama')
-    expect(content).to have_content('4. Rhett Lecheire')
+    expect(content).to have_content("1.\nAquila Eccellenza")
+    expect(content).to have_content("2.\nHandsomeDan Bulldog")
+    expect(content).to have_content("3.\nAmor Llama")
+    expect(content).to have_content("4.\nRhett Lecheire")
   end
 
   it 'sorts by date from newest to oldest' do
@@ -86,9 +86,9 @@ RSpec.describe 'Search results should be sorted', type: :system, js: :true, clea
     click_on 'date (newest first)'
 
     content = find(:css, '#content')
-    expect(content).to have_content('1. Rhett Lecheire')
-    expect(content).to have_content('2. Amor Llama')
-    expect(content).to have_content('3. HandsomeDan Bulldog')
-    expect(content).to have_content('4. Aquila Eccellenza')
+    expect(content).to have_content("1.\nRhett Lecheire")
+    expect(content).to have_content("2.\nAmor Llama")
+    expect(content).to have_content("3.\nHandsomeDan Bulldog")
+    expect(content).to have_content("4.\nAquila Eccellenza")
   end
 end

--- a/spec/system/sort_in_search_spec.rb
+++ b/spec/system/sort_in_search_spec.rb
@@ -14,57 +14,57 @@ RSpec.describe 'Search results should be sorted', type: :system, js: :true, clea
 
   let(:llama) do
     {
-        id: '111',
-        title_tesim: ['Amor Llama'],
-        format: 'text',
-        language_ssim: 'la',
-        visibility_ssi: 'Public',
-        publicationPlace_ssim: 'Spain',
-        resourceType_ssim: 'Maps, Atlases & Globes',
-        author_ssim: ['Anna Elizabeth Dewdney'],
-        dateStructured_ssim: '1911-1954'
+      id: '111',
+      title_tesim: ['Amor Llama'],
+      format: 'text',
+      language_ssim: 'la',
+      visibility_ssi: 'Public',
+      publicationPlace_ssim: 'Spain',
+      resourceType_ssim: 'Maps, Atlases & Globes',
+      author_ssim: ['Anna Elizabeth Dewdney'],
+      dateStructured_ssim: '1911-1954'
     }
   end
 
   let(:dog) do
     {
-        id: '222',
-        title_tesim: ['HandsomeDan Bulldog'],
-        format: 'three dimensional object',
-        language_ssim: 'en',
-        visibility_ssi: 'Public',
-        publicationPlace_ssim: 'New Haven',
-        resourceType_ssim: 'Books, Journals & Pamphlets',
-        author_ssim: ['Andy Graves'],
-        dateStructured_ssim: '1755-00-00T00:00:00Z'
+      id: '222',
+      title_tesim: ['HandsomeDan Bulldog'],
+      format: 'three dimensional object',
+      language_ssim: 'en',
+      visibility_ssi: 'Public',
+      publicationPlace_ssim: 'New Haven',
+      resourceType_ssim: 'Books, Journals & Pamphlets',
+      author_ssim: ['Andy Graves'],
+      dateStructured_ssim: '1755-00-00T00:00:00Z'
     }
   end
 
   let(:puppy) do
     {
-        id: '444',
-        title_tesim: ['Rhett Lecheire'],
-        format: 'text',
-        language_ssim: 'fr',
-        visibility_ssi: 'Public',
-        publicationPlace_ssim: 'Constantinople or southern Italy',
-        resourceType_ssim: 'Archives or Manuscripts',
-        author_ssim: ['Paulo Coelho'],
-        dateStructured_ssim: '1972200'
+      id: '444',
+      title_tesim: ['Rhett Lecheire'],
+      format: 'text',
+      language_ssim: 'fr',
+      visibility_ssi: 'Public',
+      publicationPlace_ssim: 'Constantinople or southern Italy',
+      resourceType_ssim: 'Archives or Manuscripts',
+      author_ssim: ['Paulo Coelho'],
+      dateStructured_ssim: '1972200'
     }
   end
 
   let(:eagle) do
     {
-        id: '333',
-        title_tesim: ['Aquila Eccellenza'],
-        format: 'still image',
-        language_ssim: 'it',
-        visibility_ssi: 'Public',
-        publicationPlace_ssim: 'White-Hall, printed upon the ice, on the River Thames',
-        resourceType_ssim: 'Archives or Manuscripts',
-        author_ssim: ['Andrew Norriss'],
-        dateStructured_ssim: '1699'
+      id: '333',
+      title_tesim: ['Aquila Eccellenza'],
+      format: 'still image',
+      language_ssim: 'it',
+      visibility_ssi: 'Public',
+      publicationPlace_ssim: 'White-Hall, printed upon the ice, on the River Thames',
+      resourceType_ssim: 'Archives or Manuscripts',
+      author_ssim: ['Andrew Norriss'],
+      dateStructured_ssim: '1699'
     }
   end
 


### PR DESCRIPTION
Co-authored-by: Eric DeJesus <eric.dejesus@yale.com>

We did have search term highlighting in the title working (https://github.com/yalelibrary/YUL-DC/issues/338), but it seems to have stopped working when we removed the extra title from the search results metadata (https://github.com/yalelibrary/YUL-DC/issues/422). See screenshot below.

- [x] Restore the highlighting in the title, without adding an extra title term to the metadata display
- [x] Add an automated test for this functionality so it doesn't break without our noticing again

----

![Screen Shot 2020-08-31 at 12 58 44 PM](https://user-images.githubusercontent.com/41123693/91749588-b2c00200-eb8f-11ea-9757-74f54943a696.png)
