### PR TITLE
Change language to "Back to Search Results"

### DIFF
--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -8,7 +8,7 @@ en:
   blacklight:
     application_name: 'Yale University Library'
     sidebar:
-      links: Links 
+      links: Links
       manifest: Manifest Link
     citation:
       apa: 'APA, 6th edition'
@@ -18,3 +18,4 @@ en:
       logout: Sign out
     search:
       search_constraints_header: You Searched For
+    back_to_search: 'Back to Search Results'

--- a/spec/system/show_page_spec.rb
+++ b/spec/system/show_page_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe 'Show Page', type: :system, js: :true, clean: true do
+RSpec.describe 'Show Page', type: :system, js: true, clean: true do
   before do
     solr = Blacklight.default_index.connection
     solr.add([llama,
@@ -72,9 +72,9 @@ RSpec.describe 'Show Page', type: :system, js: :true, clean: true do
     expect(page).to have_css '.link-card-header'
     expect(page).to have_css '.manifest'
   end
-  context '"Back to Search" button' do
+  context '"Back to Search Results" button' do
     it 'returns user to search results' do
-      expect(page).to have_link("Back to Search", href: "/?page=1&per_page=10&search_field=all_fields")
+      expect(page).to have_link("Back to Search Results", href: "/?page=1&per_page=10&search_field=all_fields")
     end
   end
   context '"Start Over" button' do


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/45948126/97918763-a178aa80-1d24-11eb-9e36-caecba7a36e7.png)

I've tried this at a number of widths, including cell phone view, and the styling seems good.

Connected to https://github.com/yalelibrary/YUL-DC/issues/725