### PR TITLE
Fix metadata overlap on search results list view

### DIFF
--- a/app/assets/stylesheets/customOverrides/search_result.scss
+++ b/app/assets/stylesheets/customOverrides/search_result.scss
@@ -2,92 +2,33 @@
 DEFAULT MOBILE STYLING
 ********************************************************/
 
-.dd {
-  margin-left:  22%;
-  text-align: justify;
-}
-
-.dt {
-  position: relative;
-}
-
-.document-title{
-  padding-left: 10px;
-  padding-bottom: 10px;
-}
-.document-title-heading {
-  display: contents;
-  position: static;
-  max-width: 45%;
-  margin-bottom: 3%;
-}
-
-.documentHeader{
-  padding-left: 19px!important;
-  display: -webkit-box;
-}
-
 .search-highlight {
   background-color: yellow;
 }
 
-//Fields on Single Items and Search Result pages
-.document-metadata{
-  display: contents;
-  position: static;
-  max-width: 55%;
-  margin-bottom: 3%;
+.search-results dt {
+  font-size: 12px;
+  color: $medium_grey;
+  font-family: $mallory_medium, Arial, Helvetica, sans-serif !important;
+  font-weight: 900;
 }
 
-@media screen and (min-width: $medium_device) {
-  .dl-invert dt {
-    position: absolute;
-    width: 100%;
-    padding-right: 15px;
-    padding-left: 0px!important;
-  }
-
-  .document-metadata {
-    max-width: 55%;
-    margin-bottom: 3%;
-  }
-
-  .col-md-9 {
-    padding-left: 25%;
-  }
+.search-results dd {
+  font-size: 12px;
+  color: $medium_grey;
+  font-family: $mallory_medium, Arial, Helvetica, sans-serif !important;
+  font-weight: 500;
 }
 
-@media screen and (min-width: $large_device) {
-
-  .dl-invert dt {
-    position: absolute;
-    width: 100%;
-    padding-right: 15px;
-    padding-left: 0px!important;
-  }
-
-  .document-metadata {
-    max-width: 55%;
-    margin-bottom: 3%;
-  }
-
-  .col-md-9 {
-    padding-left: 25%;
-  }
+.search-results .document-title {
+  font-size: 14px;
+  color: $light_blue;
+  font-family: $mallory_medium, Arial, Helvetica, sans-serif !important;
+  font-weight: 500;
 }
 
-@media screen and (min-width: $xlarge_device) {
-
-  .dl-invert dt {
-    position: absolute;
-  }
-
-  .document-metadata {
-    max-width: 55%;
-    margin-bottom: 3%;
-  }
-
-  .col-md-9 {
-    padding-left: 25%;
-  }
+.search-results .document-thumbnail {
+  height: 200px;
+  padding: 0px 25px;
 }
+

--- a/app/views/catalog/_search_results.html.erb
+++ b/app/views/catalog/_search_results.html.erb
@@ -1,0 +1,34 @@
+<% @page_title = t('blacklight.search.page_title.title', :constraints => render_search_to_page_title(params), :application_name => application_name) %>
+
+<% content_for(:head) do -%>
+  <%= render 'catalog/opensearch_response_metadata', response: @response %>
+  <%= rss_feed_link_tag %>
+  <%= atom_feed_link_tag %>
+  <%= json_api_link_tag %>
+<% end %>
+
+<% content_for(:skip_links) do -%>
+    <%= link_to t('blacklight.skip_links.first_result'), '#documents', class: 'element-invisible element-focusable rounded-bottom py-2 px-3', data: { turbolinks: 'false' } %>
+<% end %>
+
+<% content_for(:container_header) do -%>
+  <h1 class="sr-only top-content-title"><%= t('blacklight.search.header') %></h1>
+
+  <%= render 'constraints' %>
+<% end %>
+
+<%= render 'search_header' %>
+
+<h2 class="sr-only"><%= t('blacklight.search.search_results') %></h2>
+
+<div class="search-results">
+	<%- if @response.empty? %>
+		<%= render "zero_results" %>
+	<%- elsif render_grouped_response? %>
+		<%= render_grouped_document_index %>
+	<%- else %>
+		<%= render_document_index %>
+	<%- end %>
+</div>
+
+<%= render 'results_pagination' %>


### PR DESCRIPTION
# Summary
Adds styling to search results list view.

# Related Ticket
#465 [ZenHub Link](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/465)

# Notes
* A bug was introduced that overlapped the metadata on the search result list view
* This PR fixes that bug and moves closer to the intended design
* This PR does not 1-1 match the design and is aimed to fix the overlapping metadata bug
* See below for what the previously rendered the search results list view looked like

# Screenshot
![image](https://user-images.githubusercontent.com/36549923/92957568-96d51f80-f41d-11ea-9d17-ae44a5d3af75.png)

### Before Shot of what the misrendered page looked like
![image](https://user-images.githubusercontent.com/36549923/92957737-e1ef3280-f41d-11ea-94ca-c47eca2418d1.png)

### Responsiveness Video Link
https://share.getcloudapp.com/o0u80LKG