### PR TITLE
Create a link for creator facet

### DIFF
--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -87,6 +87,10 @@ module BlacklightHelper
       field.map do |f|
         link_to f.to_s, ('/?f%5Bformat%5D%5B%5D=' + f.to_s.split.join('+')).to_s
       end[0]
+    elsif field_name == 'creator_tesim'
+      field.map do |f|
+        link_to f.to_s, ('/?f%5Bcreator_tesim%5D%5B%5D=' + f.to_s.split.join('+')).to_s
+      end[0]
     elsif field_name == 'genre_ssim'
       field.map do |f|
         link_to f.to_s, ('/?f%5Bgenre_ssim%5D%5B%5D=' + f.to_s.split.join('+')).to_s

--- a/spec/system/view_fields_in_display_spec.rb
+++ b/spec/system/view_fields_in_display_spec.rb
@@ -252,8 +252,11 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       expect(page).to have_link('English (eng)', href: '/?f%5Blanguage_ssim%5D%5B%5D=English (eng)')
       expect(page).to have_link('zz', href: '/?f%5Blanguage_ssim%5D%5B%5D=zz')
     end
-    it 'contains a link on the Orbis Bib ID to the Orbis catalog record' do
+    it 'contains a link on the Orbis Bib ID to the Orbis catalog record' do
       expect(page).to have_link('1234567', href: 'http://hdl.handle.net/10079/bibid/1234567')
+    end
+    it 'contains a link for the Creator field to the facet' do
+      expect(page).to have_link('Eric & Frederick', href: '/?f%5Bcreator_tesim%5D%5B%5D=Eric+&+Frederick')
     end
     it 'contains a link on the Finding Aid to the Finding Aid catalog record' do
       expect(page).to have_link('this is the finding aid', href: 'this is the finding aid')


### PR DESCRIPTION
As a user, I want to be able to click on the creator name to get a search of the creator.

**Proposed Implementation**  
![Screen Shot 2020-10-21 at 8.54.04 AM.png](https://images.zenhubusercontent.com/5e6273e6ee0145d627e11c85/fd7ffa3c-1ab4-4f82-aa00-3c79be71d026)

**Actual Implementation**
![Screen Shot 2020-11-03 at 1 02 52 PM](https://user-images.githubusercontent.com/41123693/98023503-0b508d00-1dd5-11eb-8392-87417c3a0d47.png)
