### PR TITLE
Link creator facet in show page

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -185,7 +185,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'subjectTopic_tesim', label: 'Subject (Topic)'
 
     # Origin Group
-    config.add_show_field 'creator_tesim', label: 'Creator'
+    config.add_show_field 'creator_ssim', label: 'Creator'
     config.add_show_field 'copyrightDate_ssim', label: 'Copyright Date'
     config.add_show_field 'coordinates_ssim', label: 'Coordinates'
     config.add_show_field 'date_ssim', label: 'Date'

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -89,7 +89,7 @@ module BlacklightHelper
       end[0]
     elsif field_name == 'creator_ssim'
       field.map do |f|
-        link_to f.to_s, ('/?f%5Bcreator_ssim%5D%5B%5D=' + CGI.escapeHTML(f.to_s).split.join('+')).to_s
+        link_to f.to_s, ('/?f%5Bcreator_ssim%5D%5B%5D=' + f.to_s.force_encoding("utf-8").split.join('+')).to_s
       end[0]
     elsif field_name == 'genre_ssim'
       field.map do |f|

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -87,10 +87,11 @@ module BlacklightHelper
       field.map do |f|
         link_to f.to_s, ('/?f%5Bformat%5D%5B%5D=' + f.to_s.split.join('+')).to_s
       end[0]
-    elsif field_name == 'creator_tesim'
+    elsif field_name == 'creator_ssim'
       field.map do |f|
-        link_to f.to_s, ('/?f%5Bcreator_tesim%5D%5B%5D=' + f.to_s.split.join('+')).to_s
+        link_to f.to_s, ('/?f%5Bcreator_ssim%5D%5B%5D=' + CGI.escapeHTML(f.to_s).split.join('+')).to_s
       end[0]
+      # ?f%5Bcreator_ssim%5D%5B%5D=Brakhage%2C+Stan&q=
     elsif field_name == 'genre_ssim'
       field.map do |f|
         link_to f.to_s, ('/?f%5Bgenre_ssim%5D%5B%5D=' + f.to_s.split.join('+')).to_s

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -91,7 +91,6 @@ module BlacklightHelper
       field.map do |f|
         link_to f.to_s, ('/?f%5Bcreator_ssim%5D%5B%5D=' + CGI.escapeHTML(f.to_s).split.join('+')).to_s
       end[0]
-      # ?f%5Bcreator_ssim%5D%5B%5D=Brakhage%2C+Stan&q=
     elsif field_name == 'genre_ssim'
       field.map do |f|
         link_to f.to_s, ('/?f%5Bgenre_ssim%5D%5B%5D=' + f.to_s.split.join('+')).to_s

--- a/config/metadata/origin_metadata.yml
+++ b/config/metadata/origin_metadata.yml
@@ -1,4 +1,4 @@
-creator_tesim: 'Creator'
+creator_ssim: 'Creator'
 coordinates_ssim: 'Coordinates'
 copyrightDate_ssim: 'Copyright Date'
 date_ssim: 'Date'

--- a/spec/presenters/yul/metadata_presenter_spec.rb
+++ b/spec/presenters/yul/metadata_presenter_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Yul::MetadataPresenter do
 
   let(:origin_metadata) do
     {
-      'creator_tesim' => 'Creator',
+      'creator_ssim' => 'Creator',
       'coordinates_ssim' => 'Coordinates',
       'copyrightDate_ssim' => 'Copyright Date',
       'date_ssim' => 'Date',
@@ -285,7 +285,7 @@ RSpec.describe Yul::MetadataPresenter do
     context 'containing overview metadata' do
       describe 'config' do
         it 'returns the Creator Key' do
-          expect(config['creator_tesim'].to_s).to eq 'Creator'
+          expect(config['creator_ssim'].to_s).to eq 'Creator'
         end
 
         it 'returns the Coordinates Key' do

--- a/spec/system/view_fields_in_display_spec.rb
+++ b/spec/system/view_fields_in_display_spec.rb
@@ -255,7 +255,7 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       expect(page).to have_link('1234567', href: 'http://hdl.handle.net/10079/bibid/1234567')
     end
     it 'contains a link for the Creator field to the facet' do
-      expect(page).to have_link("Eric", href: '?f%5Bcreator_ssim%5D%5B%5D=Eric')
+      expect(page).to have_link("Eric", href: '/?f%5Bcreator_ssim%5D%5B%5D=Eric')
     end
     it 'contains a link on the Finding Aid to the Finding Aid catalog record' do
       expect(page).to have_link('this is the finding aid', href: 'this is the finding aid')

--- a/spec/system/view_fields_in_display_spec.rb
+++ b/spec/system/view_fields_in_display_spec.rb
@@ -33,7 +33,7 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       title_tesim: "Diversity Bull Dogs",
       subtitle_tesim: "He's handsome",
       subtitle_vern_ssim: "He's handsome",
-      creator_ssim: 'Eric',
+      creator_ssim: ['Frederick, Eric'],
       format: 'three dimensional object',
       url_fulltext_ssim: 'http://0.0.0.0:3000/catalog/111',
       url_suppl_ssim: 'http://0.0.0.0:3000/catalog/111',
@@ -91,7 +91,7 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       expect(document).to have_content("Diversity Bull Dogs")
     end
     it 'displays Creator in results' do
-      expect(document).to have_content("Eric")
+      expect(document).to have_content("Frederick, Eric")
     end
     it 'displays Subtitle in results' do
       expect(document).to have_content("He's handsome")
@@ -255,7 +255,7 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       expect(page).to have_link('1234567', href: 'http://hdl.handle.net/10079/bibid/1234567')
     end
     it 'contains a link for the Creator field to the facet' do
-      expect(page).to have_link("Eric", href: '/?f%5Bcreator_ssim%5D%5B%5D=Eric')
+      expect(page).to have_link("Frederick, Eric", href: '/?f%5Bcreator_ssim%5D%5B%5D=Frederick,+Eric')
     end
     it 'contains a link on the Finding Aid to the Finding Aid catalog record' do
       expect(page).to have_link('this is the finding aid', href: 'this is the finding aid')

--- a/spec/system/view_fields_in_display_spec.rb
+++ b/spec/system/view_fields_in_display_spec.rb
@@ -33,7 +33,7 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       title_tesim: "Diversity Bull Dogs",
       subtitle_tesim: "He's handsome",
       subtitle_vern_ssim: "He's handsome",
-      creator_ssim: ['Frederick, Eric'],
+      creator_ssim: ['Frederick,  Eric & Maggie'],
       format: 'three dimensional object',
       url_fulltext_ssim: 'http://0.0.0.0:3000/catalog/111',
       url_suppl_ssim: 'http://0.0.0.0:3000/catalog/111',
@@ -91,7 +91,7 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       expect(document).to have_content("Diversity Bull Dogs")
     end
     it 'displays Creator in results' do
-      expect(document).to have_content("Frederick, Eric")
+      expect(document).to have_content("Frederick, Eric & Maggie")
     end
     it 'displays Subtitle in results' do
       expect(document).to have_content("He's handsome")
@@ -255,7 +255,7 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       expect(page).to have_link('1234567', href: 'http://hdl.handle.net/10079/bibid/1234567')
     end
     it 'contains a link for the Creator field to the facet' do
-      expect(page).to have_link("Frederick, Eric", href: '/?f%5Bcreator_ssim%5D%5B%5D=Frederick,+Eric')
+      expect(page).to have_link("Frederick, Eric", href: '/?f%5Bcreator_ssim%5D%5B%5D=Frederick,+Eric+&+Maggie')
     end
     it 'contains a link on the Finding Aid to the Finding Aid catalog record' do
       expect(page).to have_link('this is the finding aid', href: 'this is the finding aid')

--- a/spec/system/view_fields_in_display_spec.rb
+++ b/spec/system/view_fields_in_display_spec.rb
@@ -33,7 +33,7 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       title_tesim: "Diversity Bull Dogs",
       subtitle_tesim: "He's handsome",
       subtitle_vern_ssim: "He's handsome",
-      creator_tesim: 'Eric & Frederick',
+      creator_ssim: 'Eric',
       format: 'three dimensional object',
       url_fulltext_ssim: 'http://0.0.0.0:3000/catalog/111',
       url_suppl_ssim: 'http://0.0.0.0:3000/catalog/111',
@@ -91,7 +91,7 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       expect(document).to have_content("Diversity Bull Dogs")
     end
     it 'displays Creator in results' do
-      expect(document).to have_content("Eric & Frederick")
+      expect(document).to have_content("Eric")
     end
     it 'displays Subtitle in results' do
       expect(document).to have_content("He's handsome")
@@ -255,7 +255,7 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       expect(page).to have_link('1234567', href: 'http://hdl.handle.net/10079/bibid/1234567')
     end
     it 'contains a link for the Creator field to the facet' do
-      expect(page).to have_link('Eric & Frederick', href: '/?f%5Bcreator_tesim%5D%5B%5D=Eric+&+Frederick')
+      expect(page).to have_link("Eric", href: '?f%5Bcreator_ssim%5D%5B%5D=Eric')
     end
     it 'contains a link on the Finding Aid to the Finding Aid catalog record' do
       expect(page).to have_link('this is the finding aid', href: 'this is the finding aid')


### PR DESCRIPTION
Co-authored-by: Eric DeJesus <eric.dejesus@yale.com>

As a user, I want to be able to click on the creator name to get a search of the creator.
![Screen Shot 2020-11-03 at 1.02.52 PM.png](https://images.zenhubusercontent.com/5e6013c029e314c92afd4769/b8a0eb28-1eff-4d58-99fc-94cbfadef33e)