### PR TITLE
Remove index on User.email field

### DIFF
--- a/db/migrate/20200923183339_remove_user_email_index.rb
+++ b/db/migrate/20200923183339_remove_user_email_index.rb
@@ -1,0 +1,8 @@
+class RemoveUserEmailIndex < ActiveRecord::Migration[6.0]
+  # Although devise adds an email field to the User model, that field is not
+  # populated by CAS. Since this field will (almost?) always be blank, we can't
+  # define an index on it.
+  def change
+    remove_index :users, :email
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_17_191238) do
+ActiveRecord::Schema.define(version: 2020_09_23_183339) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,7 +47,6 @@ ActiveRecord::Schema.define(version: 2020_06_17_191238) do
     t.boolean "guest", default: false
     t.string "provider"
     t.string "uid"
-    t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 


### PR DESCRIPTION
CAS does not provide an email address for users, but Devise defines an email field for the User model, and puts an index on it. We should remove the index, since most if not all User objects will have an empty string for their email address.

Connected to https://github.com/yalelibrary/YUL-DC/issues/596