### PR TITLE
Return "common fields" to "all fields"

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -329,7 +329,7 @@ class CatalogController < ApplicationController
       'visibility_ssi'
     ]
 
-    config.add_search_field('all_fields_advanced', label: 'Common Fields') do |field|
+    config.add_search_field('all_fields_advanced', label: 'All Fields') do |field|
       field.qt = 'search'
       field.include_in_simple_select = false
       field.solr_parameters = {

--- a/spec/system/advanced_search_spec.rb
+++ b/spec/system/advanced_search_spec.rb
@@ -15,6 +15,20 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: tr
 
   let(:cat) { ADVANCED_SEARCH_TESTING_2 }
 
+  describe 'search fields' do
+    it 'has the correct text field labels' do
+      expect(page).to have_content('All Fields')
+      expect(page).to have_content('Creator')
+      expect(page).to have_content('Title')
+      expect(page).to have_content('Call Number')
+      expect(page).to have_content('Date')
+      expect(page).to have_content('Subject')
+      expect(page).to have_content('Genre/format')
+      expect(page).to have_content('OID [Parent/primary]')
+      expect(page).to have_content('OID [Child/images]')
+    end
+  end
+
   describe 'searching' do
     it 'gets correct search results from advanced fields' do
       fill_in 'all_fields_advanced', with: 'Latin'


### PR DESCRIPTION
Co-authored by: JP Engstrom <jp@notch8.com>

# Ticket
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/668

# Summary
On the Advanced Search page, Replace the label 'Common Fields' with "All Fields"

# Demo
![image](https://user-images.githubusercontent.com/29032869/97353243-088fee00-1851-11eb-8b9c-4b729bc78193.png)
