### PR TITLE
Remove search bar from the advanced search page

### DIFF
--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -358,11 +358,13 @@
     </div>
 </div>
 
-<div class="navbar-search navbar navbar-light bg-light" role="navigation">
-    <div class="<%= container_classes %>">
-        <%= render_search_bar %>
+<%unless current_page?('/advanced') %>
+    <div class="navbar-search navbar navbar-light bg-light" role="navigation">
+        <div class="<%= container_classes %>">
+            <%= render_search_bar %>
+        </div>
     </div>
-</div>
+<%end%>
 
 <%= render "shared/user_subheader" %>
 


### PR DESCRIPTION
_No ticket. Part of the "Sept 17 Yale swarm" doc_

# Expected behavior
- the search bar does not show up on the "advanced search" page
- the search bar shows up on all other pages

# Demo
![remove-search-bar](https://user-images.githubusercontent.com/29032869/93519037-87088000-f8e2-11ea-9c23-c7e6ccb5d7c1.gif)

# Resources
- https://api.rubyonrails.org/classes/ActionView/Helpers/UrlHelper.html#method-i-current_page-3F
- https://stackoverflow.com/a/30221962/8079848