### PR TITLE
Search results added to title, allowing screen readers to announce result count

### DIFF
--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+module CatalogHelper
+  include Blacklight::CatalogHelperBehavior
+
+  def render_search_to_page_title(params, response = nil)
+    constraints = []
+
+    number_of_results = response&.[]('response')&.[]('numFound') || 0
+
+    if params['q'].present?
+      q_label = label_for_search_field(params[:search_field]) unless default_search_field && params[:search_field] == default_search_field[:key]
+
+      constraints += if q_label.present?
+                       [t('blacklight.search.page_title.results_with_constraint', count: number_of_results, label: q_label, value: params['q'])]
+                     else
+                       [t('blacklight.search.page_title.results', count: number_of_results, q: params['q'])]
+                     end
+    end
+
+    constraints += params['f'].to_unsafe_h.collect { |key, value| render_search_to_page_title_filter(key, Array(value)) } if params['f'].present?
+
+    constraints.join(' / ')
+  end
+end

--- a/app/views/catalog/_search_results.html.erb
+++ b/app/views/catalog/_search_results.html.erb
@@ -1,5 +1,5 @@
 
-<% @page_title = t('blacklight.search.page_title.title', :constraints => render_search_to_page_title(params), :application_name => application_name) %>
+<% @page_title = t('blacklight.search.page_title.title', :constraints => render_search_to_page_title(params, @response), :application_name => application_name) %>
 
 <% content_for(:head) do -%>
   <%= render 'catalog/opensearch_response_metadata', response: @response %>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -18,4 +18,7 @@ en:
       logout: Sign out
     search:
       search_constraints_header: You Searched For
+      page_title:
+        results: '%{count} results for %{q}'
+        results_with_constraint: '%{count} results for %{label}: %{value}'
     back_to_search: 'Back to Search Results'


### PR DESCRIPTION
I tried several methods here, including aria-live, role=alert, role=status, etc. There is something in the code which causes it to read the title on load. I decided to lean in to this as a feature instead of trying to redo how each page is announced.