### PR TITLE
Styles the input and help section of advanced search

### DIFF
--- a/app/assets/stylesheets/customOverrides/advanced_search.scss
+++ b/app/assets/stylesheets/customOverrides/advanced_search.scss
@@ -20,6 +20,39 @@ DEFAULT MOBILE STYLING
   border-color: transparent;
 }
 
+.adv-search-help h4 {
+  font-family: $yale_roman, $mallory_medium, Arial, Helvetica, sans-serif;
+  font-size: 28px;
+  font-weight: 500;
+  color: $yale_blue;
+  padding-left: 25px;
+}
+
+.adv-search-help li {
+  font-family: $mallory_mp_medium, $mallory_medium, Arial, Helvetica, sans-serif;
+  font-size: 14px;
+  font-weight: 500;
+  color: $medium_grey;
+}
+
+.adv-search-fields {
+  display: flex;
+  flex-wrap: wrap;
+  white-space: nowrap;
+}
+
+.adv-search-fields input {
+  border: 1px solid $medium_grey;
+  width: 325px;
+}
+
+.adv-search-fields label {
+  font-family: $mallory_mp_black, $mallory_medium, Arial, Helvetica, sans-serif;
+  font-size: 12px;
+  font-weight: 900;
+  color: $medium_grey;
+}
+
 @media screen and (min-width: $small_device) {
   .advanced_search {
     position: absolute;
@@ -59,6 +92,16 @@ DEFAULT MOBILE STYLING
     color: $light_blue;
     border-color: transparent;
   }
+
+  .adv-search-fields .advanced-search-field {
+    flex: 45%;
+    white-space: nowrap;
+    margin-bottom: 30px;
+  }
+
+  .adv-search-fields input {
+    margin-right: 5px;
+  }
 }
 
 
@@ -80,6 +123,10 @@ DEFAULT MOBILE STYLING
     color: $light_blue;
     border-color: transparent;
   }
+
+  .adv-search-fields input {
+    margin-right: 10px;
+  }
 }
 
 @media screen and (min-width: $xlarge_device) {
@@ -99,5 +146,15 @@ DEFAULT MOBILE STYLING
     background: none !important;
     color: $light_blue;
     border-color: transparent;
+  }
+
+  .adv-search-fields .advanced-search-field {
+    flex: 45%;
+    white-space: nowrap;
+    margin-bottom: 30px;
+  }
+
+  .adv-search-fields input {
+    margin-right: 10px;
   }
 }

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -276,6 +276,12 @@ class CatalogController < ApplicationController
     # Now we see how to over-ride Solr request handler defaults, in this
     # case for a BL "search field", which is really a dismax aggregate
     # of Solr search fields.
+    config.add_search_field('author_tesim', label: 'Creator') do |field|
+      field.solr_parameters = {
+        qf: 'author_tesim',
+        pf: ''
+      }
+    end
 
     config.add_search_field('title_tesim', label: 'Title') do |field|
       field.qt = 'search'
@@ -285,9 +291,18 @@ class CatalogController < ApplicationController
       }
     end
 
-    config.add_search_field('author_tesim', label: 'Author') do |field|
+    config.add_search_field('identifierShelfMark_tesim', label: 'Call Number') do |field|
+      field.qt = 'search'
       field.solr_parameters = {
-        qf: 'author_tesim',
+        qf: 'identifierShelfMark_tesim',
+        pf: ''
+      }
+    end
+
+    config.add_search_field('date_ssim', label: 'Date') do |field|
+      field.qt = 'search'
+      field.solr_parameters = {
+        qf: 'date_ssim',
         pf: ''
       }
     end
@@ -304,15 +319,38 @@ class CatalogController < ApplicationController
       }
     end
 
+    subject_fields = ['subjectEra_ssim', 'subjectGeographic_tesim', 'subjectTitle_tsim', 'subjectTitleDisplay_tsim', 'subjectName_ssim', 'subjectName_tesim', 'subjectTopic_tesim', 'subjectTopic_ssim']
+
+    config.add_search_field('subject_fields', label: 'Subject') do |field|
+      field.qt = 'search'
+      field.include_in_simple_select = false
+      field.solr_parameters = {
+        qf: subject_fields.join(' '),
+        pf: ''
+      }
+    end
+
+    genre_fields = ['format', 'genre_ssim']
+
+    config.add_search_field('genre_fields', label: 'Genre/format') do |field|
+      field.qt = 'search'
+      field.include_in_simple_select = false
+      field.solr_parameters = {
+        qf: genre_fields.join(' '),
+        pf: ''
+      }
+    end
+
     config.add_search_field('orbisBibId_ssi', label: 'BibID') do |field|
       field.qt = 'search'
+      field.include_in_advanced_search = false
       field.solr_parameters = {
         qf: 'orbisBibId_ssi',
         pf: ''
       }
     end
 
-    config.add_search_field('oid_ssi', label: 'OID') do |field|
+    config.add_search_field('oid_ssi', label: 'OID [Parent/primary]') do |field|
       field.qt = 'search'
       field.include_in_simple_select = false
       field.solr_parameters = {
@@ -321,7 +359,7 @@ class CatalogController < ApplicationController
       }
     end
 
-    config.add_search_field('child_oids_ssim', label: 'Child OID') do |field|
+    config.add_search_field('child_oids_ssim', label: 'OID [Child/images]') do |field|
       field.qt = 'search'
       field.include_in_simple_select = false
       field.solr_parameters = {
@@ -330,13 +368,6 @@ class CatalogController < ApplicationController
       }
     end
 
-    config.add_search_field('identifierShelfMark_tesim', label: 'Call Number') do |field|
-      field.qt = 'search'
-      field.solr_parameters = {
-        qf: 'identifierShelfMark_tesim',
-        pf: ''
-      }
-    end
     # "sort results by" select (pulldown)
     # label in pulldown is followed by the name of the SOLR field to sort by and
     # whether the sort is ascending or descending (it must be asc or desc

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -299,10 +299,12 @@ class CatalogController < ApplicationController
       }
     end
 
-    config.add_search_field('date_ssim', label: 'Date') do |field|
+    date_fields = ['date_ssim', 'dateStructured_ssim']
+
+    config.add_search_field('date_fields', label: 'Date') do |field|
       field.qt = 'search'
       field.solr_parameters = {
-        qf: 'date_ssim',
+        qf: date_fields.join(' '),
         pf: ''
       }
     end

--- a/app/views/advanced/_advanced_search_form.html.erb
+++ b/app/views/advanced/_advanced_search_form.html.erb
@@ -16,7 +16,7 @@
         <%= t('blacklight_advanced_search.form.query_criteria_heading_html', :select_menu =>  select_menu_for_field_operator ) %>
       </h3>
 
-      <div id="advanced_search">
+      <div id="advanced_search" class="adv-search-fields">
         <%= render 'advanced/advanced_search_fields' %>
       </div>
     </div>

--- a/app/views/advanced/index.html.erb
+++ b/app/views/advanced/index.html.erb
@@ -12,7 +12,7 @@
         <div class="col-md-8">
             <%= render 'advanced_search_form' %>
         </div>
-        <div class="col-md-4">
+        <div class="col-md-4 adv-search-help">
             <%= render "advanced_search_help" %>
         </div>
 

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe CatalogController, type: :controller do
       let(:search_fields) { controller.blacklight_config.search_fields.keys }
 
       let(:expected_search_fields) do
-        ["all_fields", "all_fields_advanced", "author_tesim", "child_oids_ssim", "date_ssim", "genre_fields",
+        ["all_fields", "all_fields_advanced", "author_tesim", "child_oids_ssim", "date_fields", "genre_fields",
          "identifierShelfMark_tesim", "oid_ssi", "orbisBibId_ssi", "subjectName_ssim", "subject_fields", "title_tesim"]
       end
 

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe CatalogController, type: :controller do
       let(:search_fields) { controller.blacklight_config.search_fields.keys }
 
       let(:expected_search_fields) do
-        ["all_fields", "all_fields_advanced", "author_tesim", "child_oids_ssim", "identifierShelfMark_tesim", "oid_ssi", "orbisBibId_ssi", "subjectName_ssim", "title_tesim"]
+        ["all_fields", "all_fields_advanced", "author_tesim", "child_oids_ssim", "date_ssim", "genre_fields",
+         "identifierShelfMark_tesim", "oid_ssi", "orbisBibId_ssi", "subjectName_ssim", "subject_fields", "title_tesim"]
       end
 
       it { expect(search_fields).to contain_exactly(*expected_search_fields) }

--- a/spec/support/solr_documents/advanced_search_testing_only.rb
+++ b/spec/support/solr_documents/advanced_search_testing_only.rb
@@ -97,7 +97,6 @@ ADVANCED_SEARCH_TESTING_2 = {
                         "Script: Written in humanistic script by Franciscus de Tianis of Pistoia."],
   "extent_ssim": ["ff. ii + 192 + i : parchment ; 271 x 177 (177 x 106) mm."],
   "extentOfDigitization_ssim": ["Complete work digitized."],
-  "format": ["mixed material"],
   "genre_ssim": ["Decorated initials",
                  "Manuscripts"],
   "identifierShelfMark_ssim": ["Beinecke MS 2"],

--- a/spec/system/advanced_search_spec.rb
+++ b/spec/system/advanced_search_spec.rb
@@ -99,4 +99,19 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: tr
       expect(page).not_to have_content('Record 2')
     end
   end
+
+  describe 'advanced search styling' do
+    before do
+      visit root_path
+      click_on 'Advanced Search'
+    end
+
+    it 'has correct field input style' do
+      expect(page).to have_css '.adv-search-fields'
+    end
+
+    it 'has correct help section style' do
+      expect(page).to have_css '.adv-search-help'
+    end
+  end
 end

--- a/spec/system/advanced_search_spec.rb
+++ b/spec/system/advanced_search_spec.rb
@@ -55,11 +55,22 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: tr
       expect(page).not_to have_content('Record 2')
     end
   end
-  it 'gets correct search results from orbisBibId_ssi' do
+  it 'gets correct search results from date_ssim' do
     visit root_path
     click_on 'Advanced Search'
     # Search for something
-    fill_in 'orbisBibId_ssi', with: '3832098'
+    fill_in 'date_ssim', with: '[17--?]'
+    click_on 'advanced-search-submit'
+    within '#documents' do
+      expect(page).to     have_content('Record 1')
+      expect(page).not_to have_content('Record 2')
+    end
+  end
+  it 'gets correct search results from subject_fields' do
+    visit root_path
+    click_on 'Advanced Search'
+    # Search for something
+    fill_in 'subject_fields', with: 'Belles lettres'
     click_on 'advanced-search-submit'
     within '#documents' do
       expect(page).to     have_content('Record 1')

--- a/spec/system/advanced_search_spec.rb
+++ b/spec/system/advanced_search_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: tr
         expect(page).not_to have_content('Record 2')
       end
     end
+
     it 'gets correct search results from author_tesim' do
       fill_in 'author_tesim', with: 'Me and Frederick'
       click_on 'SEARCH'
@@ -33,6 +34,7 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: tr
         expect(page).not_to have_content('Record 2')
       end
     end
+
     it 'gets correct search results from identifierShelfMark_tesim' do
       fill_in 'identifierShelfMark_tesim', with: '["Landberg MSS 596"]'
       click_on 'SEARCH'
@@ -41,14 +43,25 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: tr
         expect(page).not_to have_content('Record 2')
       end
     end
-    it 'gets correct search results from date_ssim' do
-      fill_in 'date_ssim', with: '[17--?]'
+
+    it 'gets correct search results from date_fields with date_ssim' do
+      fill_in 'date_fields', with: '[17--?]'
       click_on 'SEARCH'
       within '#documents' do
         expect(page).to     have_content('Record 1')
         expect(page).not_to have_content('Record 2')
       end
     end
+
+    it 'gets correct search results from date_fields with dateStructured_ssim' do
+      fill_in 'date_fields', with: '1700-00-00T00:00:00Z'
+      click_on 'SEARCH'
+      within '#documents' do
+        expect(page).to     have_content('Record 1')
+        expect(page).not_to have_content('Record 2')
+      end
+    end
+
     it 'gets correct search results from subject_fields' do
       fill_in 'subject_fields', with: 'Belles lettres'
       click_on 'SEARCH'
@@ -57,6 +70,16 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: tr
         expect(page).not_to have_content('Record 2')
       end
     end
+
+    it 'gets correct search results from genre_fields' do
+      fill_in 'genre_fields', with: 'Manuscripts'
+      click_on 'SEARCH'
+      within '#documents' do
+        expect(page).not_to have_content('Record 1')
+        expect(page).to     have_content('Record 2')
+      end
+    end
+
     it 'gets correct search results from title_tesim' do
       fill_in 'title_tesim', with: '["Record 1"]'
       click_on 'SEARCH'
@@ -65,6 +88,7 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: tr
         expect(page).not_to have_content('Record 2')
       end
     end
+
     it 'gets correct search results from oid_ssi' do
       fill_in 'oid_ssi', with: '11607445'
       click_on 'SEARCH'
@@ -73,6 +97,7 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: tr
         expect(page).not_to have_content('Record 2')
       end
     end
+
     it 'gets correct search results from child oid_ssim' do
       fill_in 'child_oids_ssim', with: '11'
       click_on 'SEARCH'
@@ -108,6 +133,6 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: tr
       expect(page).to have_css '.advanced_search'
       expect(page).to have_link('Advanced Search', href: '/advanced')
       find('.advanced_search').hover
-    end  
+    end
   end
 end

--- a/spec/system/search_fields_spec.rb
+++ b/spec/system/search_fields_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Search results displays field', type: :system, clean: true, js: 
 
   let(:search_fields) { CatalogController.blacklight_config.search_fields.keys }
   let(:expected_search_fields) do
-    ["all_fields", "all_fields_advanced", "author_tesim", "child_oids_ssim", "date_ssim", "genre_fields",
+    ["all_fields", "all_fields_advanced", "author_tesim", "child_oids_ssim", "date_fields", "genre_fields",
      "identifierShelfMark_tesim", "oid_ssi", "orbisBibId_ssi", "subjectName_ssim", "subject_fields", "title_tesim"]
   end
 

--- a/spec/system/search_fields_spec.rb
+++ b/spec/system/search_fields_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe 'Search results displays field', type: :system, clean: true, js: 
 
   let(:search_fields) { CatalogController.blacklight_config.search_fields.keys }
   let(:expected_search_fields) do
-    ["all_fields", "all_fields_advanced", "author_tesim", "child_oids_ssim", "identifierShelfMark_tesim", "oid_ssi", "orbisBibId_ssi", "subjectName_ssim", "title_tesim"]
+    ["all_fields", "all_fields_advanced", "author_tesim", "child_oids_ssim", "date_ssim", "genre_fields",
+     "identifierShelfMark_tesim", "oid_ssi", "orbisBibId_ssi", "subjectName_ssim", "subject_fields", "title_tesim"]
   end
 
   let(:dog) do


### PR DESCRIPTION
# Summary
Style the body section of the advanced search page

# Related Ticket
#563 [ZenHub](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/563)

# Screenshot

<img width="1305" alt="image" src="https://user-images.githubusercontent.com/36549923/94197812-24c3f800-fe6b-11ea-9d7e-e7126bfe53db.png">
