### PR TITLE
Change wording in submenu for course reserve

### DIFF
--- a/config/locales/submenu.en.yml
+++ b/config/locales/submenu.en.yml
@@ -91,7 +91,7 @@ en:
       courseReserves:
         title: Course Reserves
         url: http://guides.library.yale.edu/reserves
-        description:
+        description: ''
       off-CampusAccess:
         title: Off-Campus Access
         url: https://library.yale.edu/help/off-campus-access-vpn


### PR DESCRIPTION
The link is not displaying correctly. 

**Current Display on both Test and UAT** 
![Screen Shot 2020-10-09 at 1.56.19 PM.png](https://images.zenhubusercontent.com/5e6013c029e314c92afd4769/2fe15683-9a58-40be-95fd-af23b94870d5)

**Code Fix Display**
![Screen Shot 2020-10-09 at 2.05.01 PM.png](https://images.zenhubusercontent.com/5e6013c029e314c92afd4769/47e2dcdd-56a1-4b06-9dc3-2e383f348a53)