### PR TITLE
Rotate submenu arrows

### DIFF
--- a/app/assets/stylesheets/customOverrides/header.scss
+++ b/app/assets/stylesheets/customOverrides/header.scss
@@ -42,7 +42,7 @@ DEFAULT MOBILE STYLING
 
 .nav-link-caret {
   transform: rotate(180deg);
-  -ms-transform: rotate(180deg);  /*  for IE  */
+  -ms-transform: rotate(180deg); /* for IE */
   -webkit-transform: rotate(180deg); /* for browsers supporting webkit (such as chrome, firefox, safari etc.). */
   font-size: 14px;
   display: inline-block;
@@ -71,6 +71,12 @@ DEFAULT MOBILE STYLING
   font-size: small;
   border-top: $white thin solid;
   align-items: center;
+}
+
+.secondary-nav .dropdown.show .nav-link-caret {
+  transform: rotate(0deg);
+  -ms-transform: rotate(0deg); /* for IE */
+  -webkit-transform: rotate(0deg); /* for browsers supporting webkit (such as chrome, firefox, safari etc.). */
 }
 
 .secondary-nav > .row {


### PR DESCRIPTION
# Ticket
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/588

# Expected behavior
- arrows in the secondary nav rotate when a link is clicked

# Demo
![588](https://user-images.githubusercontent.com/29032869/93924469-a2e89900-fcc9-11ea-892a-01e764ab40e6.gif)