### PR TITLE
Style search results list view

### DIFF
--- a/app/assets/stylesheets/customOverrides/index_gallery.scss
+++ b/app/assets/stylesheets/customOverrides/index_gallery.scss
@@ -1,149 +1,60 @@
 /********************************************************
 DEFAULT MOBILE STYLING
 ********************************************************/
-.gallery.row {
-  .dd {
-    margin-left: 22%;
-    text-align: justify;
-  }
 
-  .dt {
-    position: relative;
-  }
+.caption,
+.caption > .documentHeader {
+  width: 200px;
+}
 
-  .document-title {
-    padding-left: 10px;
-    padding-bottom: 10px;
-  }
+.document.col {
+  display: flex;
+  margin-bottom: 50px;
+}
 
-  .document-title-heading {
-    display: contents;
-    position: static;
-    max-width: 45%;
-    margin-bottom: 3%;
-  }
+.document.col .caption .documentHeader {
+  padding-left: 15px !important;
+}
 
-  .documentHeader {
-    padding-left: 19px !important;
-    display: -webkit-box;
-  }
+.caption .document-title {
+  font-size: 14px;
+  font-family: $mallory_mp_medium;
+  padding-left: 0;
+  padding-bottom: 0;
+  width: 200px;
+  margin-top: 14px;
+}
 
-  .search-highlight {
-    background-color: yellow;
-  }
+.document-title > a {
+  color: $light_blue;
+}
 
-  //Fields on Single Items and Search Result pages
-  .document-metadata {
-    display: contents;
-    position: static;
-    max-width: 55%;
-    margin-bottom: 3%;
-  }
+#documents .thumbnail > a {
+  width: 200px;
+  display: block;
+}
 
-  .caption,
-  .caption > .documentHeader {
-    width: 200px;
-  }
+.row-cols-2 > * {
+  max-width: 100%;
+  flex: 0 0 100%;
+}
 
-  .document.col {
-    display: flex;
-    margin-bottom: 50px;
-  }
 
-  .document.col .caption .documentHeader {
-    padding-left: 15px !important;
-  }
-
-  .caption .document-title {
-    font-size: 14px;
-    font-family: $mallory_mp_medium;
-    padding-left: 0;
-    padding-bottom: 0;
-    width: 200px;
-    margin-top: 14px;
-  }
-
-  .document-title > a {
-    color: $light_blue;
-  }
-
+@media screen and (min-width: $small_device) {
   #documents .thumbnail > a {
-    width: 200px;
-    display: block;
+    height: 200px;
   }
 
   .row-cols-2 > * {
-    max-width: 100%;
-    flex: 0 0 100%;
+    max-width: 50%;
+    flex: 0 0 50%;
   }
+}
 
 
-  @media screen and (min-width: $small_device) {
-    #documents .thumbnail > a {
-      height: 200px;
-    }
-
-    .row-cols-2 > * {
-      max-width: 50%;
-      flex: 0 0 50%;
-    }
-  }
-
-  @media screen and (min-width: $medium_device) {
-    .dl-invert dt {
-      position: absolute;
-      width: 100%;
-      padding-right: 15px;
-      padding-left: 0px !important;
-    }
-
-    .document-metadata {
-      max-width: 55%;
-      margin-bottom: 3%;
-    }
-
-    .col-md-9 {
-      padding-left: 25%;
-    }
-  }
-
-
-  @media screen and (min-width: $large_device) {
-
-    .dl-invert dt {
-      position: absolute;
-      width: 100%;
-      padding-right: 15px;
-      padding-left: 0px !important;
-    }
-
-    .document-metadata {
-      max-width: 55%;
-      margin-bottom: 3%;
-    }
-
-    .col-md-9 {
-      padding-left: 25%;
-    }
-  }
-
-
-  @media screen and (min-width: $xlarge_device) {
-    .row-cols-2 > * {
-      max-width: 33%;
-      flex: 0 0 33%;
-    }
-    .dl-invert dt {
-      position: absolute;
-    }
-
-    .document-metadata {
-      max-width: 55%;
-      margin-bottom: 3%;
-    }
-
-    .col-md-9 {
-      padding-left: 25%;
-    }
+@media screen and (min-width: $xlarge_device) {
+  .row-cols-2 > * {
+    max-width: 33%;
+    flex: 0 0 33%;
   }
 }

--- a/app/assets/stylesheets/customOverrides/index_gallery.scss
+++ b/app/assets/stylesheets/customOverrides/index_gallery.scss
@@ -1,60 +1,149 @@
 /********************************************************
 DEFAULT MOBILE STYLING
 ********************************************************/
+.gallery.row {
+  .dd {
+    margin-left: 22%;
+    text-align: justify;
+  }
 
-.caption,
-.caption > .documentHeader {
-  width: 200px;
-}
+  .dt {
+    position: relative;
+  }
 
-.document.col {
-  display: flex;
-  margin-bottom: 50px;
-}
+  .document-title {
+    padding-left: 10px;
+    padding-bottom: 10px;
+  }
 
-.document.col .caption .documentHeader {
-  padding-left: 15px !important;
-}
+  .document-title-heading {
+    display: contents;
+    position: static;
+    max-width: 45%;
+    margin-bottom: 3%;
+  }
 
-.caption .document-title {
-  font-size: 14px;
-  font-family: $mallory_mp_medium;
-  padding-left: 0;
-  padding-bottom: 0;
-  width: 200px;
-  margin-top: 14px;
-}
+  .documentHeader {
+    padding-left: 19px !important;
+    display: -webkit-box;
+  }
 
-.document-title > a {
-  color: $light_blue;
-}
+  .search-highlight {
+    background-color: yellow;
+  }
 
-#documents .thumbnail > a {
-  width: 200px;
-  display: block;
-}
+  //Fields on Single Items and Search Result pages
+  .document-metadata {
+    display: contents;
+    position: static;
+    max-width: 55%;
+    margin-bottom: 3%;
+  }
 
-.row-cols-2 > * {
-  max-width: 100%;
-  flex: 0 0 100%;
-}
+  .caption,
+  .caption > .documentHeader {
+    width: 200px;
+  }
 
+  .document.col {
+    display: flex;
+    margin-bottom: 50px;
+  }
 
-@media screen and (min-width: $small_device) {
+  .document.col .caption .documentHeader {
+    padding-left: 15px !important;
+  }
+
+  .caption .document-title {
+    font-size: 14px;
+    font-family: $mallory_mp_medium;
+    padding-left: 0;
+    padding-bottom: 0;
+    width: 200px;
+    margin-top: 14px;
+  }
+
+  .document-title > a {
+    color: $light_blue;
+  }
+
   #documents .thumbnail > a {
-    height: 200px;
+    width: 200px;
+    display: block;
   }
 
   .row-cols-2 > * {
-    max-width: 50%;
-    flex: 0 0 50%;
+    max-width: 100%;
+    flex: 0 0 100%;
   }
-}
 
 
-@media screen and (min-width: $xlarge_device) {
-  .row-cols-2 > * {
-    max-width: 33%;
-    flex: 0 0 33%;
+  @media screen and (min-width: $small_device) {
+    #documents .thumbnail > a {
+      height: 200px;
+    }
+
+    .row-cols-2 > * {
+      max-width: 50%;
+      flex: 0 0 50%;
+    }
+  }
+
+  @media screen and (min-width: $medium_device) {
+    .dl-invert dt {
+      position: absolute;
+      width: 100%;
+      padding-right: 15px;
+      padding-left: 0px !important;
+    }
+
+    .document-metadata {
+      max-width: 55%;
+      margin-bottom: 3%;
+    }
+
+    .col-md-9 {
+      padding-left: 25%;
+    }
+  }
+
+
+  @media screen and (min-width: $large_device) {
+
+    .dl-invert dt {
+      position: absolute;
+      width: 100%;
+      padding-right: 15px;
+      padding-left: 0px !important;
+    }
+
+    .document-metadata {
+      max-width: 55%;
+      margin-bottom: 3%;
+    }
+
+    .col-md-9 {
+      padding-left: 25%;
+    }
+  }
+
+
+  @media screen and (min-width: $xlarge_device) {
+    .row-cols-2 > * {
+      max-width: 33%;
+      flex: 0 0 33%;
+    }
+    .dl-invert dt {
+      position: absolute;
+    }
+
+    .document-metadata {
+      max-width: 55%;
+      margin-bottom: 3%;
+    }
+
+    .col-md-9 {
+      padding-left: 25%;
+    }
   }
 }

--- a/app/assets/stylesheets/customOverrides/search_result.scss
+++ b/app/assets/stylesheets/customOverrides/search_result.scss
@@ -1,105 +1,51 @@
 /********************************************************
 DEFAULT MOBILE STYLING
 ********************************************************/
-
-.document-title > a {
-  color: $light_blue;
-  max-width: 420px;
-  font-family: $mallory_medium;
-  font-size: 15px;
-}
-
-.search-highlight {
-  background-color: yellow;
-}
-
-.dd {
-  margin-left:  22%;
-  text-align: justify;
-}
-
-.dt {
-  position: relative;
-}
-
-.document-title{
-  padding-left: 10px;
-  padding-bottom: 10px;
-}
-
-.document-title-heading {
-  display: contents;
-  position: static;
-  margin-bottom: 3%;
-}
-
-.documentHeader{
-  padding-left: 19px!important;
-  display: -webkit-box;
-}
-
-
-//Fields on Single Items and Search Result pages
-.document-metadata{
-  display: contents;
-  position: static;
-  max-width: 55%;
-  margin-bottom: 3%;
-}
-
-@media screen and (min-width: $medium_device) {
-  //.dl-invert dt {
-  //  position: absolute;
-  //  width: 100%;
-  //  padding-right: 15px;
-  //  padding-left: 0px!important;
-  //}
-  //
-  //.document-metadata {
-  //  max-width: 55%;
-  //  margin-bottom: 3%;
-  //}
-  //
-  //.col-md-9 {
-  //  padding-left: 25%;
-  //}
-}
-
-@media screen and (min-width: $large_device) {
-  //.dl-invert dt {
-  //  position: absolute;
-  //  width: 100%;
-  //  padding-right: 15px;
-  //  padding-left: 0px!important;
-  //}
-  //
-  //.document-metadata {
-  //  max-width: 55%;
-  //  margin-bottom: 3%;
-  //}
-  //
-  //.col-md-9 {
-  //  padding-left: 25%;
-  //}
-}
-
-@media screen and (min-width: $xlarge_device) {
-
-  .document{
-    width: 100%;
-    height: auto;
-    padding-bottom: 40px;
-    padding-right: calc(100% - 780px);
+.documents-list {
+  .counter_no_show{
+   display: none;
   }
 
-  .documentHeader.row{
-    display: -webkit-box;
-    margin-bottom: 1rem;
-    width: 420px!important;
-    padding-left: 0!important;
-    margin-left: 0!important;
+  .document-title > a {
+    color: $light_blue;
+    max-width: 420px;
+    font-family: $mallory_medium;
+    font-size: 15px;
+  }
+
+  .search-highlight {
+    background-color: yellow;
+  }
+
+  .dd {
+    margin-left: 22%;
+    text-align: justify;
+  }
+
+  .dt {
     position: relative;
-    float: right;
+  }
+
+  .document-title {
+    padding-left: 10px;
+    padding-bottom: 10px;
+  }
+
+  .document-title-heading {
+    display: contents;
+    position: static;
+    margin-bottom: 3%;
+  }
+
+  .documentHeader {
+    padding-left: 19px !important;
+    display: -webkit-box;
+  }
+
+  .documentHeader.row {
+    margin-bottom: 1rem;
+    padding-left: 0px !important;
+    position: relative;
   }
 
   .documents-list.document {
@@ -108,24 +54,20 @@ DEFAULT MOBILE STYLING
     padding-top: 2rem;
   }
 
-  .document-title{
+  .document-title {
     position: relative;
     font-size: 15px;
     width: 492px;
     display: -webkit-inline-flex;
     margin-top: 0rem;
     text-align: left;
-    left: -99px;
   }
 
-  .document-metadata.dl-invert.row{
+  .document-metadata.dl-invert.row {
     display: inline-block;
     position: relative;
-    top: -20px;
-    left: -90px;
-    width: 800px;
-    margin-bottom: 20px;
-    float: right;
+    top: 9px;
+    margin-bottom: 40px;
   }
 
   //Solr field titles
@@ -133,7 +75,7 @@ DEFAULT MOBILE STYLING
     width: 200px;
     text-align: left;
     position: relative;
-    color:$medium_grey;
+    color: $medium_grey;
     font-family: $mallory_mp_black;
     font-size: 12px;
     display: contents;
@@ -141,10 +83,10 @@ DEFAULT MOBILE STYLING
   }
 
   //Solr field details
-  .dl-invert dd{
+  .dl-invert dd {
     font-size: 12px;
     font: $mallory_medium;
-    color:$medium_grey;
+    color: $medium_grey;
     flex-wrap: wrap;
     margin-top: -21px;
     margin-left: 74px;
@@ -155,26 +97,204 @@ DEFAULT MOBILE STYLING
     margin-bottom: 1%;
 
   }
+
   .document-thumbnail {
-    float: left!important;
-    margin: 12px 0 0 0!important;
-    margin-left: 10px;
-    height: 200px;
-    width:200px;
+    float: left !important;
+    margin: 12px 100% 12px 0 !important;
+    width: 200px;
     padding-top: 0px;
+    padding-left: .25rem !important;
   }
 
   //styling for title on search result page
   .document-title {
-    font-size:15px;
+    font-size: 15px;
     display: -webkit-inline-flex;
     margin-top: 0rem;
     padding-left: 0;
   }
+
   .col-md-9 {
     padding-left: 25%;
   }
+
   .row {
     margin-left: 5px !important;
+  }
+
+  @media screen and (min-width: $medium_device) {
+    .document {
+      width: 100%;
+      height: auto;
+      padding-right: calc(100% - 780px);
+    }
+
+    .documentHeader.row {
+      margin-bottom: 1rem;
+      width: 800px !important;
+      padding-left: 0px !important;
+      max-width: 55% !important;
+      position: relative;
+      float: right;
+      left: -85px;
+      top: 5px;
+    }
+
+    .documents-list.document {
+      border-bottom: 1px dotted $light_grey;
+      margin-top: 0rem;
+      padding-top: 2rem;
+    }
+
+    .document-title {
+      position: relative;
+      font-size: 15px;
+      width: 492px;
+      display: -webkit-inline-flex;
+      margin-top: 0rem;
+      text-align: left;
+    }
+
+    .document-metadata.dl-invert.row {
+      display: inline-block;
+      position: relative;
+      top: -20px;
+      left: -85px;
+      width: 800px;
+      margin-bottom: 20px;
+      float: right;
+    }
+
+    //Solr field titles
+    .dl-invert dt {
+      width: 200px;
+      text-align: left;
+      position: relative;
+      color: $medium_grey;
+      font-family: $mallory_mp_black;
+      font-size: 12px;
+      display: contents;
+      left: -38px;
+    }
+
+    //Solr field details
+    .dl-invert dd {
+      font-size: 12px;
+      font: $mallory_medium;
+      color: $medium_grey;
+      flex-wrap: wrap;
+      margin-top: -21px;
+      margin-left: 74px;
+    }
+
+    .document-metadata {
+      max-width: 55%;
+      margin-bottom: 1%;
+
+    }
+    .document-thumbnail {
+      float: left !important;
+      margin: 12px 0 20px 0 !important;
+      height: 200px;
+      width: 200px;
+      padding-top: 0px;
+    }
+
+    //styling for title on search result page
+    .document-title {
+      font-size: 15px;
+      display: -webkit-inline-flex;
+      margin-top: 0rem;
+      padding-left: 0;
+    }
+    .col-md-9 {
+      padding-left: 25%;
+    }
+    .row {
+      margin-left: 5px !important;
+    }
+  }
+
+  @media screen and (min-width: $large_device) {
+    margin-left: 10px;
+
+    .document-thumbnail {
+      margin: 12px 0 20px -8px !important;
+    }
+  }
+
+  @media screen and (min-width: $xlarge_device) {
+    margin-left: 0;
+
+    .documentHeader.row {
+      margin-bottom: 1rem;
+      width: 800px !important;
+      padding-left: 0px !important;
+      max-width: 55% !important;
+      position: relative;
+      float: right;
+      left: -85px;
+      top: 5px;
+    }
+
+    .document-metadata.dl-invert.row {
+      display: inline-block;
+      position: relative;
+      top: -20px;
+      left: -85px;
+      width: 800px;
+      margin-bottom: 20px;
+      float: right;
+    }
+
+    //Solr field titles
+    .dl-invert dt {
+      width: 200px;
+      text-align: left;
+      position: relative;
+      color: $medium_grey;
+      font-family: $mallory_mp_black;
+      font-size: 12px;
+      display: contents;
+      left: -38px;
+    }
+
+    //Solr field details
+    .dl-invert dd {
+      font-size: 12px;
+      font: $mallory_medium;
+      color: $medium_grey;
+      flex-wrap: wrap;
+      margin-top: -21px;
+      margin-left: 74px;
+    }
+
+    .document-metadata {
+      max-width: 55%;
+      margin-bottom: 1%;
+
+    }
+
+    .document-thumbnail {
+      float: left !important;
+      margin: 12px 0 40px 45px !important;
+      height: 200px;
+      width: 200px;
+      padding-top: 0px;
+    }
+
+    //styling for title on search result page
+    .document-title {
+      font-size: 15px;
+      display: -webkit-inline-flex;
+      margin-top: 0rem;
+      padding-left: 0;
+    }
+    .col-md-9 {
+      padding-left: 25%;
+    }
+    .row {
+      margin-left: 5px !important;
+    }
   }
 }

--- a/app/assets/stylesheets/customOverrides/search_result.scss
+++ b/app/assets/stylesheets/customOverrides/search_result.scss
@@ -2,6 +2,17 @@
 DEFAULT MOBILE STYLING
 ********************************************************/
 
+.document-title > a {
+  color: $light_blue;
+  max-width: 420px;
+  font-family: $mallory_medium;
+  font-size: 15px;
+}
+
+.search-highlight {
+  background-color: yellow;
+}
+
 .dd {
   margin-left:  22%;
   text-align: justify;
@@ -15,10 +26,10 @@ DEFAULT MOBILE STYLING
   padding-left: 10px;
   padding-bottom: 10px;
 }
+
 .document-title-heading {
   display: contents;
   position: static;
-  max-width: 45%;
   margin-bottom: 3%;
 }
 
@@ -27,9 +38,6 @@ DEFAULT MOBILE STYLING
   display: -webkit-box;
 }
 
-.search-highlight {
-  background-color: yellow;
-}
 
 //Fields on Single Items and Search Result pages
 .document-metadata{
@@ -40,54 +48,133 @@ DEFAULT MOBILE STYLING
 }
 
 @media screen and (min-width: $medium_device) {
-  .dl-invert dt {
-    position: absolute;
-    width: 100%;
-    padding-right: 15px;
-    padding-left: 0px!important;
-  }
-
-  .document-metadata {
-    max-width: 55%;
-    margin-bottom: 3%;
-  }
-
-  .col-md-9 {
-    padding-left: 25%;
-  }
+  //.dl-invert dt {
+  //  position: absolute;
+  //  width: 100%;
+  //  padding-right: 15px;
+  //  padding-left: 0px!important;
+  //}
+  //
+  //.document-metadata {
+  //  max-width: 55%;
+  //  margin-bottom: 3%;
+  //}
+  //
+  //.col-md-9 {
+  //  padding-left: 25%;
+  //}
 }
 
 @media screen and (min-width: $large_device) {
-
-  .dl-invert dt {
-    position: absolute;
-    width: 100%;
-    padding-right: 15px;
-    padding-left: 0px!important;
-  }
-
-  .document-metadata {
-    max-width: 55%;
-    margin-bottom: 3%;
-  }
-
-  .col-md-9 {
-    padding-left: 25%;
-  }
+  //.dl-invert dt {
+  //  position: absolute;
+  //  width: 100%;
+  //  padding-right: 15px;
+  //  padding-left: 0px!important;
+  //}
+  //
+  //.document-metadata {
+  //  max-width: 55%;
+  //  margin-bottom: 3%;
+  //}
+  //
+  //.col-md-9 {
+  //  padding-left: 25%;
+  //}
 }
 
 @media screen and (min-width: $xlarge_device) {
 
+  .document{
+    width: 100%;
+    height: auto;
+    padding-bottom: 40px;
+    padding-right: calc(100% - 780px);
+  }
+
+  .documentHeader.row{
+    display: -webkit-box;
+    margin-bottom: 1rem;
+    width: 420px!important;
+    padding-left: 0!important;
+    margin-left: 0!important;
+    position: relative;
+    float: right;
+  }
+
+  .documents-list.document {
+    border-bottom: 1px dotted $light_grey;
+    margin-top: 0rem;
+    padding-top: 2rem;
+  }
+
+  .document-title{
+    position: relative;
+    font-size: 15px;
+    width: 492px;
+    display: -webkit-inline-flex;
+    margin-top: 0rem;
+    text-align: left;
+    left: -99px;
+  }
+
+  .document-metadata.dl-invert.row{
+    display: inline-block;
+    position: relative;
+    top: -20px;
+    left: -90px;
+    width: 800px;
+    margin-bottom: 20px;
+    float: right;
+  }
+
+  //Solr field titles
   .dl-invert dt {
-    position: absolute;
+    width: 200px;
+    text-align: left;
+    position: relative;
+    color:$medium_grey;
+    font-family: $mallory_mp_black;
+    font-size: 12px;
+    display: contents;
+    left: -38px;
+  }
+
+  //Solr field details
+  .dl-invert dd{
+    font-size: 12px;
+    font: $mallory_medium;
+    color:$medium_grey;
+    flex-wrap: wrap;
+    margin-top: -21px;
+    margin-left: 74px;
   }
 
   .document-metadata {
     max-width: 55%;
-    margin-bottom: 3%;
+    margin-bottom: 1%;
+
+  }
+  .document-thumbnail {
+    float: left!important;
+    margin: 12px 0 0 0!important;
+    margin-left: 10px;
+    height: 200px;
+    width:200px;
+    padding-top: 0px;
   }
 
+  //styling for title on search result page
+  .document-title {
+    font-size:15px;
+    display: -webkit-inline-flex;
+    margin-top: 0rem;
+    padding-left: 0;
+  }
   .col-md-9 {
     padding-left: 25%;
+  }
+  .row {
+    margin-left: 5px !important;
   }
 }

--- a/app/views/catalog/_index_header.html.erb
+++ b/app/views/catalog/_index_header.html.erb
@@ -39,7 +39,6 @@
 <%else %>
   <div class='documentHeader row'>
     <h3 class='index_title document-title-heading <%= title_class %>'>
-      <%= counter %>
       <div class='document-title'>
         <%= link_to_document document, document.highlight_field('title_tesim').try(:[],0) || document['title_tesim'], counter:document_counter %>
       </div>

--- a/app/views/catalog/_index_header.html.erb
+++ b/app/views/catalog/_index_header.html.erb
@@ -39,6 +39,7 @@
 <%else %>
   <div class='documentHeader row'>
     <h3 class='index_title document-title-heading <%= title_class %>'>
+     <span class='counter_no_show' ><%= counter %> </span>
       <div class='document-title'>
         <%= link_to_document document, document.highlight_field('title_tesim').try(:[],0) || document['title_tesim'], counter:document_counter %>
       </div>

--- a/spec/system/search_result_spec.rb
+++ b/spec/system/search_result_spec.rb
@@ -1,15 +1,46 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe 'search result', type: :system do
+RSpec.describe 'search result', type: :system, clean: true do
+  before do
+    solr = Blacklight.default_index.connection
+    solr.add(document_with_image)
+    solr.commit
+    stub_request(:get, "http://iiif_image:8182/iiif/2/1234822/full/!200,200/0/default.jpg")
+      .to_return(status: 200, body: File.open("spec/fixtures/images/Sun.png").read, headers: { "Content-Type" => /image\/.+/ })
+  end
+
+  let(:document_with_image) do
+    {
+      id: 'test_record_1',
+      oid_ssi: '2055095',
+      visibility_ssi: 'Public',
+      identifierShelfMark_tesim: 'Call Number',
+      thumbnail_path_ss: "http://iiif_image:8182/iiif/2/1234822/full/!200,200/0/default.jpg"
+    }
+  end
+
   context 'in list view' do
     before do
       visit '/?search_field=all_fields&view=list'
     end
-
-    it 'has expected css' do
-      expect(page).to have_css '.dl-invert'
-      expect(page).to have_css '.document-metadata'
+    it 'has expected css', js: true, style: true do
+      within '.documents-list' do
+        expect(page).to have_css '.dl-invert'
+        expect(page).to have_css '.document-metadata'
+        expect(page).to have_css '.document-title'
+        expect(page).to have_css '.document-title-heading'
+        expect(page).to have_css '.documentHeader'
+        expect(page).to have_css '.row'
+        expect(page).to have_css '.document'
+        expect(page).to have_css '.document-metadata.dl-invert.row'
+        expect(page).to have_css '#documents > article.document > dl > dt'
+        expect(page).to have_css '.document-metadata.dl-invert > dt'
+        expect(page).to have_css '.document-metadata.dl-invert > dd'
+        expect(page).to have_css '.document-metadata'
+        expect(page).to have_css '.document-thumbnail'
+        expect(page).to have_css '.col-md-9'
+      end
     end
 
     it 'has the correct "per page" options' do
@@ -24,10 +55,6 @@ RSpec.describe 'search result', type: :system do
   context 'in gallery view' do
     before do
       visit '/?q=&search_field=all_fields&view=gallery'
-    end
-
-    it 'has expected css' do
-      expect(page).to have_css '.caption'
     end
 
     it 'has the correct "per page" options' do

--- a/spec/system/search_result_spec.rb
+++ b/spec/system/search_result_spec.rb
@@ -57,6 +57,10 @@ RSpec.describe 'search result', type: :system, clean: true do
       visit '/?q=&search_field=all_fields&view=gallery'
     end
 
+    it 'has expected css' do
+      expect(page).to have_css '.caption'
+    end
+
     it 'has the correct "per page" options' do
       expect(page).to have_text '9 per page 30 per page 60 per page 99 per page'
     end


### PR DESCRIPTION
## Summary
Update the app UI to match Matt Walker's design: https://app.zeplin.io/project/5f0fd2b5fa16ac9ddd54d6fa/screen/5f0fd3010b521c8d2c66b758
(View the design at 100% when making comparisons to the blacklight app)

## Current UI
![image.png](https://images.zenhubusercontent.com/5e5ea9bffa78052c1cbcc74f/d3b78198-e875-4051-b0e5-b15783aa578e)

## Intended UI
![image.png](https://images.zenhubusercontent.com/5e5ea9bffa78052c1cbcc74f/9bd5e074-f64b-45ea-8763-69630be533e3)

External example:  https://digital.library.emory.edu/?utf8=%E2%9C%93&search_field=common_fields&q=

## Acceptance Criteria
- [ ] The grey line that separates search results is darker
- [ ] Thumbnails show to the immediate left of the search result number and is top aligned with the number
- [ ] The thumbnail is relegated to 200 x 200 pixel size (Yale Bulldog image is a square example)
- [ ] The result number is in the correct color, size and (nearest) font
- [ ] The title of the result is top aligned with the number and thumbnail, but is to the left of the thumbnail with 71 px of spacing
- [ ] The title of the result is title cased, in the correct color, size and (nearest) font
- [ ] The result details are left aligned with the title and directly underneath the title
- [ ] The name of each detail is title cased, in the correct color, size and (nearest) font
- [ ] The description of each detail is title cased, in the correct color, size and (nearest) font
- [ ] The description of each detail is left aligned to the one(s) above and/or beneath it
- [ ] The description of each detail doesn't extend beyond the checkbox. It can wrap if necessary

-----

**The Actual UI**
**Mobile**
![mobile.png](https://images.zenhubusercontent.com/5e6013c029e314c92afd4769/427fed88-b85c-4e12-a4bd-e2d622a4abd4)

**Mobile Medium**
![mobileMedium.png](https://images.zenhubusercontent.com/5e6013c029e314c92afd4769/8c7ddd29-b691-41e3-9d44-2ef9f1737223)

**Mobile Large**
![mobileLarge.png](https://images.zenhubusercontent.com/5e6013c029e314c92afd4769/2bf712fe-0492-4d28-bc92-46c0f2a720d8)

**Desktop**
![Desktop.png](https://images.zenhubusercontent.com/5e6013c029e314c92afd4769/3c5f89fc-ce37-4c69-a417-e193b296cc6a)

