### PR TITLE
Advanced search footer styling

### DIFF
--- a/app/assets/stylesheets/customOverrides/advanced_search.scss
+++ b/app/assets/stylesheets/customOverrides/advanced_search.scss
@@ -12,6 +12,18 @@ DEFAULT MOBILE STYLING
   margin-bottom: 13px;
 }
 
+.adv-search-border-top{
+  width: auto;
+  border-top: 1px solid $light_grey;
+  padding-top: 20px;
+}
+
+.adv-search-border-bottom{
+  width: auto;
+  border-top: 1px solid $light_grey;
+  padding-top: 20px;
+}
+
 .query_criteria_heading{
   color:$medium_grey;
   font-weight: bold;
@@ -59,7 +71,7 @@ DEFAULT MOBILE STYLING
   background-position-x: right;
   background-origin: content-box;
   display: inline-block;
-  width: 38%;
+  width: 66%;
   height: calc(1.65em + .65rem + .65rem) !important;
   vertical-align: baseline;
   background-repeat: no-repeat;
@@ -76,7 +88,6 @@ DEFAULT MOBILE STYLING
  }
 
 .input-match{
-  border-bottom: 1.75px solid $light_grey;
   padding-bottom: 17px;
   margin-bottom:13px
 }
@@ -95,7 +106,7 @@ input.btn:nth-child(2) {
   display: none;
 }
 .advanced_search_fields > div > div >.form-control{
-  border: 1px solid #ced4da !important;
+  border: 1px solid $light_grey !important;
 }
 
 .adv-search-help h4 {
@@ -132,6 +143,10 @@ input.btn:nth-child(2) {
 }
 
 @media screen and (min-width: $medium_device) {
+  .adv-search-border-top{
+    width: 154%;
+  }
+
   .adv-search-help{
     display: contents;
     position: relative;
@@ -139,12 +154,26 @@ input.btn:nth-child(2) {
     padding-right: 15px;
     padding-left: 15px;
   }
+
+  .adv-search-border-bottom{
+    width: 154%;
+    border-top: 1px solid $light_grey;
+    padding-top: 20px;
+  }
 }
 
   @media screen and (min-width: $large_device) {
+
+    .adv-search-border-top{
+      width: 160%;
+    }
+
+    .adv-search-border-bottom{
+      width: 160%;
+    }
+
     .advanced_page_header {
       width:100%!important;
-      border-bottom: 1px solid #ced4da !important;
       padding-bottom: 25px;
       padding-top: 30px;
     }
@@ -211,11 +240,15 @@ input.btn:nth-child(2) {
       height: 0px
     }
 
+    .adv-search-border-top{
+      margin-top: -40px;
+      margin-bottom: 20px;
+    }
+
     .advanced_search_fields{
       position: relative;
       top: -14px;
     }
-
 
     .input-small{
       width: 29%;

--- a/app/assets/stylesheets/customOverrides/advanced_search.scss
+++ b/app/assets/stylesheets/customOverrides/advanced_search.scss
@@ -98,6 +98,48 @@ input.btn:nth-child(2) {
   border: 1px solid #ced4da !important;
 }
 
+.adv-search-help h4 {
+  font-family: $yale_roman, $mallory_medium, Arial, Helvetica, sans-serif;
+  font-size: 28px;
+  font-weight: 500;
+  color: $yale_blue;
+  padding-left: 25px;
+}
+
+.adv-search-help li {
+  font-family: $mallory_mp_medium, $mallory_medium, Arial, Helvetica, sans-serif;
+  font-size: 14px;
+  font-weight: 500;
+  color: $medium_grey;
+}
+
+.adv-search-fields {
+  display: flex;
+  flex-wrap: wrap;
+  white-space: nowrap;
+}
+
+.adv-search-fields input {
+  border: 1px solid $medium_grey;
+  width: 325px;
+}
+
+.adv-search-fields label {
+  font-family: $mallory_mp_black, $mallory_medium, Arial, Helvetica, sans-serif;
+  font-size: 12px;
+  font-weight: 900;
+  color: $medium_grey;
+}
+
+@media screen and (min-width: $medium_device) {
+  .adv-search-help{
+    display: contents;
+    position: relative;
+    width: 100%;
+    padding-right: 15px;
+    padding-left: 15px;
+  }
+}
 
   @media screen and (min-width: $large_device) {
     .advanced_page_header {
@@ -124,7 +166,6 @@ input.btn:nth-child(2) {
     .adv-search-sort-submit-buttons.sort-submit-top{
       margin-top: -3px;
     }
-
 
     //Sort button text
     .sort-select {
@@ -153,6 +194,10 @@ input.btn:nth-child(2) {
       float: right;
       margin-top: -45px;
       margin-right: 24px;
+    }
+
+    .adv-search-fields input {
+      margin-right: 10px;
     }
   }
 
@@ -184,4 +229,18 @@ input.btn:nth-child(2) {
     .query_criteria_heading{
       margin-left: -35px;
     }
+
+    .adv-search-fields .advanced-search-field {
+      flex: 45%;
+      white-space: nowrap;
+      margin-bottom: 30px;
+    }
+
+    .adv-search-fields input {
+      margin-right: 10px;
+    }
+    .adv-search-help{
+      display: inline-block;
+    }
+
   }

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -144,7 +144,7 @@ class CatalogController < ApplicationController
     # solr fields to be displayed in the index (search results) view
     #   The ordering of the field names is the order of the display
     config.add_index_field 'author_tesim', label: 'Creator', highlight: true
-    config.add_index_field 'date_ssim', label: 'Date',highlight: true
+    config.add_index_field 'date_ssim', label: 'Date', highlight: true
     config.add_index_field 'identifierShelfMark_tesim', label: 'Call Number', highlight: true
     config.add_index_field 'imageCount_isi', label: 'Image Count'
     config.add_index_field 'partOf_ssim', label: 'Collection Name'

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -144,7 +144,7 @@ class CatalogController < ApplicationController
     # solr fields to be displayed in the index (search results) view
     #   The ordering of the field names is the order of the display
     config.add_index_field 'author_tesim', label: 'Creator', highlight: true
-    config.add_index_field 'date_ssim', label: 'Date'
+    config.add_index_field 'date_ssim', label: 'Date',highlight: true
     config.add_index_field 'identifierShelfMark_tesim', label: 'Call Number', highlight: true
     config.add_index_field 'imageCount_isi', label: 'Image Count'
     config.add_index_field 'partOf_ssim', label: 'Collection Name'

--- a/app/views/advanced/_advanced_search_form.html.erb
+++ b/app/views/advanced/_advanced_search_form.html.erb
@@ -16,7 +16,7 @@
       </div>
     </div>
     <!--    Sort Results by-->
-    <div class="adv-search-sort-submit-buttons sort-submit-top  clearfix">
+    <div class="adv-search-sort-submit-buttons sort-submit-top adv-search-fields clearfix">
       <%= render 'advanced_search_submit_btns' %>
     </div>
   </div>

--- a/app/views/advanced/_advanced_search_form.html.erb
+++ b/app/views/advanced/_advanced_search_form.html.erb
@@ -20,9 +20,16 @@
       <%= render 'advanced_search_submit_btns' %>
     </div>
   </div>
+
+  <div class="adv-search-border-top">
+  </div>
+
   <!-- Fields on the form     -->
   <div class="advanced_search_fields" id="advanced_search">
     <%= render 'advanced/advanced_search_fields' %>
+  </div>
+
+  <div class="adv-search-border-bottom">
   </div>
 
   <div class="adv-search-sort-submit-buttons clearfix">

--- a/spec/system/advanced_search_spec.rb
+++ b/spec/system/advanced_search_spec.rb
@@ -216,6 +216,14 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: tr
       expect(page).to have_link 'BASIC SEARCH', href: "/"
     end
 
+    it 'renders header border' do
+      expect(page).to have_css '.adv-search-border-top'
+    end
+
+    it 'renders footer border' do
+      expect(page).to have_css '.adv-search-border-bottom'
+    end
+
     it 'render sort and submit buttons in header' do
       expect(page).to have_css '.sort-buttons'
       expect(page).to have_css '#op'


### PR DESCRIPTION
# Summary
Updated the Advanced Search page to reflect the design [in zeplin](https://app.zeplin.io/project/5f0fd2b5fa16ac9ddd54d6fa/screen/5f5707bfd9b7b87a960b8314)

# Current UI
![image.png](https://images.zenhubusercontent.com/5e5ea9bffa78052c1cbcc74f/aeb72f2b-56dc-4b46-8ee9-1554e5ae96f7)

# Intended UI
![image.png](https://images.zenhubusercontent.com/5e5ea9bffa78052c1cbcc74f/b92f6103-562e-4bee-8903-f0e480309f10)

# Acceptance Criteria
- [x] all text in the ~"start over"~ "clear search" button has the proper color, font, size and capitalized
- [x] all text in the "search" button has the proper color, font, size and capitalized
- [x] the borders of both buttons have the proper color and size
- [x] remove the default hover and active state css changes on all drop downs and buttons in this section
- [x] from left to right the buttons are ordered "Search", "Clear", and a "Basic Search" link
- [x] proper spacing between each of the buttons, and between the row and the elements above/beneath it