### PR TITLE
Change color of links on the whole site

### DIFF
--- a/app/assets/stylesheets/theme/colors.scss
+++ b/app/assets/stylesheets/theme/colors.scss
@@ -10,5 +10,5 @@ $lightest_grey: #f9f9f9;
 $border_grey: #cccccc;
 
 $yale_blue: #043669;
-$light_blue: #3399ff;
+$light_blue: #006EF5;
 $lighter_blue: #009cff;


### PR DESCRIPTION
Per Accessibility requirements 
- [ ] Change light blue to  Cornflower Blue  (#006EF5)

Current Color: 
![Screen Shot 2020-11-05 at 1.24.24 PM.png](https://images.zenhubusercontent.com/5e6273e6ee0145d627e11c85/7623017b-791f-4c6d-8708-fddc21bf8922)

New Color: 
![Screen Shot 2020-11-05 at 3.24.13 PM.png](https://images.zenhubusercontent.com/5e6013c029e314c92afd4769/d654aca5-e212-44fa-95df-700471862b9b)