### PR TITLE
Removed creator field link on result page

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -143,7 +143,7 @@ class CatalogController < ApplicationController
 
     # solr fields to be displayed in the index (search results) view
     #   The ordering of the field names is the order of the display
-    config.add_index_field 'creator_tesim', label: 'Creator', highlight: true, link_to_facet: true
+    config.add_index_field 'creator_tesim', label: 'Creator', highlight: true
     config.add_index_field 'date_ssim', label: 'Date', highlight: true
     config.add_index_field 'identifierShelfMark_tesim', label: 'Call Number', highlight: true
     config.add_index_field 'imageCount_isi', label: 'Image Count'


### PR DESCRIPTION
The current code creator field has a link displayed on the result page:  

![Screen Shot 2020-11-13 at 2 27 34 PM](https://user-images.githubusercontent.com/41123693/99113208-d86c7d00-25bc-11eb-884c-5e6ee4ecd480.png)

--------

The code change removes the link from displaying on the result page: 

![Screen Shot 2020-11-13 at 2 31 41 PM](https://user-images.githubusercontent.com/41123693/99113283-fcc85980-25bc-11eb-9844-8ba9a4323e16.png)
