### PR TITLE
Gemfile rubocop fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,9 @@ ruby '2.6.6'
 
 gem 'awesome_print'
 gem 'blacklight', '>= 7.0'
+gem 'blacklight_advanced_search'
 gem 'blacklight-gallery'
 gem 'blacklight-marc', '>= 7.0.0.rc1', '< 8'
-gem "blacklight_advanced_search"
 gem 'blacklight_range_limit'
 gem 'bootsnap', '>= 1.4.2', require: false
 gem 'bootstrap', '~> 4.0'


### PR DESCRIPTION
# Summary
reordered the gemfile list per the rubocop warning below

![image](https://user-images.githubusercontent.com/29032869/94465905-77582980-0175-11eb-99dd-319043e85350.png)
