### PR TITLE
More Options -> Advanced Search

### DIFF
--- a/app/views/advanced/index.html.erb
+++ b/app/views/advanced/index.html.erb
@@ -1,0 +1,21 @@
+<% @page_title = "Advanced Search Options - #{application_name}" %>
+
+<div class="advanced-search-form col-sm-12">
+
+    <h1 class="advanced page-header">
+        <%= 'Advanced Search Options' %>
+        <%= link_to t('blacklight_advanced_search.form.start_over'), blacklight_advanced_search_engine.advanced_search_path, :class =>"btn btn-secondary pull-right advanced-search-start-over" %>
+    </h1>
+
+    <div class="row">
+
+        <div class="col-md-8">
+            <%= render 'advanced_search_form' %>
+        </div>
+        <div class="col-md-4">
+            <%= render "advanced_search_help" %>
+        </div>
+
+    </div>
+
+</div>

--- a/app/views/advanced/index.html.erb
+++ b/app/views/advanced/index.html.erb
@@ -1,9 +1,9 @@
-<% @page_title = "Advanced Search Options - #{application_name}" %>
+<% @page_title = "Advanced Search - #{application_name}" %>
 
 <div class="advanced-search-form col-sm-12">
 
     <h1 class="advanced page-header">
-        <%= 'Advanced Search Options' %>
+        <%= 'Advanced Search' %>
         <%= link_to t('blacklight_advanced_search.form.start_over'), blacklight_advanced_search_engine.advanced_search_path, :class =>"btn btn-secondary pull-right advanced-search-start-over" %>
     </h1>
 

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -30,5 +30,5 @@
 
 
 <div>
-  <%= link_to 'More Options', blacklight_advanced_search_engine.advanced_search_path(search_state.to_h), class: 'advanced_search btn btn-secondary'%>
+  <%= link_to 'Advanced Search', blacklight_advanced_search_engine.advanced_search_path(search_state.to_h), class: 'advanced_search btn btn-secondary'%>
 </div>

--- a/spec/system/advanced_search_spec.rb
+++ b/spec/system/advanced_search_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: tr
 
   it 'gets correct search results from all fields' do
     visit root_path
-    click_on "More Options"
+    click_on "Advanced Search"
     # Search for something
     fill_in 'all_fields_advanced', with: 'Record 1'
     click_on 'advanced-search-submit'
@@ -27,7 +27,7 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: tr
   end
   it 'gets correct search results from author_tesim' do
     visit root_path
-    click_on 'More Options'
+    click_on 'Advanced Search'
     # Search for something
     fill_in 'author_tesim', with: 'Me and Frederick'
     click_on 'advanced-search-submit'
@@ -38,7 +38,7 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: tr
   end
   it 'gets correct search results from identifierShelfMark_tesim' do
     visit root_path
-    click_on 'More Options'
+    click_on 'Advanced Search'
     # Search for something
     fill_in 'identifierShelfMark_tesim', with: '["Landberg MSS 596"]'
     click_on 'advanced-search-submit'
@@ -49,7 +49,7 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: tr
   end
   it 'gets correct search results from orbisBibId_ssi' do
     visit root_path
-    click_on 'More Options'
+    click_on 'Advanced Search'
     # Search for something
     fill_in 'orbisBibId_ssi', with: '3832098'
     click_on 'advanced-search-submit'
@@ -60,7 +60,7 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: tr
   end
   it 'gets correct search results from title_tesim' do
     visit root_path
-    click_on 'More Options'
+    click_on 'Advanced Search'
     # Search for something
     fill_in 'title_tesim', with: '["Record 1"]'
     click_on 'advanced-search-submit'
@@ -71,7 +71,7 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: tr
   end
   it 'gets correct search results from oid_ssi' do
     visit root_path
-    click_on 'More Options'
+    click_on 'Advanced Search'
     # Search for something
     fill_in 'oid_ssi', with: '11607445'
     click_on 'advanced-search-submit'
@@ -82,7 +82,7 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: tr
   end
   it 'gets correct search results from child oid_ssim' do
     visit root_path
-    click_on 'More Options'
+    click_on 'Advanced Search'
     # Search for something
     fill_in 'child_oids_ssim', with: '11'
     click_on 'advanced-search-submit'


### PR DESCRIPTION
_No ticket. Part of the "Sept 17 Yale swarm" doc_

# Expected behavior
- the second button on the search bar now says "advanced search" instead of "more options"
- when on the advanced search page, it now says "advance search" instead of "more search options"
- the title in the tab on that page also now says "advanced search"

# Demo
<img width="1440" alt="Screen Shot 2020-09-17 at 11 22 02 AM" src="https://user-images.githubusercontent.com/29032869/93512313-fda08000-f8d8-11ea-9587-a805f1b60cf5.png">
<img width="1440" alt="Screen Shot 2020-09-17 at 11 24 21 AM" src="https://user-images.githubusercontent.com/29032869/93512331-02fdca80-f8d9-11ea-9864-05fe83bff1eb.png">
