### PR TITLE
Adds styling to search results bottom pagination

### DIFF
--- a/app/assets/stylesheets/customOverrides/pagination.scss
+++ b/app/assets/stylesheets/customOverrides/pagination.scss
@@ -22,7 +22,7 @@ DEFAULT MOBILE STYLING
 // Pagination at the bottom of the page
 .page-item .page-link {
   font-family: $mallory_medium, Arial, Helvetica, sans-serif;
-  font-size: 15px;
+  font-size: 16px;
   color: $light_blue;
   border: none;
   margin-left: 0px;
@@ -43,6 +43,7 @@ DEFAULT MOBILE STYLING
 
 .pagination {
   padding: 8px 0px;
+  justify-content: center;
 }
 
 .pagination .page-item:nth-child(1),
@@ -72,3 +73,45 @@ DEFAULT MOBILE STYLING
   color: $medium_grey;
 }
 
+@media screen and (min-width: $small_device) {
+  .page-item .page-link[aria-label="Go to previous page"] {
+    position: absolute;
+    left: 0;
+    top: 40px;
+  }
+  
+  .page-item .page-link[aria-label="Go to next page"] {
+    position: absolute;
+    right: 0;
+    top: 40px;
+  }    
+}
+
+@media screen and (min-width: $medium_device) {
+  .page-item .page-link[aria-label="Go to previous page"] {
+    position: absolute;
+    left: 0;
+    top: 18px;
+  }
+  
+  .page-item .page-link[aria-label="Go to next page"] {
+    position: absolute;
+    right: 0;
+    top: 18px;
+  }    
+}
+
+
+@media screen and (min-width: $xlarge_device) {
+  .page-item .page-link[aria-label="Go to previous page"] {
+    position: absolute;
+    left: 0;
+    top: 18px;
+  }
+  
+  .page-item .page-link[aria-label="Go to next page"] {
+    position: absolute;
+    right: 0;
+    top: 18px;
+  }      
+}


### PR DESCRIPTION
# Summary
Styles the bottom pagination on the search results page

# Related Ticket
#531 [ZenHub Link](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/531)

### Zeplin Design
<img width="998" alt="image" src="https://user-images.githubusercontent.com/36549923/92798398-c0cc0a80-f367-11ea-8f2a-8158e7de9e92.png">

### Screenshot of Full Screen Pagination
<img width="930" alt="image" src="https://user-images.githubusercontent.com/36549923/92798562-e8bb6e00-f367-11ea-83cc-458102e744d3.png">

### Responsiveness Video
https://share.getcloudapp.com/Jru6Yre2
