### PR TITLE
Styles bottom pagination

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,7 @@ Layout/LineLength:
 RSpec/DescribeClass:
   Exclude:
     - spec/views/**/*
+    - spec/system/search_result_pagination_spec.rb
 
 RSpec/RepeatedExample:
   Exclude:

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -2,3 +2,5 @@
 //= link_directory ../stylesheets
 //= link application.js
 //= link application.css
+
+//= link x2x.png

--- a/app/assets/stylesheets/customOverrides/main.scss
+++ b/app/assets/stylesheets/customOverrides/main.scss
@@ -76,7 +76,7 @@ a {
 }
 
 .remove::before {
-  content: url(x2x.png);
+  content: image-url("x2x.png");
 }
 
 .text-success, .facet-values li .selected {

--- a/app/assets/stylesheets/customOverrides/pagination.scss
+++ b/app/assets/stylesheets/customOverrides/pagination.scss
@@ -20,6 +20,20 @@ DEFAULT MOBILE STYLING
 
 
 // Pagination at the bottom of the page
+
+#first-page-arrows.disabled {
+  padding-left: 10px;
+  padding-right: 10px;
+}
+
+#last-page-arrows.disabled {
+  padding-left: 10px;
+  padding-right: 10px;
+}
+
+#last-page-arrows::marker {
+  display: none;
+}
 .page-item .page-link {
   font-family: $mallory_medium, Arial, Helvetica, sans-serif;
   font-size: 16px;
@@ -51,8 +65,8 @@ DEFAULT MOBILE STYLING
   text-transform: uppercase;
 }
 
-// add a right border to all page numbers except the last page
-.page-item:nth-child(n+3):not(:last-child) {
+// add a right border to all page numbers except the last page double arrows and Next button
+.page-item:nth-child(n+3):not(:nth-last-child(1)):not(:nth-last-child(2)):not(:nth-last-child(3)) {
   border-right: 1px solid $medium_grey;
 }
 

--- a/app/views/kaminari/blacklight/_first_page.html.erb
+++ b/app/views/kaminari/blacklight/_first_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "First" page
+  - available local variables
+    url:           url to the first page
+    current_page:  a page object for the currently displayed page
+    num_pages:     total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<li id="first-page-arrows" class="page-item <%= 'disabled' if current_page.first? %>">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, :remote => remote, class: 'page-link', aria: { label: t('views.pagination.aria.go_to_first_page') } %>
+</li>

--- a/app/views/kaminari/blacklight/_last_page.html.erb
+++ b/app/views/kaminari/blacklight/_last_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Last" page
+  - available local variables
+    url:           url to the last page
+    current_page:  a page object for the currently displayed page
+    num_pages:     total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<li id="last-page-arrows" class="page-item <%= 'disabled' if current_page.last? %>">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, :remote => remote, class: 'page-link', aria: { label: t('views.pagination.aria.go_to_last_page') } %>
+</li>

--- a/app/views/kaminari/blacklight/_paginator.html.erb
+++ b/app/views/kaminari/blacklight/_paginator.html.erb
@@ -1,0 +1,25 @@
+<%# The container tag
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    num_pages:     total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+    paginator:     the paginator that renders the pagination tags inside
+
+   Paginator now using the Bootstrap paginator class
+-%>
+<%= paginator.render do -%>
+  <ul class="pagination">
+    <%= prev_page_tag %>
+    <%= first_page_tag  %>
+    <% each_relevant_page do |page| -%>
+      <% if page.left_outer? || page.right_outer? || page.inside_window? -%>
+        <%= page_tag page %>
+      <% elsif !page.was_truncated? -%>
+        <%= gap_tag %>
+      <% end -%>
+    <% end -%> 
+    <%= last_page_tag  %>
+    <%= next_page_tag  %> 
+  </ul>
+<% end -%>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -1,6 +1,8 @@
 en:
   views:
     pagination:
+      first: "&laquo;"
+      last: "&raquo;"
       previous: 'Previous'
       next: 'Next'
   blacklight:

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -1,4 +1,8 @@
 en:
+  views:
+    pagination:
+      previous: 'Previous'
+      next: 'Next'
   blacklight:
     application_name: 'Yale University Library'
     sidebar:

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -3,8 +3,8 @@ en:
     pagination:
       first: "&laquo;"
       last: "&raquo;"
-      previous: 'Previous'
-      next: 'Next'
+      previous: 'PREVIOUS'
+      next: 'NEXT'
   blacklight:
     application_name: 'Yale University Library'
     sidebar:

--- a/spec/system/search_result_pagination_spec.rb
+++ b/spec/system/search_result_pagination_spec.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe "search result pagination", type: :system, clean: true, js: true do
-
-	before do
+  before do
     solr = Blacklight.default_index.connection
     solr.add([dog, cat, bird])
     solr.commit
@@ -29,8 +28,8 @@ RSpec.describe "search result pagination", type: :system, clean: true, js: true 
       orbisBibId_ssi: '1234567',
       visibility_ssi: 'Public'
     }
-	end
-	
+  end
+
   let(:bird) do
     {
       id: '313',

--- a/spec/system/search_result_pagination_spec.rb
+++ b/spec/system/search_result_pagination_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+RSpec.describe "search result pagination", type: :system, clean: true, js: true do
+
+	before do
+    solr = Blacklight.default_index.connection
+    solr.add([dog, cat, bird])
+    solr.commit
+  end
+
+  let(:dog) do
+    {
+      id: '111',
+      title_tesim: 'Handsome Dan is a bull dog.',
+      author_tesim: 'Eric & Frederick',
+      subjectName_ssim: "this is the subject name",
+      sourceTitle_tesim: "this is the source title",
+      orbisBibId_ssi: '1238901',
+      visibility_ssi: 'Public'
+    }
+  end
+
+  let(:cat) do
+    {
+      id: '212',
+      title_tesim: 'Handsome Dan is not a cat.',
+      author_tesim: 'Frederick & Eric',
+      sourceTitle_tesim: "this is the source title",
+      orbisBibId_ssi: '1234567',
+      visibility_ssi: 'Public'
+    }
+	end
+	
+  let(:bird) do
+    {
+      id: '313',
+      title_tesim: 'Handsome Dan is not a bird.',
+      author_tesim: 'Frederick & Eric',
+      sourceTitle_tesim: "this is the source title",
+      orbisBibId_ssi: '1234567',
+      visibility_ssi: 'Public'
+    }
+  end
+
+  it "displays no pagination when search results are less than per page cap" do
+    # default per page cap is 10 and there are 3 search results
+    visit '/?search_field=all_fields&view=list'
+    # this double arrow is the last page link in the bottom pagination
+    expect(page).not_to have_link "»"
+  end
+
+  it 'displays pagination when search results are greater than per page cap"' do
+    # sets per page cap to 2 and there are 3 search results
+    visit '/?per_page=2&q=&search_field=all_fields'
+    # last page link
+    expect(page).to have_link "»"
+  end
+
+  context "navigating with search context links" do
+    it "has the appropriate context links on the first page of results" do
+      visit '/?per_page=2&q=&search_field=all_fields'
+      expect(page).to have_link "PREVIOUS"
+      # this link is disabled on the first page of results
+      expect(page).not_to have_link "«"
+      expect(page).to have_link "»"
+      expect(page).to have_link "NEXT"
+    end
+
+    it "jumps to last page of results" do
+      visit '/?per_page=2&q=&search_field=all_fields'
+      click_on "»"
+      within 'ul.pagination' do
+        # next button is disabled on last page so it cannot be found
+        expect(page).not_to have_button("NEXT")
+      end
+    end
+
+    it "jumps to first page of results" do
+      visit '/?per_page=2&q=&search_field=all_fields'
+      click_on "»"
+      click_on "«"
+      within 'ul.pagination' do
+        # previous button is disabled on first page so it cannot be found
+        expect(page).not_to have_button("PREVIOUS")
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Summary
Continued improvement to bottom pagination 

# Related Ticket
#531 [ZenHub Link](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/531)

# Acceptance Criteria
- [x] remove double arrows by Previous and Next - screenshot in details
- [x] add go to last and first double arrow links in pagination

# Screenshot
<img width="935" alt="image" src="https://user-images.githubusercontent.com/36549923/93285322-71cc0e00-f789-11ea-8a5c-8d7058cf99e2.png">
