### PR TITLE
Add search by identifier shelf mark

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -334,7 +334,6 @@ class CatalogController < ApplicationController
 
     config.add_search_field('identifierShelfMark_tesim', label: 'Identifier Shelf Mark') do |field|
       field.qt = 'search'
-      field.include_in_simple_select = false
       field.solr_parameters = {
         qf: 'identifierShelfMark_tesim',
         pf: ''

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -332,7 +332,7 @@ class CatalogController < ApplicationController
       }
     end
 
-    config.add_search_field('identifierShelfMark_tesim', label: 'Identifier Shelf Mark') do |field|
+    config.add_search_field('identifierShelfMark_tesim', label: 'Call Number') do |field|
       field.qt = 'search'
       field.solr_parameters = {
         qf: 'identifierShelfMark_tesim',

--- a/spec/system/search_fields_spec.rb
+++ b/spec/system/search_fields_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe 'Search results displays field', type: :system, clean: true, js: 
       author_tesim: 'Eric & Frederick',
       subjectName_ssim: "this is the subject name",
       sourceTitle_tesim: "this is the source title",
+      identifierShelfMark_tesim: 'WA MSS 987',
       orbisBibId_ssi: '1238901',
       visibility_ssi: 'Public'
     }
@@ -33,6 +34,7 @@ RSpec.describe 'Search results displays field', type: :system, clean: true, js: 
       author_tesim: 'Frederick & Eric',
       sourceTitle_tesim: "this is the source title",
       orbisBibId_ssi: '1234567',
+      identifierShelfMark_tesim: 'Yale MS 123',
       visibility_ssi: 'Public'
     }
   end
@@ -40,6 +42,12 @@ RSpec.describe 'Search results displays field', type: :system, clean: true, js: 
   context 'search fields' do
     it ' contains all search fields in the view' do
       expect(search_fields).to contain_exactly(*expected_search_fields)
+    end
+
+    it 'contains displays the correct record when searching by Identifier Shelf Mark' do
+      visit '/?search_field=identifierShelfMark_tesim&q=WA+MSS+987'
+      expect(page).to have_content 'Handsome Dan is a bull dog.'
+      expect(page).not_to have_content 'Handsome Dan is not a cat.'
     end
 
     it 'contains displays the correct record when searching by BibId' do

--- a/spec/system/view_facet_spec.rb
+++ b/spec/system/view_facet_spec.rb
@@ -104,10 +104,6 @@ RSpec.describe 'Facets should display', type: :system, js: :true, clean: true do
     expect(page).not_to have_content('Amor Llama')
   end
 
-  it 'does not show the Identifier Shelf Mark facet' do
-    expect(page).not_to have_content('Identifier Shelf Mark')
-  end
-
   it 'renders the facet header' do
     expect(page).to have_css('.facet-field-heading')
   end


### PR DESCRIPTION
**ACCEPTANCE**
- [x] I can choose "Call Number" as the target for my search
- [x] Call number searches produce an exact match on the prefix/first part of call number



![CallNumberFeature](https://user-images.githubusercontent.com/41123693/93284025-c084a280-f79f-11ea-8d9e-3bde00c5da18.gif)

