### PR TITLE
Revert "Enable x-forwared-for (#380)"

### DIFF
--- a/ops/webapp.conf
+++ b/ops/webapp.conf
@@ -16,12 +16,6 @@ server {
     passenger_enabled on;
     passenger_user app;
 
-    # Enable X-Forwarded-For
-    log_format  main  '$http_x_forwarded_for - $remote_user [$time_local] "$request" '
-                      '$status $body_bytes_sent "$http_referer" '
-                      '"$http_user_agent"';
-
-
     # If this is a Ruby app, specify a Ruby version:
     # For Ruby 2.6
     passenger_ruby /usr/bin/ruby2.6;


### PR DESCRIPTION
This reverts commit e2785e95e7fb68f7dddf0563fa8f1e97c3cd4250.

This change appears to be blocking deployment, see CloudWatch [logs for failed yul-test deployment ](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/yul-dc-test/log-events/blacklight$252Fblacklight$252F3aa465d5cb17496bb7d243b0850f65aa) (not sure how long this link will work)
```
nginx: [emerg] "log_format" directive is not allowed here in /etc/nginx/sites-enabled/webapp.conf:22
```

![image](https://user-images.githubusercontent.com/45948126/98857430-0c189d00-242d-11eb-87eb-9e3af45e988b.png)
