### PR TITLE
Adds fields to advanced search and changes author to creator

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -141,7 +141,7 @@ class CatalogController < ApplicationController
 
     # solr fields to be displayed in the index (search results) view
     #   The ordering of the field names is the order of the display
-    config.add_index_field 'author_tesim', label: 'Author', highlight: true
+    config.add_index_field 'author_tesim', label: 'Creator', highlight: true
     config.add_index_field 'date_ssim', label: 'Date'
     config.add_index_field 'identifierShelfMark_tesim', label: 'Call Number', highlight: true
     config.add_index_field 'imageCount_isi', label: 'Image Count'
@@ -185,7 +185,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'subjectTopic_tesim', label: 'Subject Topic'
 
     # Origin Group
-    config.add_show_field 'author_tsim', label: 'Author'
+    config.add_show_field 'author_tsim', label: 'Creator'
     config.add_show_field 'copyrightDate_ssim', label: 'Copyright Date'
     config.add_show_field 'coordinates_ssim', label: 'Coordinates'
     config.add_show_field 'date_ssim', label: 'Date'

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -264,11 +264,74 @@ class CatalogController < ApplicationController
       }
     end
 
+    advanced_search_fields = [
+      'abstract_tesim',
+      'accessRestrictions_tesim',
+      'accessionNumber_ssi',
+      'alternativeTitle_tesim',
+      'alternativeTitleDisplay_tesim',
+      'archiveSpaceUri_ssi',
+      'box_ssim',
+      'collectionId_tesim',
+      'contents_tesim',
+      'contributor_tsim',
+      'contributorDisplay_tsim',
+      'coordinates_ssim',
+      'author_tesim',
+      'creatorDisplay_tsim',
+      'date_ssim',
+      'dateStructured_ssim',
+      'copyrightDate_ssim',
+      'dateDepicted_ssim',
+      'description_tesim',
+      'digital_ssim',
+      'edition_ssim',
+      'extent_ssim',
+      'extentOfDigitization_ssim',
+      'folder_ssim',
+      'format',
+      'genre_ssim',
+      'identifierMfhd_ssim',
+      'identifierShelfMark_tesim',
+      'identifierShelfMark_ssim',
+      'illustrativeMatter_tesim',
+      'caption_tesim',
+      'label_tesim',
+      'language_ssim',
+      'localRecordNumber_ssim',
+      'material_tesim',
+      'oid_ssi',
+      'child_oids_ssim',
+      'orbisBarcode_ssi',
+      'orbisBibId_ssi',
+      'partOf_tesim',
+      'projection_tesim',
+      'publicationPlace_tesim',
+      'publisher_tesim',
+      'references_tesim',
+      'repository_ssim',
+      'resourceType_tesim',
+      'rights_tesim',
+      'scale_tesim',
+      'sourceCreated_tesim',
+      'sourceDate_tesim',
+      'sourceNote_tesim',
+      'sourceTitle_tesim',
+      'subjectEra_ssim',
+      'subjectGeographic_tesim',
+      'subjectTitle_tsim',
+      'subjectTitleDisplay_tsim',
+      'subjectName_tesim',
+      'subjectTopic_tesim',
+      'title_tesim',
+      'visibility_ssi'
+    ]
+
     config.add_search_field('all_fields_advanced', label: 'Common Fields') do |field|
       field.qt = 'search'
       field.include_in_simple_select = false
       field.solr_parameters = {
-        qf: search_fields.join(' '),
+        qf: advanced_search_fields.join(' '),
         pf: ''
       }
     end

--- a/spec/system/advanced_search_spec.rb
+++ b/spec/system/advanced_search_spec.rb
@@ -16,13 +16,13 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: tr
   let(:cat) { ADVANCED_SEARCH_TESTING_2 }
 
   describe 'searching' do
-    it 'gets correct search results from common fields' do
-      fill_in 'all_fields_advanced', with: 'Record 1'
+    it 'gets correct search results from advanced fields' do
+      fill_in 'all_fields_advanced', with: 'Latin'
       click_on 'SEARCH'
 
       within '#documents' do
-        expect(page).to     have_content('Record 1')
-        expect(page).not_to have_content('Record 2')
+        expect(page).not_to have_content('Record 1')
+        expect(page).to have_content('Record 2')
       end
     end
 


### PR DESCRIPTION
# Summary
* Add most fields to the 'Common Fields' input search on the Advanced Search page
* Changes 'Author' label to 'Creator'

# Related Ticket
#594 [ZenHub](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/594)

# Screenshot
<img width="509" alt="image" src="https://user-images.githubusercontent.com/36549923/94305266-c445c100-ff25-11ea-834e-9b992ee88981.png">
<img width="1244" alt="image" src="https://user-images.githubusercontent.com/36549923/94598390-b94fa100-0243-11eb-813f-ea8b21cbfb91.png">

