### PR TITLE
Semantic buttons on show page and advanced search

### DIFF
--- a/app/views/advanced/_advanced_search_form.html.erb
+++ b/app/views/advanced/_advanced_search_form.html.erb
@@ -33,9 +33,9 @@
   </div>
 
   <div class="adv-search-sort-submit-buttons clearfix">
-    <input type="submit" name="commit" value="SEARCH" class="btn btn-primary lg-btn advanced-search-submit" id="advanced-search-submit" data-disable-with="Search" aria-label="Search">
-    <%= link_to "BASIC SEARCH", root_path, :class =>"btn btn-primary lg-btn pull-right", aria: { label: 'Basic Search' } %>
-    <%= link_to "CLEAR", blacklight_advanced_search_engine.advanced_search_path, :class =>"btn btn-primary lg-btn advanced-search-start-over", aria: { label: 'Clear Form' } %>
+    <input type="submit" name="commit" value="SEARCH" class="btn btn-primary lg-btn advanced-search-submit" id="advanced-search-submit" data-disable-with="Search" aria-label="Search" role="button">
+    <%= link_to "BASIC SEARCH", root_path, :class =>"btn btn-primary lg-btn pull-right", aria: { label: 'Basic Search' }, "role" => "button" %>
+    <%= link_to "CLEAR", blacklight_advanced_search_engine.advanced_search_path, :class =>"btn btn-primary lg-btn advanced-search-start-over", aria: { label: 'Clear Form' }, "role" => "button" %>
   </div>
 
 <% end %>

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -19,13 +19,13 @@
     <%= text_field_tag :q, params[:q], placeholder: t('blacklight.search.form.search.placeholder'), class: "search-q q form-control rounded-#{search_fields.length > 1 ? '0' : 'left'}", id: "q", aria: { label: 'search' }, autocomplete: presenter.autocomplete_enabled? ? "off" : "", autofocus: presenter.autofocus?, data: { autocomplete_enabled: presenter.autocomplete_enabled?, autocomplete_path: search_action_path(action: :suggest) }  %>
 
     <span class="input-group-append">
-      <button type="submit" class="btn btn-primary search-btn" id="search">
+      <button type="submit" class="btn btn-primary search-btn" id="search" role="button">
         <span class="submit-search-text"><%= t('blacklight.search.form.submit') %></span>
         <%= blacklight_icon :search, aria_hidden: true %>
       </button>
     </span>
     <span>
-      <%= link_to 'Advanced Search', blacklight_advanced_search_engine.advanced_search_path(pristine_search_state.to_h), class: 'advanced_search btn btn-secondary'%>
+      <%= link_to 'Advanced Search', blacklight_advanced_search_engine.advanced_search_path(pristine_search_state.to_h), class: 'advanced_search btn btn-secondary', 'role' => 'button'%>
     </span>
   </div>
 <% end %>

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -2,7 +2,7 @@
   <div id="appliedParams" class="clearfix constraints-container">
     <div id="showSearchButtons" class="show-buttons" >
       <%= render 'start_over' %>
-      <%= link_back_to_catalog class: 'btn btn-primary btn-show' %>
+      <%= link_back_to_catalog class: 'btn btn-primary btn-show', "role" => "button" %>
     </div>
     <%= render 'previous_next_doc' if @search_context %>
   </div>


### PR DESCRIPTION
# Ticket
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/837

# Summary
- the three buttons at the bottom of the advanced search page now have a role of button (see screenshots below)
- the "back to search results", "search" and "advanced search" buttons at the top of the individual show page now have a role of button (see screenshots below)
- the "start over" button on that same page already had a role of button

# Demo
##### advanced search
| | | |
| --- | --- | --- |
| ![Screen Shot 2020-11-17 at 12 44 44 PM](https://user-images.githubusercontent.com/29032869/99459622-4083d180-28e3-11eb-8edf-7cbc69274dac.png) | ![Screen Shot 2020-11-17 at 12 44 52 PM](https://user-images.githubusercontent.com/29032869/99459657-4e395700-28e3-11eb-9d85-f55d147b20fa.png) | ![Screen Shot 2020-11-17 at 12 45 00 PM](https://user-images.githubusercontent.com/29032869/99459680-55606500-28e3-11eb-9be4-02495f941831.png) |

##### show page
| | | |
| --- | --- | --- |
| ![Screen Shot 2020-11-17 at 2 31 40 PM](https://user-images.githubusercontent.com/29032869/99459735-6dd07f80-28e3-11eb-99ed-f4d519532c52.png)|![Screen Shot 2020-11-17 at 2 34 58 PM](https://user-images.githubusercontent.com/29032869/99459755-72953380-28e3-11eb-99d4-0de5333b3942.png) |![Screen Shot 2020-11-17 at 2 35 22 PM](https://user-images.githubusercontent.com/29032869/99459763-77f27e00-28e3-11eb-8922-c51d4a529b2e.png) |