### PR TITLE
Positions context search above blocking elements

### DIFF
--- a/app/assets/stylesheets/customOverrides/show_page.scss
+++ b/app/assets/stylesheets/customOverrides/show_page.scss
@@ -37,6 +37,8 @@ DEFAULT MOBILE STYLING
   margin-left: 1%;
   justify-self: center;
   display: flex;
+  z-index: 1;
+  position: relative;
 }
 
 .show-buttons {
@@ -171,6 +173,8 @@ DEFAULT MOBILE STYLING
     justify-self: center;
     justify-content: space-between;
     display: flex;
+    z-index: 1;
+    position: relative;
   }
 
   .universal-viewer-iframe {
@@ -202,6 +206,8 @@ DEFAULT MOBILE STYLING
     justify-self: center;
     justify-content: space-between;
     display: flex;
+    z-index: 1;
+    position: relative;
   }
 
   .show-tools {
@@ -242,6 +248,8 @@ DEFAULT MOBILE STYLING
     justify-self: center;
     justify-content: space-between;
     display: flex;
+    z-index: 1;
+    position: relative;
   }
 
   .show-tools {


### PR DESCRIPTION
# Summary
On single item show page the previous and next buttons were not clickable because of overlapping elements.  This PR makes them clickable again.

# Video 
https://share.getcloudapp.com/5zuGxDmE