### PR TITLE
Modified title sort for a more accurate result

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -438,13 +438,10 @@ class CatalogController < ApplicationController
     # whether the sort is ascending or descending (it must be asc or desc
     # except in the relevancy case).
     config.add_sort_field 'score desc, pub_date_si desc, title_si asc', label: 'relevance'
-    # config.add_sort_field 'pub_date_si desc, title_si asc', label: 'year'
-    # config.add_sort_field 'dateStructured_ssim asc, title_si asc', label: 'date (oldest first)'
-    # config.add_sort_field 'dateStructured_ssim desc, title_si asc', label: 'date (newest first)'
     config.add_sort_field 'creator_ssim asc, title_ssim asc', label: 'Creator (A --> Z)'
     config.add_sort_field 'creator_ssim desc, title_ssim asc', label: 'Creator (Z --> A)'
-    config.add_sort_field 'title_ssim asc, pub_date_si desc', label: 'Title (A --> Z)'
-    config.add_sort_field 'title_ssim desc, pub_date_si desc', label: 'Title (Z --> A)'
+    config.add_sort_field 'title_ssim asc, oid_ssi desc', label: 'Title (A --> Z)'
+    config.add_sort_field 'title_ssim desc, oid_ssi desc', label: 'Title (Z --> A)'
 
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.

--- a/spec/system/advanced_search_spec.rb
+++ b/spec/system/advanced_search_spec.rb
@@ -191,7 +191,7 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: tr
 
     it 'can sort by title' do
       within '#sort' do
-        find("option[value='title_ssim asc, pub_date_si desc']").click
+        find("option[value='title_ssim asc, oid_ssi desc']").click
       end
 
       click_on 'SEARCH'


### PR DESCRIPTION
Co-authored-by: Eric DeJesus <eric.dejesus@yale.edu>
Co-authored-by: Lakeisha Robinson <lakeisha.robinson@yale.edu>

The title sort search appears to be working correctly. Currently, the code has a secondary field, pub_date_si, not being used in Solr.

- [x] Should the title sort have a secondary sort field?   Yes
- [x] What secondary field should be used for publication dates, if any? Parent OID instead of pub date