### PR TITLE
Title highlighting in gallery view works again

### DIFF
--- a/app/assets/stylesheets/customOverrides/header.scss
+++ b/app/assets/stylesheets/customOverrides/header.scss
@@ -42,7 +42,7 @@ DEFAULT MOBILE STYLING
 
 .nav-link-caret {
   transform: rotate(180deg);
-  -ms-transform: rotate(180deg);  /*  for IE  */
+  -ms-transform: rotate(180deg); /* for IE */
   -webkit-transform: rotate(180deg); /* for browsers supporting webkit (such as chrome, firefox, safari etc.). */
   font-size: 14px;
   display: inline-block;
@@ -71,6 +71,12 @@ DEFAULT MOBILE STYLING
   font-size: small;
   border-top: $white thin solid;
   align-items: center;
+}
+
+.secondary-nav .dropdown.show .nav-link-caret {
+  transform: rotate(0deg);
+  -ms-transform: rotate(0deg); /* for IE */
+  -webkit-transform: rotate(0deg); /* for browsers supporting webkit (such as chrome, firefox, safari etc.). */
 }
 
 .secondary-nav > .row {

--- a/app/assets/stylesheets/customOverrides/index_gallery.scss
+++ b/app/assets/stylesheets/customOverrides/index_gallery.scss
@@ -12,10 +12,6 @@ DEFAULT MOBILE STYLING
   margin-bottom: 50px;
 }
 
-.document.col .caption span {
-  display: none;
-}
-
 .document.col .caption .documentHeader {
   padding-left: 15px !important;
 }

--- a/app/views/catalog/_index_header.html.erb
+++ b/app/views/catalog/_index_header.html.erb
@@ -23,12 +23,26 @@
   unless title_class == :none
   end
 
+  original_url = request.original_url
+  parsed_url = Addressable::URI.parse(original_url)
+  view = parsed_url.query_values['view']
 -%>
-<div class="documentHeader row">
-  <h3 class="index_title document-title-heading <%= title_class %>">
-    <%= counter %>
-    <div class="document-title">
-      <%= link_to_document document, document.highlight_field('title_tesim').try(:[],0) ||document['title_tesim'], counter:document_counter %>
-    </div>
-  </h3>
-</div>
+
+<%if view == 'list' %>
+  <div class="documentHeader row">
+    <h3 class="index_title document-title-heading <%= title_class %>">
+      <%= counter %>
+      <div class="document-title">
+        <%= link_to_document document, document.highlight_field('title_tesim').try(:[],0) || document['title_tesim'], counter:document_counter %>
+      </div>
+    </h3>
+  </div>
+<%elsif view == 'gallery' %>
+  <div class="documentHeader row">
+    <h3 class="index_title document-title-heading <%= title_class %>">
+      <div class="document-title">
+        <%= link_to_document document, document.highlight_field('title_tesim').try(:[],0) || document['title_tesim'] %>
+      </div>
+    </h3>
+  </div>
+<%end%>

--- a/app/views/catalog/_index_header.html.erb
+++ b/app/views/catalog/_index_header.html.erb
@@ -28,20 +28,20 @@
   view = parsed_url.query_values['view']
 -%>
 
-<%if view == 'list' %>
-  <div class="documentHeader row">
-    <h3 class="index_title document-title-heading <%= title_class %>">
-      <%= counter %>
-      <div class="document-title">
-        <%= link_to_document document, document.highlight_field('title_tesim').try(:[],0) || document['title_tesim'], counter:document_counter %>
+<%if view == 'gallery' %>
+  <div class='documentHeader row'>
+    <h3 class='index_title document-title-heading <%= title_class %>'>
+      <div class='document-title'>
+        <%= link_to_document document, document.highlight_field('title_tesim').try(:[],0) || document['title_tesim'] %>
       </div>
     </h3>
   </div>
-<%elsif view == 'gallery' %>
-  <div class="documentHeader row">
-    <h3 class="index_title document-title-heading <%= title_class %>">
-      <div class="document-title">
-        <%= link_to_document document, document.highlight_field('title_tesim').try(:[],0) || document['title_tesim'] %>
+<%else %>
+  <div class='documentHeader row'>
+    <h3 class='index_title document-title-heading <%= title_class %>'>
+      <%= counter %>
+      <div class='document-title'>
+        <%= link_to_document document, document.highlight_field('title_tesim').try(:[],0) || document['title_tesim'], counter:document_counter %>
       </div>
     </h3>
   </div>

--- a/spec/system/search_result_spec.rb
+++ b/spec/system/search_result_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'search result', type: :system do
     end
 
     it 'does not show the index number' do
-      expect(page).to have_selector '#documents > .document.col:first-child span', visible: false
+      expect(page).not_to have_selector '#documents > .document.col:first-child span'
     end
   end
 end


### PR DESCRIPTION
# Ticket
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/575

# Expected behavior
- searching for a word/phrase will show that word/phrase in the title in list view and gallery view

# Demo
![575](https://user-images.githubusercontent.com/29032869/93942167-b9501e00-fce4-11ea-802d-9fddc9677308.gif)

# Resources
- https://stackoverflow.com/a/7317016/8079848
- https://stackoverflow.com/a/2165727/8079848