### PR TITLE
Adds styling and buttons to advanced search footer

### DIFF
--- a/app/assets/stylesheets/customOverrides/advanced_search.scss
+++ b/app/assets/stylesheets/customOverrides/advanced_search.scss
@@ -10,7 +10,7 @@ DEFAULT MOBILE STYLING
   background: transparent;
   border: transparent;
   font-size: 16px;
-  font: $mallory_medium;
+  font-family: $mallory_medium, Arial, Helvetica, sans-serif;
   text-transform: uppercase;
 }
 
@@ -19,6 +19,22 @@ DEFAULT MOBILE STYLING
   color: $light_blue;
   border-color: transparent;
 }
+
+.sort-submit-buttons {
+  display: none;
+}
+
+.adv-search-sort-submit-buttons {
+  border-top: 1px solid $light_grey;
+  padding-top: 20px;
+}
+
+.adv-search-sort-submit-buttons .btn-primary:hover {
+  background-color: $white;
+  color: $yale_blue;
+  border-color: $medium_grey;
+}
+
 
 @media screen and (min-width: $small_device) {
   .advanced_search {
@@ -29,7 +45,6 @@ DEFAULT MOBILE STYLING
     background: transparent;
     border: transparent;
     font-size: 16px;
-    font: $mallory_medium;
     text-transform: uppercase;
   }
 
@@ -50,7 +65,6 @@ DEFAULT MOBILE STYLING
     background: transparent;
     border: transparent;
     font-size: 16px;
-    font: $mallory_medium;
     text-transform: uppercase;
   }
 
@@ -71,7 +85,6 @@ DEFAULT MOBILE STYLING
     background: transparent;
     border: transparent;
     font-size: 16px;
-    font: $mallory_medium;
     text-transform: uppercase;
   }
 
@@ -91,7 +104,6 @@ DEFAULT MOBILE STYLING
     background: transparent;
     border: transparent;
     font-size: 16px;
-    font: $mallory_medium;
     text-transform: uppercase;
   }
 

--- a/app/assets/stylesheets/customOverrides/advanced_search.scss
+++ b/app/assets/stylesheets/customOverrides/advanced_search.scss
@@ -29,10 +29,21 @@ DEFAULT MOBILE STYLING
   padding-top: 20px;
 }
 
+.adv-search-sort-submit-buttons .btn:not(:nth-child(2n)) {
+  margin-right: 20px;
+}
+
 .adv-search-sort-submit-buttons .btn-primary:hover {
   background-color: $white;
   color: $yale_blue;
-  border-color: $medium_grey;
+}
+.adv-search-sort-submit-buttons .btn-primary {
+  border-color: $light_grey;
+}
+
+.adv-search-sort-submit-buttons .btn-primary.advanced-search-start-over {
+  border: none;
+  color: $light_blue;
 }
 
 

--- a/app/assets/stylesheets/customOverrides/advanced_search.scss
+++ b/app/assets/stylesheets/customOverrides/advanced_search.scss
@@ -42,6 +42,7 @@ DEFAULT MOBILE STYLING
   font-size: 20px;
   font-weight: 500;
   padding: 12px 24px 12px 24px;
+  margin-bottom: 40px;
 }
 
 .adv-search-sort-submit-buttons .btn-primary.advanced-search-start-over {

--- a/app/assets/stylesheets/customOverrides/advanced_search.scss
+++ b/app/assets/stylesheets/customOverrides/advanced_search.scss
@@ -39,6 +39,9 @@ DEFAULT MOBILE STYLING
 }
 .adv-search-sort-submit-buttons .btn-primary {
   border-color: $light_grey;
+  font-size: 20px;
+  font-weight: 500;
+  padding: 12px 24px 12px 24px;
 }
 
 .adv-search-sort-submit-buttons .btn-primary.advanced-search-start-over {

--- a/app/views/advanced/_advanced_search_form.html.erb
+++ b/app/views/advanced/_advanced_search_form.html.erb
@@ -23,9 +23,14 @@
 
   </div>
 
-
   <div class="sort-submit-buttons clearfix">
     <%= render 'advanced_search_submit_btns' %>
+  </div>
+
+  <div class="adv-search-sort-submit-buttons clearfix">
+    <input type="submit" name="commit" value="SEARCH" class="btn btn-primary advanced-search-submit" id="advanced-search-submit" data-disable-with="Search" aria-label="Search">
+    <%= link_to "CLEAR", blacklight_advanced_search_engine.advanced_search_path, :class =>"btn btn-primary advanced-search-start-over", aria: { label: 'Clear Form' } %>
+    <%= link_to "BASIC SEARCH", root_path, :class =>"btn btn-primary pull-right", aria: { label: 'Basic Search' } %>
   </div>
 
 <% end %>

--- a/app/views/advanced/_advanced_search_form.html.erb
+++ b/app/views/advanced/_advanced_search_form.html.erb
@@ -29,8 +29,8 @@
 
   <div class="adv-search-sort-submit-buttons clearfix">
     <input type="submit" name="commit" value="SEARCH" class="btn btn-primary advanced-search-submit" id="advanced-search-submit" data-disable-with="Search" aria-label="Search">
-    <%= link_to "CLEAR", blacklight_advanced_search_engine.advanced_search_path, :class =>"btn btn-primary advanced-search-start-over", aria: { label: 'Clear Form' } %>
     <%= link_to "BASIC SEARCH", root_path, :class =>"btn btn-primary pull-right", aria: { label: 'Basic Search' } %>
+    <%= link_to "CLEAR", blacklight_advanced_search_engine.advanced_search_path, :class =>"btn btn-primary advanced-search-start-over", aria: { label: 'Clear Form' } %>
   </div>
 
 <% end %>

--- a/spec/system/advanced_search_spec.rb
+++ b/spec/system/advanced_search_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: tr
 
   it 'has css for the button' do
     visit root_path
-    page.should have_content "Advanced Search"
+    expect(page).to have_content "Advanced Search"
     expect(page).to have_css '.advanced_search'
     expect(page).to have_link('Advanced Search', href: '/advanced')
     find('.advanced_search').hover
@@ -26,7 +26,7 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: tr
     click_on "Advanced Search"
     # Search for something
     fill_in 'all_fields_advanced', with: 'Record 1'
-    click_on 'advanced-search-submit'
+    click_on 'SEARCH'
 
     within '#documents' do
       expect(page).to     have_content('Record 1')
@@ -38,7 +38,7 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: tr
     click_on 'Advanced Search'
     # Search for something
     fill_in 'author_tesim', with: 'Me and Frederick'
-    click_on 'advanced-search-submit'
+    click_on 'SEARCH'
     within '#documents' do
       expect(page).to     have_content('Record 1')
       expect(page).not_to have_content('Record 2')
@@ -49,7 +49,7 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: tr
     click_on 'Advanced Search'
     # Search for something
     fill_in 'identifierShelfMark_tesim', with: '["Landberg MSS 596"]'
-    click_on 'advanced-search-submit'
+    click_on 'SEARCH'
     within '#documents' do
       expect(page).to     have_content('Record 1')
       expect(page).not_to have_content('Record 2')
@@ -60,7 +60,7 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: tr
     click_on 'Advanced Search'
     # Search for something
     fill_in 'orbisBibId_ssi', with: '3832098'
-    click_on 'advanced-search-submit'
+    click_on 'SEARCH'
     within '#documents' do
       expect(page).to     have_content('Record 1')
       expect(page).not_to have_content('Record 2')
@@ -71,7 +71,7 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: tr
     click_on 'Advanced Search'
     # Search for something
     fill_in 'title_tesim', with: '["Record 1"]'
-    click_on 'advanced-search-submit'
+    click_on 'SEARCH'
     within '#documents' do
       expect(page).to     have_content('Record 1')
       expect(page).not_to have_content('Record 2')
@@ -82,7 +82,7 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: tr
     click_on 'Advanced Search'
     # Search for something
     fill_in 'oid_ssi', with: '11607445'
-    click_on 'advanced-search-submit'
+    click_on 'SEARCH'
     within '#documents' do
       expect(page).to     have_content('Record 1')
       expect(page).not_to have_content('Record 2')
@@ -93,10 +93,27 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: tr
     click_on 'Advanced Search'
     # Search for something
     fill_in 'child_oids_ssim', with: '11'
-    click_on 'advanced-search-submit'
+    click_on 'SEARCH'
     within '#documents' do
       expect(page).to     have_content('Record 1')
       expect(page).not_to have_content('Record 2')
+    end
+  end
+
+  describe 'footer' do
+    before do
+      visit root_path
+      click_on 'Advanced Search'
+    end
+
+    it 'renders buttons' do
+      expect(page).to have_button 'SEARCH'
+      expect(page).to have_link 'CLEAR', href: "/advanced"
+      expect(page).to have_link 'BASIC SEARCH', href: "/"
+    end
+
+    it 'does not render default sort and submit buttons' do
+      expect(page).not_to have_css 'sort-submit-buttons'
     end
   end
 end


### PR DESCRIPTION
# Summary
Styles the footer of the advanced search page.

# Related Ticket
#562 [ZenHub](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/562)

# Screenshot
<img width="655" alt="image" src="https://user-images.githubusercontent.com/36549923/94176124-7e68fa00-fe4c-11ea-82d9-dee4c253e8b4.png">


