### PR TITLE
Fixed publication date slider bug

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -111,7 +111,7 @@ class CatalogController < ApplicationController
                                                     assumed_boundaries: [1100, Time.current.year + 2],
                                                     segments: true,
                                                     maxlength: 4
-                                                  }, include_in_advanced_search: false
+                                                  }
 
     # the facets below are set to false because we aren't filtering on them from the main search page
     # but we need to be able to provide a label when they are filtered upon from an individual show page


### PR DESCRIPTION
**STEPS TO REPRODUCE**
1. Go to any system running v.1.15.1 (e.g. https://collections-test.library.yale.edu/?search_field=all_fields&q= )
2. Click on search (search for all items)
3. Expand the "Publication Date" facet
4. *Use the mouse* to slide the upper date limit about 1/4 of the way earlier (i.e. from around 2020 --> 1775)
5. Click on "Apply"

**EXPECTED RESULT**
- [x] I should get some subset of the previous results
- [x] I should have a facet limit for the years that I can click to remove

**ACTUAL RESULT**
- [x] I get no results found
- [x] There is no facet constraint shown


**STEP 3**
<img width="315" alt="image" src="https://user-images.githubusercontent.com/3064318/92637118-0e7c4080-f29e-11ea-9545-314f7a82d2b1.png">


**STEP 4**
<img width="311" alt="image" src="https://user-images.githubusercontent.com/3064318/92637275-3d92b200-f29e-11ea-9fb2-eedea859002a.png">

**Bug Behavior**
<img width="758" alt="image" src="https://user-images.githubusercontent.com/3064318/92637372-5d29da80-f29e-11ea-9a5f-d73fb5944388.png">

**Expected Behavior**
https://share.getcloudapp.com/12uJdQzJ



