### PR TITLE
Update the welcome message on the homepage

### DIFF
--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -1,0 +1,38 @@
+<div>
+  <div><h1>Welcome!</h1></div>
+  Welcome to the Yale University Digital Collections internal preview site
+  
+  <ul>
+    <li>The initial preview includes approximately 500 items from across the Beinecke's digital holdings</li>
+    <li>Over the duration of the initial phase, the content will grow to represent over 125,000 items representing the Beinecke Libaries digital holdings</li>
+    <li>In addition, the site will include one additional collection from YULs diverse holdings at the initial public launch</li>
+    <li>Future phases will incorporate additonal content from across YUL's digital holdings</li>
+  </ul>
+</div>
+
+<div>
+  <h3>Plese feel free to explore the site and share your feedback with us</h3>
+  The preview is designed to give a fully functional preview of browse, search, and view capabilities as we migrate content from the legacy site.  Here's a few things you can do:
+  <ul>
+    <li>Search for content by Title, Keyword, and Author using the search bar above</li>
+    <li>Browse content using the "Limit Your Search" facets at the left of the screen</li>
+    <li>Pan, Zoom, and page through materials by clicking through to item-level show pages</li>
+  </ul>
+</div>
+
+<div>
+  <h3>Giving Feedback</h3>
+  We're using a tool called BugHerd to give stakeholders an easy way to give us clear and precise feedback about your experiences
+  
+  <ol>
+    <li>Search, browse, and use the site as you normally would</li>
+    <li>When you see something you'd like to give us feedback about, click the "&lt;BH" icon at the right side of your screen</li>
+    <li>Click the green plus button on the BugHerd toolbar</li>
+    <li>Click on the item or part of the screen you have feedback about</li>
+    <li>Type a short description of your feedback in the "Task Details" box</li>
+    <li>Click on the "Create Task" button to send us your feedback</li>
+  </ol>
+  <span style='color:gray' class='info'><em>NOTE:</em> If you don’t see the BugHerd icon, 
+    please see the instructions in the 
+    <a href='https://support.bugherd.com/hc/en-us/articles/204171570-Help-The-BugHerd-sidebar-isn-t-appearing-'>BugHerd FAQ</a></span>
+</div>


### PR DESCRIPTION
This commit overrides blacklight's default homepage partial so we can
provide Yale specific messaging.

At this point, we're providing some weclome text to help users of the
internal preview to get started exploring. The page also describes how
to use BugHerd to send feedback to the development team.