### PR TITLE
Fix date slider bounds and tests. Add date constraint.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -111,11 +111,12 @@ class CatalogController < ApplicationController
     config.add_facet_field 'pub_date_ssim', label: 'Publication Year', single: true
     config.add_facet_field 'dateStructured_ssim', label: 'Publication Date',
                                                   range: {
-                                                    num_segments: 6,
-                                                    assumed_boundaries: [800, Time.current.year + 2],
                                                     segments: true,
                                                     maxlength: 4
-                                                  }, solr_params: { 'facet.pivot.mincount' => 2 }
+                                                  },
+                                                  if: lambda { |_context, _field_config, facet|
+                                                        facet.items.length > 1
+                                                      }
 
     # the facets below are set to false because we aren't filtering on them from the main search page
     # but we need to be able to provide a label when they are filtered upon from an individual show page

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -3,6 +3,41 @@
 module BlacklightHelper
   include Blacklight::BlacklightHelperBehavior
 
+  # sets up date params for constraint partial
+  def render_date_constraint(params)
+    label = "Date"
+
+    # if date is unknown
+    if params["range"].try(:[], "dateStructured_ssim").try(:[], "missing")
+      value = "Unknown"
+      remove_url = range_unknown_remove_url
+    else
+      beg_date = params["range"].values[0]["begin"]
+      end_date = params["range"].values[0]["end"]
+
+      value ||= "#{beg_date} - #{end_date}"
+      remove_url = range_remove_url
+    end
+
+    options = {
+      remove: remove_url,
+      classes: ["dateStructured_ssim"]
+    }
+    render partial: "constraints_element", locals: { value: value, label: label, options: options }
+  end
+
+  # removes date range params from link with unknown date
+  def range_unknown_remove_url
+    url = request.url.gsub(/[?&]range%5BdateStructured_ssim%5D%5Bmissing%5D=true&commit=Apply/, '')
+    url.gsub!(/[?&]range%5BdateStructured_ssim%5D%5Bmissing%5D=true/, '')
+  end
+
+  # removes date range params from link
+  def range_remove_url
+    url = request.url.gsub(/[&?]range%5BdateStructured_ssim%5D%5Bbegin%5D=[\d]{4}&range%5BdateStructured_ssim%5D%5Bend%5D=[\d]{4}&commit=Apply/, '')
+    url.gsub(/[&?]range%5BdateStructured_ssim%5D%5Bbegin%5D=[\d]{4}&range%5BdateStructured_ssim%5D%5Bend%5D=[\d]{4}/, '')
+  end
+
   def manifest_url(oid)
     File.join(manifest_base_url, "#{oid}.json")
   end

--- a/app/views/catalog/_constraints.html.erb
+++ b/app/views/catalog/_constraints.html.erb
@@ -4,6 +4,7 @@
 
 
     <span class="constraints-label sr-only"><%= t('blacklight.search.filters.title') %></span>
+    <%= render_date_constraint(params) if params["range"].present? %>
     <%= render_constraints(controller.params != params ? params : search_state) %>
     <%= render 'start_over', show_icon: true%>
   </div>

--- a/app/views/catalog/_constraints_element.html.erb
+++ b/app/views/catalog/_constraints_element.html.erb
@@ -6,7 +6,6 @@
     #   :classes => array of classes to add to container span
     options ||= {}
 %>
-
 <span class="btn-group applied-filter constraint query <%= options[:classes].join(" ") if options[:classes] %>">
   <span class="constraint-value btn btn-outline-secondary ">
     <% unless label.blank? %>

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -29,3 +29,16 @@ RSpec.configure do |config|
     driven_by :chrome_headless
   end
 end
+
+module CapybaraExtension
+  delegate :drag_by, to: :base
+end
+
+module CapybaraSeleniumExtension
+  def drag_by(right_by, down_by)
+    driver.browser.action.drag_and_drop_by(native, right_by, down_by).perform
+  end
+end
+
+::Capybara::Selenium::Node.send :include, CapybaraSeleniumExtension
+::Capybara::Node::Element.send :include, CapybaraExtension

--- a/spec/system/date_slider_spec.rb
+++ b/spec/system/date_slider_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "Blacklight Range Limit", type: :system, clean: true, js: true do
   let(:rabbit) do
     {
       id: '400',
-      identifierShelfMark_ssim: 'call number',
+      identifierShelfMark_ssim: 'MS123',
       title_tesim: 'Handsome Dan is not a rabbit.',
       dateStructured_ssim: '1555',
       creator_tesim: 'Frederick & Eric',
@@ -61,7 +61,7 @@ RSpec.describe "Blacklight Range Limit", type: :system, clean: true, js: true do
   let(:elephant) do
     {
       id: '401',
-      identifierShelfMark_ssim: 'call number',
+      identifierShelfMark_ssim: 'MS123',
       title_tesim: 'Handsome Dan is not a elephant.',
       dateStructured_ssim: '1555',
       creator_tesim: 'Frederick & Eric',
@@ -89,25 +89,34 @@ RSpec.describe "Blacklight Range Limit", type: :system, clean: true, js: true do
     expect(el).to have_content("1100 : 2023")
   end
 
-  it "does not show the date slider if only one date" do
-    visit '?search_field=identifierShelfMark_tesim&q="call number"'
+  it "does not show the date slider if only one date", :style do
+    visit '?f%5BidentifierShelfMark_ssim%5D%5B%5D=MS123'
+    expect(page).to have_content("1 - 2")
     expect(page).not_to have_css('.card.facet-limit.blacklight-dateStructured_ssim')
   end
 
-  xit "should be able to search with the slider" do
+  it "is able to search with the slider", :style do
     visit root_path
     click_button 'Publication Date'
-    within '.card.facet-limit.blacklight-dateStructured_ssim' do
-      source = page.find('.slider-handle.round').last
-      source.drag_by(30, 0)
+    within '#facet-datestructured_ssim' do
+      sliders = find_all('.slider-handle.round')
+
+      beg_slider = sliders.first
+      beg_slider.drag_by(30, 0)
+
+      end_slider = sliders.last
+      end_slider.drag_by(-105, 0)
+    end
+    within '#facet-datestructured_ssim' do
+      click_on "Apply"
     end
 
     within '.blacklight-dateStructured_ssim' do
-      expect(page).to have_content "1100 to 1600"
+      expect(page.text).to match(/12\d\d to 16\d\d/)
     end
 
     within '.constraints-container' do
-      expect(page).to have_content '1100 to 1600'
+      expect(page.text).to match(/Date 12\d\d - 16\d\d/)
     end
 
     expect(page).to have_content '1 - 3'


### PR DESCRIPTION
# PLEASE PLAY WITH THE SLIDER TO SEE IF YOU CAN BREAK IT
Issue yalelibrary/YUL-DC#549
**STEPS TO REPRODUCE**
1. Go to any system running v.1.15.1 (e.g. https://collections-test.library.yale.edu/?search_field=all_fields&q= )
2. Click on search (search for all items)
3. Expand the "Publication Date" facet
4. *Use the mouse* to slide the upper date limit about 1/4 of the way earlier (i.e. from around 2020 --> 1775)
5. Click on "Apply"

**EXPECTED RESULT**
- [x] I should get some subset of the previous results
- [x] I should have a facet limit for the years that I can click to remove

**STEP 3**
<img width="315" alt="image" src="https://user-images.githubusercontent.com/3064318/92637118-0e7c4080-f29e-11ea-9545-314f7a82d2b1.png">


**STEP 4**
<img width="311" alt="image" src="https://user-images.githubusercontent.com/3064318/92637275-3d92b200-f29e-11ea-9fb2-eedea859002a.png">

**ACTUAL RESULT**
<img width="758" alt="image" src="https://user-images.githubusercontent.com/3064318/92637372-5d29da80-f29e-11ea-9a5f-d73fb5944388.png">

**EXPECTED RESULT**
Something similar to this
<img width="234" alt="image" src="https://user-images.githubusercontent.com/3064318/92637520-8cd8e280-f29e-11ea-9c91-a7785a3d81a6.png">

