### PR TITLE
Prevent facet count wrap

### DIFF
--- a/app/assets/stylesheets/customOverrides/facets.scss
+++ b/app/assets/stylesheets/customOverrides/facets.scss
@@ -18,7 +18,8 @@ div.card {
 }
 
 .facet-count {
-  width: 5ch !important;
+  width: 7ch !important;
+  white-space: nowrap;
   position: relative;
   right: -10px;
 }


### PR DESCRIPTION
# Summary
Facet styling rework to prevent facet count from wrapping to next line.

# Related Ticket
#462 - [ZenHub Link](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/462)

# Before
<img width="299" alt="image" src="https://user-images.githubusercontent.com/36549923/93139559-d86fff80-f695-11ea-89dd-1bc814ab6618.png">

# After
<img width="294" alt="image" src="https://user-images.githubusercontent.com/36549923/93139592-e45bc180-f695-11ea-9536-27d8beb229d7.png">

