### PR TITLE
Fix date slider for results with only one date facet.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -112,10 +112,10 @@ class CatalogController < ApplicationController
     config.add_facet_field 'dateStructured_ssim', label: 'Publication Date',
                                                   range: {
                                                     num_segments: 6,
-                                                    assumed_boundaries: [1100, Time.current.year + 2],
+                                                    assumed_boundaries: [800, Time.current.year + 2],
                                                     segments: true,
                                                     maxlength: 4
-                                                  }
+                                                  }, solr_params: { 'facet.pivot.mincount' => 2 }
 
     # the facets below are set to false because we aren't filtering on them from the main search page
     # but we need to be able to provide a label when they are filtered upon from an individual show page

--- a/spec/system/date_slider_spec.rb
+++ b/spec/system/date_slider_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 RSpec.describe "Blacklight Range Limit", type: :system, clean: true, js: true do
   before do
     solr = Blacklight.default_index.connection
-    solr.add([dog, cat, bird])
+    solr.add([dog, cat, bird, rabbit, elephant])
     solr.commit
   end
 
@@ -45,6 +45,32 @@ RSpec.describe "Blacklight Range Limit", type: :system, clean: true, js: true do
     }
   end
 
+  let(:rabbit) do
+    {
+      id: '400',
+      identifierShelfMark_ssim: 'call number',
+      title_tesim: 'Handsome Dan is not a rabbit.',
+      dateStructured_ssim: '1555',
+      author_tesim: 'Frederick & Eric',
+      sourceTitle_tesim: "this is the source title",
+      orbisBibId_ssi: '1234567',
+      visibility_ssi: 'Public'
+    }
+  end
+
+  let(:elephant) do
+    {
+      id: '401',
+      identifierShelfMark_ssim: 'call number',
+      title_tesim: 'Handsome Dan is not a elephant.',
+      dateStructured_ssim: '1555',
+      author_tesim: 'Frederick & Eric',
+      sourceTitle_tesim: "this is the source title",
+      orbisBibId_ssi: '1234567',
+      visibility_ssi: 'Public'
+    }
+  end
+
   it "shows the range limit facet" do
     visit root_path
     click_button 'Publication Date'
@@ -57,8 +83,13 @@ RSpec.describe "Blacklight Range Limit", type: :system, clean: true, js: true do
   it "provides date information" do
     visit root_path
     click_button 'Publication Date'
+    el = page.find(:css, '.slider.slider-horizontal > .tooltip.top.hide > .tooltip-inner', visible: false)
+    expect(el).to have_content("1100 : 2023")
+  end
 
-    expect(page).to have_content("1100 to 2022")
+  it "does not show the date slider if only one date" do
+    visit '?search_field=identifierShelfMark_tesim&q="call number"'
+    expect(page).not_to have_css('.card.facet-limit.blacklight-dateStructured_ssim')
   end
 
   xit "should be able to search with the slider" do


### PR DESCRIPTION
![image.png](https://images.zenhubusercontent.com/5e5ea9bffa78052c1cbcc74f/f9575dc0-07a1-4a06-9383-56e8d02384e0)

Fixes the above issue of a machine date appearing when results only have one date facet.