### PR TITLE
Force inclusion of png in asset precompile

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -2,3 +2,5 @@
 //= link_directory ../stylesheets
 //= link application.js
 //= link application.css
+
+//= link x2x.png

--- a/app/assets/stylesheets/customOverrides/main.scss
+++ b/app/assets/stylesheets/customOverrides/main.scss
@@ -76,7 +76,7 @@ a {
 }
 
 .remove::before {
-  content: url(x2x.png);
+  content: image-url("x2x.png");
 }
 
 .text-success, .facet-values li .selected {


### PR DESCRIPTION
# Summary
x png was displaying intermittently in production.  This PR forces the inclusion of the png image in the asset pipeline.

# Related Ticket
#462 [ZenHub Link](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/462)

# Screenshots
<img width="596" alt="image" src="https://user-images.githubusercontent.com/36549923/93143735-5e437900-f69d-11ea-807c-69e50d03cd32.png">
<img width="448" alt="image" src="https://user-images.githubusercontent.com/36549923/93143771-70251c00-f69d-11ea-9fa2-ce28cdaccd50.png">
