### PR TITLE
Added Include IIIF Logo to Show page

### DIFF
--- a/app/assets/stylesheets/customOverrides/show_page.scss
+++ b/app/assets/stylesheets/customOverrides/show_page.scss
@@ -18,7 +18,7 @@ DEFAULT MOBILE STYLING
 }
 
 .iiif-logo img {
-  display: none;
+  margin-top: -3px;
 }
 
 .list-group{


### PR DESCRIPTION
Co-authored-by: Eric DeJesus <eric.dejesus@yale.com>

Include IIIF logo and link under Links at bottom of single item view page.

**Current View**
![Screen Shot 2020-09-02 at 7.14.11 PM.png](https://images.zenhubusercontent.com/5e5d4b9fe308104eddc52c88/3cb21ccb-9cc9-4be7-bc2b-fc3ccafc680e)

**Proposed View**
![Screen Shot 2020-09-08 at 1.41.59 PM.png](https://images.zenhubusercontent.com/5e6013c029e314c92afd4769/88ed0cd8-e4bd-4594-b5c7-01ebc5e4a58a)

**ACCEPTANCE:**
- [x] IIIF logo appears under Links
- [x] Links out to manifest URL

Related to: https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/478