### PR TITLE
Rename all fields to common fields

### DIFF
--- a/app/assets/stylesheets/customOverrides/search_bar.scss
+++ b/app/assets/stylesheets/customOverrides/search_bar.scss
@@ -128,7 +128,7 @@ DEFAULT MOBILE STYLING
   }
 
   .navbar-search .search-field {
-    max-width: 221px;
+    max-width: 245px;
   }
 
   .navbar-search .search-query-form {
@@ -147,7 +147,11 @@ DEFAULT MOBILE STYLING
   }
 
   .twitter-typeahead {
-    width: 560px;
-    max-width: 560px;
+    width: 505px;
+    max-width: 505px;
   }
+  .navbar-search .search-field {
+    max-width: 245px;
+  }
+
 }

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -253,13 +253,13 @@ class CatalogController < ApplicationController
     # Blacklight 'out of box code'
     # config.add_search_field 'all_fields', label: 'All Fields'
 
-    # Array allows for only listed Solr fields to be searched in the 'All Fields'
+    # Array allows for only listed Solr fields to be searched in the 'Common Fields'
     search_fields = ['abstract_tesim', 'author_tesim', 'alternativeTitle_tesim', 'description_tesim', 'subjectGeographic_tesim',
                      'identifierShelfMark_tesim', 'orbisBibId_ssi', 'publicatonPlace_tesim', 'publisher_tesim',
                      'resourceType_tesim', 'sourceCreated_tesim', 'subjectName_tesim', 'subject_topic_tesim',
                      'title_tesim']
 
-    config.add_search_field('all_fields', label: 'All Fields') do |field|
+    config.add_search_field('all_fields', label: 'Common Fields') do |field|
       field.qt = 'search'
       field.include_in_advanced_search = false
       field.solr_parameters = {
@@ -268,7 +268,7 @@ class CatalogController < ApplicationController
       }
     end
 
-    config.add_search_field('all_fields_advanced', label: 'All Fields') do |field|
+    config.add_search_field('all_fields_advanced', label: 'Common Fields') do |field|
       field.qt = 'search'
       field.include_in_simple_select = false
       field.solr_parameters = {

--- a/spec/system/advanced_search_spec.rb
+++ b/spec/system/advanced_search_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: tr
     find('.advanced_search').hover
   end
 
-  it 'gets correct search results from all fields' do
+  it 'gets correct search results from common fields' do
     visit root_path
     click_on "Advanced Search"
     # Search for something


### PR DESCRIPTION
**ACCEPTANCE**
- [x] The default search option is listed as "Common Fields" instead of "All Fields"

![image.png](https://images.zenhubusercontent.com/5ca3b270500af570674ef5bc/942cab74-57ed-4ebd-9d94-fb3e93ce8678)