### PR TITLE
Make landing page collections link to exact search matches

### DIFF
--- a/app/views/application/landing.html.erb
+++ b/app/views/application/landing.html.erb
@@ -84,7 +84,7 @@
           </span>
         </div>
       <% end %>
-    
+
       <p class="d-none d-lg-block">Yale University Libraries Digital Collections provides access to millions of digitized works and images from our collections.
         At launch, you can browse hundreds of thousands of works from the Beinecke Rare Book & Manuscript Library’s collections of
         literary archives, early manuscripts, and rare books.
@@ -100,11 +100,11 @@
     <div id='highlights'>
       <h2>HIGHLIGHTS</h2>
       <ul class='clearfix'>
-        <li><%= link_to( search_catalog_path(search_field: 'identifierShelfMark_tesim', q: 'JWJ MSS 26'), id: 'hughes-papers', class: 'btn float-left') do %>
+        <li><%= link_to( search_catalog_path(search_field: 'identifierShelfMark_tesim', q: '"JWJ MSS 26"'), id: 'hughes-papers', class: 'btn float-left') do %>
           <div class='highlight-link'>Langston Hughes Papers</div>
           <% end %>
         </li>
-        <li><%= link_to( search_catalog_path(search_field: 'identifierShelfMark_tesim', q: 'YCAL MSS 46'), id: 'carson-papers', class: 'btn float-left') do %>
+        <li><%= link_to( search_catalog_path(search_field: 'identifierShelfMark_tesim', q: '"YCAL MSS 46"'), id: 'carson-papers', class: 'btn float-left') do %>
           <div class='highlight-link'>Rachel Carson Papers</div>
           <% end %>
         </li>
@@ -112,20 +112,20 @@
           <div class='highlight-link'>Divina Commedia</div>
           <% end %>
         </li>
-        <li><%= link_to( search_catalog_path(search_field: 'identifierShelfMark_tesim', q: ' JWJ MSS 1050'), id: 'van-vechten-papers', class: 'btn float-left') do %>
+        <li><%= link_to( search_catalog_path(search_field: 'identifierShelfMark_tesim', q: '"JWJ MSS 1050"'), id: 'van-vechten-papers', class: 'btn float-left') do %>
           <div class='highlight-link'>Carl Van Vechten Papers</div>
           <% end %>
         </li>
-        <li><%= link_to( search_catalog_path(search_field: 'identifierShelfMark_tesim', q: 'WA MSS S-2368'), id: 'stenzel-collection', class: 'btn float-left') do %>
+        <li><%= link_to( search_catalog_path(search_field: 'identifierShelfMark_tesim', q: '"WA MSS S-2368"'), id: 'stenzel-collection', class: 'btn float-left') do %>
           <div class='highlight-link'>Stenzel Collection of <br/> Western American Art</div>
           <% end %>
         </li>
-        <li><%= link_to( search_catalog_path(search_field: 'identifierShelfMark_tesim', q: 'WA Photos 466'), id: 'lewis-photographs', class: 'btn float-left') do %>
+        <li><%= link_to( search_catalog_path(search_field: 'identifierShelfMark_tesim', q: '"WA Photos 466"'), id: 'lewis-photographs', class: 'btn float-left') do %>
           <div class='highlight-link'>Jon Lewis Photographs</div>
           <% end %>
         </li>
-        <li><%= link_to( search_catalog_path(search_field: 'identifierShelfMark_tesim', q: 'JWJ MSS 26'), id: 'declaration-of-independence', class: 'btn float-left') do %>
-          <div class='highlight-link'>Declaration of independence</div>
+        <li><%= link_to( solr_document_path('2003775'), id: 'declaration-of-independence', class: 'btn float-left') do %>
+          <div class='highlight-link'>Declaration of Independence</div>
           <% end %>
         </li>
         <li><%= link_to( search_catalog_path(search_field: 'all_fields', q: ''), id: 'coming-soon', class: 'btn float-left ') do %>


### PR DESCRIPTION
We need to add quotes around collection call numbers to
make sure we only get exact matches instead of partial matches
from other collection call numbers.