### PR TITLE
Add Ascending and Descending options for result sorting#730

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -442,8 +442,10 @@ class CatalogController < ApplicationController
     # config.add_sort_field 'pub_date_si desc, title_si asc', label: 'year'
     # config.add_sort_field 'dateStructured_ssim asc, title_si asc', label: 'date (oldest first)'
     # config.add_sort_field 'dateStructured_ssim desc, title_si asc', label: 'date (newest first)'
-    config.add_sort_field 'creator_ssim asc, title_ssim asc', label: 'creator'
-    config.add_sort_field 'title_ssim asc, pub_date_si desc', label: 'title'
+    config.add_sort_field 'creator_ssim asc, title_ssim asc', label: 'Creator (A --> Z)'
+    config.add_sort_field 'creator_ssim desc, title_ssim desc', label: 'Creator (Z --> A)'
+    config.add_sort_field 'title_ssim asc, pub_date_si desc', label: 'Title (A --> Z)'
+    config.add_sort_field 'title_ssim desc, pub_date_si desc', label: 'Title (Z --> A)'
 
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -443,7 +443,7 @@ class CatalogController < ApplicationController
     # config.add_sort_field 'dateStructured_ssim asc, title_si asc', label: 'date (oldest first)'
     # config.add_sort_field 'dateStructured_ssim desc, title_si asc', label: 'date (newest first)'
     config.add_sort_field 'creator_ssim asc, title_ssim asc', label: 'Creator (A --> Z)'
-    config.add_sort_field 'creator_ssim desc, title_ssim desc', label: 'Creator (Z --> A)'
+    config.add_sort_field 'creator_ssim desc, title_ssim asc', label: 'Creator (Z --> A)'
     config.add_sort_field 'title_ssim asc, pub_date_si desc', label: 'Title (A --> Z)'
     config.add_sort_field 'title_ssim desc, pub_date_si desc', label: 'Title (Z --> A)'
 

--- a/spec/system/sort_in_search_spec.rb
+++ b/spec/system/sort_in_search_spec.rb
@@ -97,31 +97,64 @@ RSpec.describe 'Search results should be sorted', type: :system, js: :true, clea
   end
 
   # add creator and title test
-  it 'sorts by title' do
-    click_on 'search'
-    click_on 'Sort by relevance'
-    within('div#sort-dropdown') do
-      click_on 'title'
+
+  context 'sorts by title' do
+    it 'asc' do
+      click_on 'search'
+      click_on 'Sort by relevance'
+      within('div#sort-dropdown') do
+        click_on 'Title (A --> Z)'
+      end
+
+      content = find(:css, '#content')
+      expect(content).to have_content("1.\nAmor Llama")
+      expect(content).to have_content("2.\nAquila Eccellenza")
+      expect(content).to have_content("3.\nHandsomeDan Bulldog")
+      expect(content).to have_content("4.\nRhett Lecheire")
     end
 
-    content = find(:css, '#content')
-    expect(content).to have_content("1.\nAmor Llama")
-    expect(content).to have_content("2.\nAquila Eccellenza")
-    expect(content).to have_content("3.\nHandsomeDan Bulldog")
-    expect(content).to have_content("4.\nRhett Lecheire")
+    it 'desc' do
+      click_on 'search'
+      click_on 'Sort by relevance'
+      within('div#sort-dropdown') do
+        click_on 'Title (Z --> A)'
+      end
+
+      content = find(:css, '#content')
+      expect(content).to have_content("4.\nAmor Llama")
+      expect(content).to have_content("3.\nAquila Eccellenza")
+      expect(content).to have_content("2.\nHandsomeDan Bulldog")
+      expect(content).to have_content("1.\nRhett Lecheire")
+    end
   end
 
-  it 'sorts by creator' do
-    click_on 'search'
-    click_on 'Sort by relevance'
-    within('div#sort-dropdown') do
-      click_on 'creator'
+  context 'sorts by creator' do
+    it 'sorts by creater asc' do
+      click_on 'search'
+      click_on 'Sort by relevance'
+      within('div#sort-dropdown') do
+        click_on 'Creator (A --> Z)'
+      end
+
+      content = find(:css, '#content')
+      expect(content).to have_content("1.\nAquila Eccellenza")
+      expect(content).to have_content("2.\nHandsomeDan Bulldog")
+      expect(content).to have_content("3.\nAmor Llama")
+      expect(content).to have_content("4.\nRhett Lecheire")
     end
 
-    content = find(:css, '#content')
-    expect(content).to have_content("1.\nAquila Eccellenza")
-    expect(content).to have_content("2.\nHandsomeDan Bulldog")
-    expect(content).to have_content("3.\nAmor Llama")
-    expect(content).to have_content("4.\nRhett Lecheire")
+    it 'sorts by creater desc' do
+      click_on 'search'
+      click_on 'Sort by relevance'
+      within('div#sort-dropdown') do
+        click_on 'Creator (Z --> A)'
+      end
+
+      content = find(:css, '#content')
+      expect(content).to have_content("4.\nAquila Eccellenza")
+      expect(content).to have_content("3.\nHandsomeDan Bulldog")
+      expect(content).to have_content("2.\nAmor Llama")
+      expect(content).to have_content("1.\nRhett Lecheire")
+    end
   end
 end


### PR DESCRIPTION
Issue yalelibrary/YUL-DC#730

Co-authored-by: Martin Lovell <martin.lovell@yale.edu>
Co-authored-by: Frederick Rodriguez <frederick.rodriguez@yale.edu>
Co-authored-by: Maggie Zhao <maggie.zhao@yale.edu>
Co-authored-by: Eric DeJesus <eric.dejesus@yale.edu>

**ACCEPTANCE**
- [x] I can sort results by creator in ascending or descending order
- [x] I can sort results by title in ascending or descending order
- [x] Sorting by relevance is the default sort
- [x] Sorting by relevance displays results from most relevant to least relevant

![image.png](https://images.zenhubusercontent.com/5ca3b270500af570674ef5bc/3b9bd7ca-d14a-4aac-b2c7-e3e128ee01d9) 