### PR TITLE
Different "per page" option for list and gallery views

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -42,7 +42,7 @@ class CatalogController < ApplicationController
     # config.document_solr_path = 'get'
 
     # items to show per page, each number in the array represent another option to choose from.
-    # config.per_page = params[:view] == 'list' ? [10,20,50,100] : [9, 30, 60, 99]
+    # config.per_page = [10,20,50,100]
 
     # solr field configuration for search results/index views
     config.index.title_field = 'title_tesim'

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -5,6 +5,8 @@ class CatalogController < ApplicationController
   include Blacklight::Catalog
   include Blacklight::Marc::Catalog
 
+  before_action :determine_per_page
+
   configure_blacklight do |config|
     # default advanced config values
     config.advanced_search ||= Blacklight::OpenStructWithHashAccess.new
@@ -40,7 +42,7 @@ class CatalogController < ApplicationController
     # config.document_solr_path = 'get'
 
     # items to show per page, each number in the array represent another option to choose from.
-    # config.per_page = [10,20,50,100]
+    # config.per_page = params[:view] == 'list' ? [10,20,50,100] : [9, 30, 60, 99]
 
     # solr field configuration for search results/index views
     config.index.title_field = 'title_tesim'
@@ -361,5 +363,10 @@ class CatalogController < ApplicationController
     # if the name of the solr.SuggestComponent provided in your solrcongig.xml is not the
     # default 'mySuggester', uncomment and provide it below
     # config.autocomplete_suggester = 'mySuggester'
+  end
+
+  def determine_per_page
+    grouping = params[:view] == 'list' ? [10, 20, 50, 100] : [9, 30, 60, 99]
+    blacklight_config[:per_page] = grouping
   end
 end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -366,7 +366,7 @@ class CatalogController < ApplicationController
   end
 
   def determine_per_page
-    grouping = params[:view] == 'list' ? [10, 20, 50, 100] : [9, 30, 60, 99]
+    grouping = params[:view] == 'gallery' ? [9, 30, 60, 99] : [10, 20, 50, 100]
     blacklight_config[:per_page] = grouping
   end
 end

--- a/spec/system/search_result_spec.rb
+++ b/spec/system/search_result_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe 'search result', type: :system do
     it 'has the correct "per page" options' do
       expect(page).to have_text '10 per page 20 per page 50 per page 100 per page'
     end
+  end
 
   context 'in gallery view' do
     before do

--- a/spec/system/search_result_spec.rb
+++ b/spec/system/search_result_spec.rb
@@ -11,7 +11,10 @@ RSpec.describe 'search result', type: :system do
       expect(page).to have_css '.dl-invert'
       expect(page).to have_css '.document-metadata'
     end
-  end
+
+    it 'has the correct "per page" options' do
+      expect(page).to have_text '10 per page 20 per page 50 per page 100 per page'
+    end
 
   context 'in gallery view' do
     before do
@@ -19,8 +22,11 @@ RSpec.describe 'search result', type: :system do
     end
 
     it 'has expected css' do
-      expect(page).to have_css '.index'
       expect(page).to have_css '.caption'
+    end
+
+    it 'has the correct "per page" options' do
+      expect(page).to have_text '9 per page 30 per page 60 per page 99 per page'
     end
   end
 end


### PR DESCRIPTION
# Ticket
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/515

# Expected behavior
- in gallery view the "per page" option is 9, 30, 60 and 99
- in list view the "per page" option is 10, 20, 50, 100

# Demo
![515](https://user-images.githubusercontent.com/29032869/93277979-35dc7d00-f778-11ea-8191-a94e50a477b1.gif)
