### PR TITLE
Remove screen reader-only label that duplicates visible text

### DIFF
--- a/app/views/catalog/_constraints.html.erb
+++ b/app/views/catalog/_constraints.html.erb
@@ -3,7 +3,6 @@
     <h2 class="sr searched-heading"><%= t('blacklight.search.search_constraints_header') %></h2>
 
 
-    <span class="constraints-label sr-only"><%= t('blacklight.search.filters.title') %></span>
     <%= render_constraints(controller.params != params ? params : search_state) %>
     <%= render 'start_over', show_icon: true%>
   </div>


### PR DESCRIPTION
For yalelibrary/YUL-DC#819