### PR TITLE
Style the advanced search header

### DIFF
--- a/app/assets/stylesheets/customOverrides/advanced_search.scss
+++ b/app/assets/stylesheets/customOverrides/advanced_search.scss
@@ -1,0 +1,187 @@
+/********************************************************
+DEFAULT MOBILE STYLING
+********************************************************/
+
+//TODO: add the correct font type YaleNew-Roman
+.advanced_page_header {
+  font-size: 27px;
+  color: $yale_blue;
+  font: $yale_italic;
+  margin-left: 12px;
+  padding-top: 25px;
+  margin-bottom: 13px;
+}
+
+.query_criteria_heading{
+  color:$medium_grey;
+  font-weight: bold;
+  font-size: 12px;
+  text-transform: uppercase;
+  font: $mallory_mp_black;
+  padding-left: 30px;
+}
+
+.input-small{
+  background-size: 11px;
+  background-position-x: right;
+  background-origin: content-box;
+  background-color: transparent;
+  display: inline-block;
+  width: 20%;
+  height: calc(1.75em + 1rem + 2px);
+  padding: 0.65rem 0.65rem 0.5rem 1rem;
+  vertical-align: baseline;
+  background-repeat: no-repeat;
+  background-image: image-url('light-blue-double-arrow.png');  border: 1px solid #ced4da;
+  border-radius: 0rem;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  color: $yale_blue;
+  text-transform: uppercase;
+  font-size: 14px;
+  font: $mallory_medium;
+  font-weight: bold;
+}
+//Sort text next to button
+.sort-buttons  {
+  color:$medium_grey;
+  font-weight: bold;
+  font-size: 12px;
+  text-transform: uppercase;
+  font: $mallory_mp_black;
+  padding-left: 30px;
+  margin-top: 20px;
+}
+//Sort button text
+.sort-select {
+  background-size: 11px;
+  background-position-y: center;
+  background-position-x: right;
+  background-origin: content-box;
+  display: inline-block;
+  width: 38%;
+  height: calc(1.65em + .65rem + .65rem) !important;
+  vertical-align: baseline;
+  background-repeat: no-repeat;
+  padding: 0.65rem 0.65rem 0.5rem 1rem;
+  background-image: image-url('light-blue-double-arrow.png');  border: 1px solid #ced4da!important;
+  border-radius: 0rem;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  color: $yale_blue;
+  text-transform: uppercase;
+  font-size: 14px;
+  font-weight: bold;
+  font: $mallory_medium;
+ }
+
+.input-match{
+  border-bottom: 1.75px solid $light_grey;
+  padding-bottom: 17px;
+  margin-bottom:13px
+}
+
+.advanced_search_clear_top{
+  float: right;
+  margin-top: -45px;
+  margin-right: 24px;
+}
+
+a.btn:nth-child(1) {
+  display: none;
+}
+
+input.btn:nth-child(2) {
+  display: none;
+}
+.advanced_search_fields > div > div >.form-control{
+  border: 1px solid #ced4da !important;
+}
+
+
+  @media screen and (min-width: $large_device) {
+    .advanced_page_header {
+      width:100%!important;
+      border-bottom: 1px solid #ced4da !important;
+      padding-bottom: 25px;
+      padding-top: 30px;
+    }
+    .advanced_search_form{
+      display: inline-flex;
+      flex-wrap: wrap;
+    }
+    .query_criteria_heading{
+      width: 330px;
+    }
+
+    //Sort text next to button
+    .sort-buttons  {
+      width: 500px;
+      margin-left: -75px;
+      margin-top: 4px;
+      }
+
+    .adv-search-sort-submit-buttons.sort-submit-top{
+      margin-top: -3px;
+    }
+
+
+    //Sort button text
+    .sort-select {
+      background-origin: content-box;
+      display: inline-block;
+      width: 225px;
+      height: calc(1.65em + .65rem + .65rem) !important;
+    }
+
+    .input-small{
+      width: 25%;
+    }
+
+    .input-match{
+      padding-bottom: 17px;
+      margin-bottom:13px;
+      display: inline-flex;
+      border: none;
+      position: absolute;
+      top: -81px;
+      left: 230px;
+      width: auto;
+    }
+
+    .advanced_search_clear_top{
+      float: right;
+      margin-top: -45px;
+      margin-right: 24px;
+    }
+  }
+
+  @media screen and (min-width: $xlarge_device) {
+    .input-match{
+      padding-bottom: 0;
+      margin-bottom: 0;
+      position: relative;
+      top: -81px;
+      left: 60%;
+      height: 0px
+    }
+
+    .advanced_search_fields{
+      position: relative;
+      top: -14px;
+    }
+
+
+    .input-small{
+      width: 29%;
+    }
+
+    .sort-buttons {
+      margin-left: -65px;
+      margin-top: 3px;
+    }
+
+    .query_criteria_heading{
+      margin-left: -35px;
+    }
+  }

--- a/app/assets/stylesheets/customOverrides/search_bar.scss
+++ b/app/assets/stylesheets/customOverrides/search_bar.scss
@@ -3,13 +3,14 @@ DEFAULT MOBILE STYLING
 ********************************************************/
 
 .advanced_search {
-  padding: 11px 0px 11px 23px;
+  padding: 14px 0px 11px 23px;
   color: $light_blue;
   background: transparent;
   border: transparent;
   font-size: 16px;
   font-family: $mallory_medium;
   text-transform: uppercase;
+  display: block !important;
 }
 
 .advanced_search:hover {
@@ -42,7 +43,7 @@ DEFAULT MOBILE STYLING
 .custom-select,
 .form-control,
 .search-btn {
-  padding: 17px;
+  padding: 14px;
   line-height: 1;
   border: 1px solid $border_grey;
   border-radius: 0px;
@@ -58,15 +59,13 @@ DEFAULT MOBILE STYLING
   font-family: $mallory_medium;
 }
 
-.form-control {
-  border-top: none;
-}
 
 .input-group {
   margin-top: 30px;
   margin-bottom: 30px;
   width: 98%;
 }
+
 
 .input-group .btn-primary:not(:disabled):not(.disabled):active,
 .input-group .search-btn:hover {

--- a/app/views/advanced/_advanced_search_form.html.erb
+++ b/app/views/advanced/_advanced_search_form.html.erb
@@ -1,4 +1,4 @@
-<% unless (search_context_str = render_search_to_s( advanced_search_context)).blank? %>
+<% unless (search_context_str = render_search_to_s(advanced_search_context)).blank? %>
   <div class="constraints well search_history">
     <h4><%= t 'blacklight_advanced_search.form.search_context' %></h4>
     <%= search_context_str %>
@@ -6,25 +6,23 @@
 <% end %>
 
 <%= form_tag search_catalog_path, :class => 'advanced form-horizontal', :method => :get do  %>
-
   <%= render_hash_as_hidden_fields(advanced_search_context) %>
 
-  <div class="input-criteria">
-
-    <div class="query-criteria">
-      <h3 class="query-criteria-heading">
+  <!--  Find items that match-->
+  <div class="input-match">
+    <div class="query-criteria" aria-valuetext="FIND ITEMS THAT MATCH">
+      <div class="query_criteria_heading">
         <%= t('blacklight_advanced_search.form.query_criteria_heading_html', :select_menu =>  select_menu_for_field_operator ) %>
-      </h3>
-
-      <div id="advanced_search" class="adv-search-fields">
-        <%= render 'advanced/advanced_search_fields' %>
       </div>
     </div>
-
+    <!--    Sort Results by-->
+    <div class="adv-search-sort-submit-buttons sort-submit-top  clearfix">
+      <%= render 'advanced_search_submit_btns' %>
+    </div>
   </div>
-
-  <div class="sort-submit-buttons clearfix">
-    <%= render 'advanced_search_submit_btns' %>
+  <!-- Fields on the form     -->
+  <div class="advanced_search_fields" id="advanced_search">
+    <%= render 'advanced/advanced_search_fields' %>
   </div>
 
   <div class="adv-search-sort-submit-buttons clearfix">

--- a/app/views/advanced/index.html.erb
+++ b/app/views/advanced/index.html.erb
@@ -1,14 +1,12 @@
 <% @page_title = "Advanced Search - #{application_name}" %>
 
-<div class="advanced-search-form col-sm-12">
+<div class="advanced_search_form col-sm-12">
 
-    <h1 class="advanced page-header">
+    <div class="advanced_page_header">
         <%= 'Advanced Search' %>
-        <%= link_to t('blacklight_advanced_search.form.start_over'), blacklight_advanced_search_engine.advanced_search_path, :class =>"btn btn-secondary pull-right advanced-search-start-over" %>
-    </h1>
+    </div>
 
     <div class="row">
-
         <div class="col-md-8">
             <%= render 'advanced_search_form' %>
         </div>

--- a/app/views/shared/_user_subheader.html.erb
+++ b/app/views/shared/_user_subheader.html.erb
@@ -1,22 +1,7 @@
+<%unless current_page?('/advanced') %>
 <div class="user-subheader">
   <div class="user-subheader-title">
     Digital Collections
   </div>
-  <%
-=begin%>
- <%if user_signed_in? %>
-    <div class="user-subheader-options" >
-      <div class="user-subheader-current-user">
-       <div class="user-logo"></div>
-        <%= current_user.email.presence || current_user.uid%>
-      </div>
-      <div class="user-subheader-logout">
-        <%= link_to(destroy_user_session_path, method: :delete, class: 'user-subheader-logout-link') do %>
-          <div class="logout-logo"></div> Logout
-        <%end %>
-      </div>
-    </div>
-  <%end%>
-<%
-=end%>
 </div>
+<%end%>

--- a/config/locales/blacklight_advanced_search.en.yml
+++ b/config/locales/blacklight_advanced_search.en.yml
@@ -1,0 +1,12 @@
+en:
+  blacklight_advanced_search:
+    all: all
+    any: any
+    form:
+      title: More Search Options
+      search_context: Within search
+      limit_criteria_heading_html: "<strong>AND</strong> have these attributes"
+      query_criteria_heading_html: "Find items that match %{select_menu}"
+      sort_label: "Sort results by"
+      start_over: "Start over"
+      search_btn: 'Search'

--- a/spec/system/advanced_search_spec.rb
+++ b/spec/system/advanced_search_spec.rb
@@ -108,9 +108,102 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: tr
     end
   end
 
+  context 'sorting' do
+    it 'can sort by date from oldest to newest' do
+      within '#sort' do
+        find("option[value='dateStructured_ssim desc, title_si asc']").click
+      end
+
+      click_on 'SEARCH'
+      within '#documents' do
+        expect(page).to have_content("1.\nRecord 1")
+        expect(page).to have_content("2.\nRecord 2")
+      end
+    end
+
+    it 'can sort by date from newest to oldest' do
+      within '#sort' do
+        find("option[value='dateStructured_ssim asc, title_si asc']").click
+      end
+
+      click_on 'SEARCH'
+      within '#documents' do
+        expect(page).to have_content("1.\nRecord 2")
+        expect(page).to have_content("2.\nRecord 1")
+      end
+    end
+
+    it 'can sort by year' do
+      within '#sort' do
+        find("option[value='pub_date_si desc, title_si asc']").click
+      end
+
+      click_on 'SEARCH'
+      within '#documents' do
+        expect(page).to have_content("1.\nRecord 1")
+        expect(page).to have_content("2.\nRecord 2")
+      end
+    end
+
+    it 'can sort by title' do
+      within '#sort' do
+        find("option[value='title_si asc, pub_date_si desc']").click
+      end
+
+      click_on 'SEARCH'
+      within '#documents' do
+        expect(page).to have_content("1.\nRecord 1")
+        expect(page).to have_content("2.\nRecord 2")
+      end
+    end
+
+    it 'can sort by author' do
+      within '#sort' do
+        find("option[value='author_si asc, title_si asc']").click
+      end
+
+      click_on 'SEARCH'
+      within '#documents' do
+        expect(page).to have_content("1.\nRecord 1")
+        expect(page).to have_content("2.\nRecord 2")
+      end
+    end
+  end
+
+  context 'Boolean logic' do
+    it 'displays both records with "any"' do
+      within '#op' do
+        find("option[value='OR']").click
+      end
+
+      fill_in 'oid_ssi', with: '11607445' # for record 1
+      fill_in 'author_tesim', with: 'Zeno, Jacopo, 1417-1481' # for record 2
+      click_on 'SEARCH'
+      within '#documents' do
+        expect(page).to have_content('Record 1')
+        expect(page).to have_content('Record 2')
+      end
+    end
+
+    it 'displays only 1 record with "all"' do
+      within '#op' do
+        find("option[value='AND']").click
+      end
+
+      fill_in 'oid_ssi', with: '11607445' # for record 1
+      fill_in 'author_tesim', with: '*'
+      click_on 'SEARCH'
+      within '#documents' do
+        expect(page).to have_content('Record 1')
+        expect(page).not_to have_content('Record 2')
+      end
+    end
+  end
+
   describe 'styling' do
     it 'renders field input style' do
-      expect(page).to have_css '.adv-search-fields'
+      expect(page).to have_css '.advanced_search_fields'
+      expect(page).to have_css '.advanced-search-field', count: 9
     end
 
     it 'renders help section style' do
@@ -123,13 +216,17 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: tr
       expect(page).to have_link 'BASIC SEARCH', href: "/"
     end
 
-    it 'does not render default sort and submit buttons in footer' do
-      expect(page).not_to have_css 'sort-submit-buttons'
+    it 'render sort and submit buttons in header' do
+      expect(page).to have_css '.sort-buttons'
+      expect(page).to have_css '#op'
+    end
+
+    it 'does not render default find items that match in header' do
+      expect(page).to have_css '.query_criteria_heading'
     end
 
     it 'renders the button on the homepage' do
       visit root_path
-      expect(page).to have_content "Advanced Search"
       expect(page).to have_css '.advanced_search'
       expect(page).to have_link('Advanced Search', href: '/advanced')
       find('.advanced_search').hover

--- a/spec/system/sort_in_search_spec.rb
+++ b/spec/system/sort_in_search_spec.rb
@@ -91,4 +91,6 @@ RSpec.describe 'Search results should be sorted', type: :system, js: :true, clea
     expect(content).to have_content("3.\nHandsomeDan Bulldog")
     expect(content).to have_content("4.\nAquila Eccellenza")
   end
+
+  # add author and title test
 end


### PR DESCRIPTION
Co-authored-by: Frederick Rodriguez <frederick.rodriguez@yale.com>

# Current UI
![image.png](https://images.zenhubusercontent.com/5e5ea9bffa78052c1cbcc74f/4bc9ad16-0be4-4c64-8ce6-0ca8b9555abd)

# Intended UI
![image.png](https://images.zenhubusercontent.com/5e5ea9bffa78052c1cbcc74f/b74186ea-c119-4cdd-89bf-18d555d7ec5b)

# PR UI
![Screen Shot 2020-09-30 at 4 05 29 PM](https://user-images.githubusercontent.com/40175979/94734244-f21c7280-0336-11eb-9761-6223133d8757.png)


# Acceptance Criteria
- [x] remove the Basic Search bar
- [x] replace "Digital Collections" with "Advanced Search"
- [x] the "find items..." section is aligned with the "Advanced Search" text
- [x] the button to clear the form says "Clear Search" instead of "Start Over"
- [x] the "Clear Search" button is styled correctly and in line with the "Advanced Search" text
- [x] the "sort by" dropdown that's on a regular search page, needs to also be on this page
- [x] the "sort by" dropdown needs to say "sort results by" and not just "sort by"
- [x] all text in the header have the proper color, font, sizes and capitalized
- [x] proper spacing between each of the items in the row, and between the row and the elements above/beneath it
- [x] remove the default hover and active state css changes on all drop downs and buttons in this section