### PR TITLE
Made Filter and startover buttons

### DIFF
--- a/app/assets/stylesheets/customOverrides/constraints.scss
+++ b/app/assets/stylesheets/customOverrides/constraints.scss
@@ -46,8 +46,9 @@ DEFAULT MOBILE STYLING
 
 .constraint-value.btn.btn-outline-secondary {
   display:inline;
+  margin-top: -1px;
   margin-left: 10px;
-  height: calc(100% - 15px);
+  height: calc(100% - 1px);
   width: content-box;
   padding: 3px 0 3px 5.5px;
   background-color: $white;
@@ -63,9 +64,9 @@ DEFAULT MOBILE STYLING
 }
 
 .filter-name{
-  margin-top: 5px;
+  margin-top: 1px;
   position: relative;
-  top: -2px;
+  top: 0;
   color: $medium_grey;
   font-family: $mallory_medium;
   font-size: 12px;
@@ -74,7 +75,7 @@ DEFAULT MOBILE STYLING
 
 .filter-value {
   position: relative;
-  top: -2px;
+  top: 0;
   color: $medium_grey;
   font-family: $mallory_medium;
   font-size: 12px;
@@ -88,7 +89,7 @@ DEFAULT MOBILE STYLING
   text-align: left;
   color: $medium_grey;
   text-transform: uppercase;
-  margin-top:13px;
+  margin-top:19px;
   margin-bottom: 0;
   margin-left: 16px;
   position: relative;

--- a/app/assets/stylesheets/customOverrides/main.scss
+++ b/app/assets/stylesheets/customOverrides/main.scss
@@ -71,15 +71,15 @@ a {
   color: $yale_blue;
 }
 
-
 .btn.btn-outline-secondary.remove > .remove-icon {
   position: relative;
-  top: -9px
+  top: 1px
 }
 
 .start-over-icon {
-margin-left: 5px;
+  margin-left: 5px;
 }
+
 .start-over-image {
   filter: invert(42%) sepia(73%) saturate(6447%) hue-rotate(203deg) brightness(97%) contrast(103%);
 }

--- a/app/views/catalog/_constraints_element.html.erb
+++ b/app/views/catalog/_constraints_element.html.erb
@@ -8,26 +8,18 @@
 %>
 
 <span class="btn-group applied-filter constraint query <%= options[:classes].join(" ") if options[:classes] %>">
-  <span class="constraint-value btn btn-outline-secondary ">
+  <button class="constraint-value btn btn-outline-secondary">
     <% unless label.blank? %>
-      <span class="filter-name"><%= label %></span>
+      <span class="filter-name"><%= label %> </span>
     <% end %>
+
     <% unless value.blank? %>
       <%= content_tag :span, value, class: 'filter-value'%>
-    <% end %>
-    <% unless options[:remove].blank? %>
-    <% accessible_remove_label = content_tag :span, class: 'sr-only' do
-      if label.blank?
-        t('blacklight.search.filters.remove.value', value: value)
-      else
-        t('blacklight.search.filters.remove.label_value', label: label, value: value)
-      end
-    end
-    %>
+      <!-- icon to remove-->
       <%= link_to(content_tag(:span, image_tag('x2x.png', alt: ""),
                               class: 'remove-icon') ,
                   options[:remove], class: 'btn btn-outline-secondary remove'
           ) %>
-  <%- end -%>
-  </span>
+       <% end %>
+  </button>
 </span>

--- a/app/views/catalog/_start_over.html.erb
+++ b/app/views/catalog/_start_over.html.erb
@@ -1,3 +1,4 @@
+<button class="catalog_startOverLink btn btn-primary btn-show">
 <% href = 'start_over.png' %>
 <%= link_to safe_join([
                     content_tag(:span,t('blacklight.search.start_over')),
@@ -5,6 +6,6 @@
                         :span, image_tag(href, class:'start-over-image', alt: ""),
                         class: 'start-over-icon'
                     )]),
-            start_over_path,
-            class: "catalog_startOverLink button btn btn-primary btn-show"
+            start_over_path
 %>
+</button>


### PR DESCRIPTION
**DETAILS**
See issue 4 in https://drive.google.com/open?id=1KsZmdBi00ScskmAMffnM1O_N-CnMUZIv

**ACCEPTANCE**
- [x] Make sure these are 44px high and 44px wide minimum
- [x] The Remove Filter button and Start Over buttons found at the top of the Search Results page should be buttons.
- [x] The images within these buttons should have null alt text. Currently, the file name is being read aloud by VoiceOver, which is not a good experience.