### PR TITLE
Add disable arrow sytling to bottom bar pagination

### DIFF
--- a/app/assets/stylesheets/customOverrides/pagination.scss
+++ b/app/assets/stylesheets/customOverrides/pagination.scss
@@ -24,11 +24,13 @@ DEFAULT MOBILE STYLING
 #first-page-arrows.disabled {
   padding-left: 10px;
   padding-right: 10px;
+  padding-top: 10px;
 }
 
 #last-page-arrows.disabled {
   padding-left: 10px;
   padding-right: 10px;
+  padding-top: 10px;
 }
 
 #last-page-arrows::marker {


### PR DESCRIPTION
**The disable pagination arrows at the bottom should match the height of the enable arrows.**

![Screen Shot 2020-11-18 at 2.59.15 PM.png](https://images.zenhubusercontent.com/5e6013c029e314c92afd4769/5c62b1ce-9cd5-471c-8c27-eca7a6cb60fa)

![Screen Shot 2020-11-19 at 1.22.53 PM.png](https://images.zenhubusercontent.com/5e6273e6ee0145d627e11c85/18562054-16de-477f-849f-059ecb91a602)