### PR TITLE
Add a link to the mirador viewer in the tools

### DIFF
--- a/app/assets/stylesheets/customOverrides/show_page.scss
+++ b/app/assets/stylesheets/customOverrides/show_page.scss
@@ -74,11 +74,14 @@ DEFAULT MOBILE STYLING
 
 }
 
-#citationLink {
+#citationLink, #manifestLink, #miradorLink{
   color: $light_blue !important;
   font: $mallory_medium;
   font-size: 11px;
   text-transform: uppercase;
+}
+
+#citationLink {
   padding-left: 19px;
 }
 
@@ -86,15 +89,16 @@ DEFAULT MOBILE STYLING
   content: ' >';
 }
 
-#manifestLink {
-  color: $light_blue !important;
-  font: $mallory_medium;
-  font-size: 11px;
-  text-transform: uppercase;
-}
-
 #manifestLink:after {
   content: ' >';
+}
+
+#miradorLink:after {
+  content: ' >';
+}
+
+#miradorLink{
+  margin-left: 15px;
 }
 
 // metadata grouping

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -46,6 +46,10 @@ module BlacklightHelper
     ENV.fetch('IIIF_MANIFESTS_BASE_URL', "#{request.protocol}localhost/manifests")
   end
 
+  def mirador_url(oid)
+    "/mirador/#{oid}"
+  end
+
   def language_codes(args)
     language_values = args[:document][args[:field]]
     language_values.map do |language_code|

--- a/app/views/catalog/_show_links.html.erb
+++ b/app/views/catalog/_show_links.html.erb
@@ -8,7 +8,8 @@
       <div class='nav-link'>
         <% oid = @document.id %>
         <%= link_to image_tag('iiif.png', alt: 'IIIF Logo'), manifest_url(oid), target: '_blank', class: 'iiif-logo', rel: 'external' %>
-        <%= link_to t('blacklight.sidebar.manifest'), manifest_url(oid), target: '_blank', id: 'manifestLink'%> 
+        <%= link_to t('blacklight.sidebar.manifest'), manifest_url(oid), target: '_blank', id: 'manifestLink'%>
+        <%= link_to 'View in Mirador', mirador_url(oid), target: '_blank', id: 'miradorLink'%>
       </div>
     </li>
   </ul>

--- a/spec/views/catalog/_show_links.html.erb_spec.rb
+++ b/spec/views/catalog/_show_links.html.erb_spec.rb
@@ -19,5 +19,10 @@ RSpec.describe 'catalog/_show_tools.html.erb' do
       render partial: 'catalog/show_links'
       expect(rendered).to have_link 'Manifest Link', href: "http://localhost/manifests/xyz.json"
     end
+
+    it 'renders the mirador link' do
+      render partial: 'catalog/show_links'
+      expect(rendered).to have_link 'View in Mirador', href: "/mirador/xyz"
+    end
   end
 end


### PR DESCRIPTION
Co-authored-by: Martin Lovell <martin.lovell@yale.edu>
Co-authored-by: Maggie Zhao <maggie.zhao@yale.edu>
Co-authored-by: Lakeisha Robinson <lakeisha.robinson@yale.edu>


**ACCEPTANCE**
- [ ] The tools section at the bottom of the page includes a link to view the item in Mirador
- [ ] The link has the same styling as the Cite and Manifest links
- [ ] The link points to /mirador/[id]

Mock up (but styling should match existing links)
![image.png](https://images.zenhubusercontent.com/5ca3b270500af570674ef5bc/8f05ddcc-f29c-4d25-9382-3e487033a9cf)

**ACTUAL IMPLICATION**
