### PR TITLE
Digital Collections row styling

### DIFF
--- a/app/assets/stylesheets/customOverrides/subheader_users.scss
+++ b/app/assets/stylesheets/customOverrides/subheader_users.scss
@@ -38,7 +38,7 @@ DEFAULT MOBILE STYLING
   display: flex;
 }
 
-.user-subheader-logout a{
+.user-subheader-logout a {
   display: flex;
   color: $medium_grey !important;
 }

--- a/app/assets/stylesheets/customOverrides/subheader_users.scss
+++ b/app/assets/stylesheets/customOverrides/subheader_users.scss
@@ -3,35 +3,41 @@ DEFAULT MOBILE STYLING
 ********************************************************/
 
 .user-subheader {
-  margin-left: 3.5%;
+  margin-left: 15px;
+  margin-right: 15px;
+  margin-bottom: 25px;
   display: flex;
-  width: 525px;
   border-bottom: .5px solid $light_grey;
-  margin-bottom: 6px;
   padding-bottom: 6px;
-
 }
+
 .user-subheader-title {
   font-family: $yale_roman; // TO-DO: should be Yaledisplay_roman
   color: $yale_blue;
   font-size: 30px;
   overflow: visible;
   width: 250px;
+  padding-bottom: 12px;
+  padding-top: 12px;
 }
+
 .user-subheader-options {
   font-family: $mallory_medium;
   color: $medium_grey;
   display: flex;
   padding-left: 18%;
-  padding-top: 2%
+  padding-top: 2%;
 }
+
 .user-subheader-current-user {
   display: flex;
 }
+
 .user-subheader-logout {
   padding-left: 10%;
   display: flex;
 }
+
 .user-subheader-logout a{
   display: flex;
   color: $medium_grey !important;
@@ -54,52 +60,51 @@ DEFAULT MOBILE STYLING
   width: 30px;
 
 }
+
+
+@media screen and (min-width: $small_device) {
+  .user-subheader {
+    width: 88%;
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
+
 @media screen and (min-width: $medium_device) {
   .user-subheader {
-    margin-left: 6%;
-    display: flex;
-    width: 675px;
-    margin-bottom: 4px;
+    width: 87%;
   }
+
   .user-subheader-options {
     padding-left: 35%;
-    padding-top: 2%
   }
+
   .user-subheader-logout {
     padding-left: 7.5%;
   }
 }
 
+
 @media screen and (min-width: $large_device) {
-  .user-subheader {
-    margin-left: 6.5%;
-    display: flex;
-    width: 875px;
-  }
   .user-subheader-title {
     font-size: 30px;
     width: 300px;
   }
+
   .user-subheader-options {
     padding-left: 45%;
     padding-top: 2%
   }
 }
 
+
 @media screen and (min-width: $xlarge_device) {
   .user-subheader {
-    margin-left: 6.5%;
-    display: flex;
-    width: 1025px;
+    width: 85%;
   }
-  .user-subheader-title {
-    font-size: 30px;
-    width: 300px;
-  }
+
   .user-subheader-options {
     padding-left: 52.5%;
-    padding-top: 2%
-  }
-  .user-subheader-logout {
   }
 }

--- a/app/views/shared/_user_subheader.html.erb
+++ b/app/views/shared/_user_subheader.html.erb
@@ -2,7 +2,9 @@
   <div class="user-subheader-title">
     Digital Collections
   </div>
-  <%if user_signed_in? %>
+  <%
+=begin%>
+ <%if user_signed_in? %>
     <div class="user-subheader-options" >
       <div class="user-subheader-current-user">
        <div class="user-logo"></div>
@@ -15,4 +17,6 @@
       </div>
     </div>
   <%end%>
+<%
+=end%>
 </div>

--- a/spec/system/subheader_spec.rb
+++ b/spec/system/subheader_spec.rb
@@ -9,12 +9,12 @@ RSpec.describe 'User Subheader', type: :system, js: true, style: true, clean: tr
     it 'has css' do
       expect(page).to have_css '.user-subheader'
       expect(page).to have_css '.user-subheader-title'
-      expect(page).not_to have_css '.user-subheader-options'
-      expect(page).not_to have_css '.user-subheader-current-user'
-      expect(page).not_to have_css '.user-subheader-logout '
-      expect(page).not_to have_css '.user-subheader-logout a'
-      expect(page).not_to have_css '.logout-logo '
-      expect(page).not_to have_css '.user-logo'
+      # expect(page).not_to have_css '.user-subheader-options'
+      # expect(page).not_to have_css '.user-subheader-current-user'
+      # expect(page).not_to have_css '.user-subheader-logout '
+      # expect(page).not_to have_css '.user-subheader-logout a'
+      # expect(page).not_to have_css '.logout-logo '
+      # expect(page).not_to have_css '.user-logo'
     end
 
     it 'does not have logout button' do
@@ -31,19 +31,19 @@ RSpec.describe 'User Subheader', type: :system, js: true, style: true, clean: tr
     it 'has css' do
       expect(page).to have_css '.user-subheader'
       expect(page).to have_css '.user-subheader-title'
-      expect(page).to have_css '.user-subheader-options'
-      expect(page).to have_css '.user-subheader-current-user'
-      expect(page).to have_css '.user-subheader-logout '
-      expect(page).to have_css '.user-subheader-logout a'
-      expect(page).to have_css '.logout-logo '
-      expect(page).to have_css '.user-logo'
+      # expect(page).to have_css '.user-subheader-options'
+      # expect(page).to have_css '.user-subheader-current-user'
+      # expect(page).to have_css '.user-subheader-logout '
+      # expect(page).to have_css '.user-subheader-logout a'
+      # expect(page).to have_css '.logout-logo '
+      # expect(page).to have_css '.user-logo'
     end
 
-    it 'signs user out on "Logout"' do
-      expect(page).to have_link("Logout")
-      click_on "Logout"
+    # it 'signs user out on "Logout"' do
+    #   expect(page).to have_link("Logout")
+    #   click_on "Logout"
 
-      expect(page).to have_content "Signed out successfully."
-    end
+    #   expect(page).to have_content "Signed out successfully."
+    # end
   end
 end


### PR DESCRIPTION
# Ticket
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/560

# Expected behavior
- Additional spacing between the bar underneath the Digital Collections row and the "Limit your search" text
- Additional spacing between the Digital Collections text and the search bar above it
- The grey line underneath the Digital Collections row right aligns with the gallery view box beneath it
- The icons for the user net id and log out options on the Digital Collections row have been commented out

# Demo
![560](https://user-images.githubusercontent.com/29032869/94067699-1d391c00-fda3-11ea-8248-74219d8e497e.gif)