### PR TITLE
Implement security for IIIF images

### DIFF
--- a/app/controllers/concerns/check_authorization.rb
+++ b/app/controllers/concerns/check_authorization.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module CheckAuthorization
+  extend ActiveSupport::Concern
+  included do
+    before_action :check_authorization
+  end
+
+  def check_authorization
+    @response, @document = search_for_item
+    if @document.blank?
+      render json: { error: 'not-found' }.to_json, status: 404
+      return false
+    end
+
+    # Handle when the 'visibility_ssi' key doesn't exist on the manifest
+    unless @document.key?('visibility_ssi')
+      render json: { error: 'not-found' }.to_json, status: 404
+      return false
+    end
+
+    case @document['visibility_ssi']
+    when 'Public'
+      true
+    when 'Yale Community Only'
+      return true if current_user
+
+      render json: { error: 'not-found' }.to_json, status: 404
+      false
+    end
+  end
+
+  # Default implementation, to make it easy to override later
+  def search_for_item
+    search_service.fetch(params[:id])
+  end
+end

--- a/app/controllers/concerns/check_authorization.rb
+++ b/app/controllers/concerns/check_authorization.rb
@@ -18,7 +18,6 @@ module CheckAuthorization
       render json: { error: 'not-found' }.to_json, status: 404
       return false
     end
-
     case @document['visibility_ssi']
     when 'Public'
       true

--- a/app/controllers/concerns/check_authorization.rb
+++ b/app/controllers/concerns/check_authorization.rb
@@ -23,7 +23,7 @@ module CheckAuthorization
     when 'Public'
       true
     when 'Yale Community Only'
-      return true if current_user
+      return true if current_user || User.on_campus?(request.remote_ip)
 
       render json: { error: 'not-found' }.to_json, status: 404
       false

--- a/app/controllers/iiif_controller.rb
+++ b/app/controllers/iiif_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Takes a request for an image and passes back the hidden proxy url for nginx to serve
+class IiifController < ApplicationController
+  include Blacklight::Catalog
+  include CheckAuthorization
+
+  def show
+    redirect_to request.original_fullpath.gsub('check', 'authorized')
+  end
+
+  protected
+
+  # IIIF doesn't just return the oid, find the child, then find the oid from there
+  def search_for_item
+    child_oid = params[:id].gsub(/^2\/(\d+)\/.*/, '\1')
+    search_state[:q] = {child_oids_ssim: child_oid}
+    search_state[:rows] = 1
+    search_service_class.new(config: blacklight_config, search_state: search_state, user_params: search_state.to_h, **search_service_context)
+    r, d = search_service.search_results
+    return [r, d.first]
+  end
+end

--- a/app/controllers/iiif_controller.rb
+++ b/app/controllers/iiif_controller.rb
@@ -14,10 +14,10 @@ class IiifController < ApplicationController
   # IIIF doesn't just return the oid, find the child, then find the oid from there
   def search_for_item
     child_oid = params[:id].gsub(/^2\/(\d+)\/.*/, '\1')
-    search_state[:q] = {child_oids_ssim: child_oid}
+    search_state[:q] = { child_oids_ssim: child_oid }
     search_state[:rows] = 1
     search_service_class.new(config: blacklight_config, search_state: search_state, user_params: search_state.to_h, **search_service_context)
     r, d = search_service.search_results
-    return [r, d.first]
+    [r, d.first]
   end
 end

--- a/app/controllers/manifests_controller.rb
+++ b/app/controllers/manifests_controller.rb
@@ -2,8 +2,8 @@
 
 # Takes a request for a manifest/oid and stream the JSON for that oid from S3
 class ManifestsController < ApplicationController
-  before_action :check_authorization
   include Blacklight::Catalog
+  include CheckAuthorization
 
   def show
     remote_path = pairtree_path
@@ -24,25 +24,5 @@ class ManifestsController < ApplicationController
     client = Aws::S3::Client.new
     response = client.get_object(bucket: ENV['SAMPLE_BUCKET'], key: remote_path)
     response.body&.read
-  end
-
-  def check_authorization
-    @response, @document = search_service.fetch(params[:id])
-
-    # Handle when the 'visibility_ssi' key doesn't exist on the manifest
-    unless @document.key?('visibility_ssi')
-      render json: { error: 'not-found' }.to_json, status: 404
-      return false
-    end
-
-    case @document['visibility_ssi']
-    when 'Public'
-      true
-    when 'Yale Community Only'
-      return true if current_user
-
-      render json: { error: 'not-found' }.to_json, status: 404
-      false
-    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,5 +38,6 @@ Rails.application.routes.draw do
   get '/manifests/*id', to: 'manifests#show', as: :manifest
   get '/pdfs/not_found.html', to: 'pdfs#not_found'
   get '/pdfs/*id', to: 'pdfs#show', as: :pdf
+  get '/check-iiif/*id', to: 'iiif#show', as: :iiif
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/ops/webapp.conf
+++ b/ops/webapp.conf
@@ -4,6 +4,14 @@ log_format  main  '$http_x_forwarded_for - $remote_user [$time_local] "$request"
                     '"$http_user_agent"';
 
 passenger_log_file /dev/stdout;
+
+## Extend timeouts to account for proxy delays
+# TODO this may not be needed for our setup
+client_body_timeout       1m;
+client_header_timeout     1m;
+# keepalive_timeout         5m;
+send_timeout              5m;
+
 server {
     error_log /dev/stdout;
     access_log /dev/stdout;
@@ -24,4 +32,148 @@ server {
     # If this is a Ruby app, specify a Ruby version:
     # For Ruby 2.6
     passenger_ruby /usr/bin/ruby2.6;
+
+    ## Proxy this location to canteloupe. Done by load balancer in production
+    ## but needed for development to make the both the same
+    location ^~ /authorized-iiif {
+       ## Override the connection timeouts
+        proxy_connect_timeout       5m;
+        proxy_send_timeout          5m;
+        proxy_read_timeout          5m;
+
+        ## Override the request headers to AWS to what S3 is expecting
+        # proxy_http_version     1.1;
+        # TODO s3 bits proxy_set_header       Connection "";
+
+        ## Make sure we're sending the correct client information to the API server and not
+        ## the NGINX server
+        proxy_set_header       X-Real-IP        $remote_addr;
+        proxy_set_header       X-Forwarded-For  $proxy_add_x_forwarded_for;
+
+        ## We don't want Cantaloupe to set any coookie information
+        proxy_hide_header      Set-Cookie;
+        proxy_ignore_headers   Set-Cookie;
+
+        ## Make sure to unset/hide any authorization requests from Cantaloupe so the client does not get an annoying popup
+        proxy_hide_header      WWW-Authorization;
+        proxy_hide_header      Authorization;
+
+        ## Add any headers you would like back to the client
+        ## I send the API request ID for debugging purposes
+        add_header             X-Request-Id $saved_request_id;
+
+        rewrite    /authorized-iiif/(.*) /iiif/$1 break;
+        proxy_pass http://iiif_image:8182;
+    }
+
+    ## Location or path of limited access media
+    location ^~  /iiif {
+        ## Override the connection timeout making sure the proxy server has time to respond
+        ## TODO may not be needed
+        proxy_connect_timeout       5m;
+        proxy_send_timeout          5m;
+        proxy_read_timeout          5m;
+
+        ## Make sure we're sending the correct client information to the API server and not
+        ## the NGINX server
+        proxy_set_header            X-Real-IP        $remote_addr;
+        proxy_set_header            X-Forwarded-For  $proxy_add_x_forwarded_for;
+
+        ## Adding a header to verify the request is coming from NGINX on the server
+        ##
+        ## TODO Find a better way not to store this in the file
+        ##  NGINX does not allow ENV variables, so you can use a
+        ##   deployment script ot update the value
+        ## proxy_set_header   X-Nginx-Secret   'some-super-secret-key';
+
+        proxy_redirect off; # We don't want a redirect to be passed to the client - NGINX needs to handle it
+        proxy_pass http://127.0.0.1:3000/check-iiif; # Send the user access request to the API server
+
+        # TODO proxy_ssl_server_name on; # Enable for HTTPS
+
+        ## Enabled so that NGINX can handle the response from the api server
+        recursive_error_pages on;
+        proxy_intercept_errors on;
+
+        ## Define the errors NGNIX will handle from the API Server
+        error_page 301 302 307  = @handle_redirect;         # The user has access to the media - redirect to presigned URL
+        error_page 401 403      = @unauthorized;            # The user does not have access to the media
+        error_page 404          = @not_found;               # Could not find the media
+        error_page 500 503      = @internal_server_error;   # There was an issue on the API server
+
+        ## Enable CORS if needed for any 3rd party tools
+        if ($http_origin ~ '^http(s)?://') {
+          add_header Access-Control-Allow-Origin $http_origin always;
+          add_header Access-Control-Allow-Methods 'OPTIONS, HEAD, GET' always;
+          add_header Access-Control-Allow-Credentials true always;
+        }
+    }
+
+    ## The API server granted the user access to the media
+    ## Redirect to a presigned AWS S3 URL to the media
+    location @handle_redirect {
+        resolver 8.8.8.8; # We need NGINX to be able to resolve the AWS url # TODO do I need this
+
+        set $saved_redirect_location '$upstream_http_location'; # Save the url location the API is redirecting to
+        set $saved_request_id '$upstream_http_x_request_id';    # Save the Request ID returned from the API server
+
+        ## Override the connection timeouts
+        proxy_connect_timeout       5m;
+        proxy_send_timeout          5m;
+        proxy_read_timeout          5m;
+
+        ## Override the request headers to AWS to what S3 is expecting
+        # proxy_http_version     1.1;
+        # TODO s3 bits proxy_set_header       Connection "";
+
+        ## Make sure we're sending the correct client information to the API server and not
+        ## the NGINX server
+        proxy_set_header       X-Real-IP        $remote_addr;
+        proxy_set_header       X-Forwarded-For  $proxy_add_x_forwarded_for;
+
+        ## We don't want Cantaloupe to set any coookie information
+        proxy_hide_header      Set-Cookie;
+        proxy_ignore_headers   Set-Cookie;
+
+        ## Make sure to unset/hide any authorization requests from Cantaloupe so the client does not get an annoying popup
+        proxy_hide_header      WWW-Authorization;
+        proxy_hide_header      Authorization;
+
+        ## Add any headers you would like back to the client
+        ## I send the API request ID for debugging purposes
+        add_header             X-Request-Id $saved_request_id;
+
+        ## Make the request to Cantaloupe using the generated URL
+        proxy_pass $saved_redirect_location;
+
+        ## Intercept any errors that Cantaloupe returns
+        proxy_intercept_errors on;
+        error_page 301 302 307  = @handle_redirect;         # Handle a redirect from Cantaloupe
+        error_page 401 403      = @unauthorized;            # AWS signed url was invalid
+        error_page 404          = @not_found;               # AWS could not find the media
+        error_page 500 503      = @internal_server_error;   # Something is wrong with Cantaloupe or the request
+
+        ## Handle any CORS that a 3rd party is expecting here
+        if ($http_origin ~ '^http(s)?://') {
+          add_header Access-Control-Allow-Origin $http_origin always;
+          add_header Access-Control-Allow-Methods 'OPTIONS, HEAD, GET' always;
+          add_header Access-Control-Allow-Credentials true always;
+        }
+      }
+
+      ## An example of handling an unauthorized error
+      location @unauthorized {
+        rewrite ^ /403?request_uri=$uri;
+      }
+
+      ## An example of handling a 404 error
+      location @not_found {
+        rewrite ^ /404?request_uri=$uri;
+      }
+
+      ## An example of handling a 500 error
+      location @internal_server_error {
+          rewrite ^ /500?request_uri=$uri;
+        }
+
 }

--- a/ops/webapp.conf
+++ b/ops/webapp.conf
@@ -41,10 +41,6 @@ server {
         proxy_send_timeout          5m;
         proxy_read_timeout          5m;
 
-        ## Override the request headers to AWS to what S3 is expecting
-        # proxy_http_version     1.1;
-        # TODO s3 bits proxy_set_header       Connection "";
-
         ## Make sure we're sending the correct client information to the API server and not
         ## the NGINX server
         proxy_set_header       X-Real-IP        $remote_addr;
@@ -89,7 +85,7 @@ server {
         proxy_redirect off; # We don't want a redirect to be passed to the client - NGINX needs to handle it
         proxy_pass http://127.0.0.1:3000/check-iiif; # Send the user access request to the API server
 
-        # TODO proxy_ssl_server_name on; # Enable for HTTPS
+        # proxy_ssl_server_name on; # Enable for HTTPS
 
         ## Enabled so that NGINX can handle the response from the api server
         recursive_error_pages on;
@@ -112,8 +108,6 @@ server {
     ## The API server granted the user access to the media
     ## Redirect to a presigned AWS S3 URL to the media
     location @handle_redirect {
-        resolver 8.8.8.8; # We need NGINX to be able to resolve the AWS url # TODO do I need this
-
         set $saved_redirect_location '$upstream_http_location'; # Save the url location the API is redirecting to
         set $saved_request_id '$upstream_http_x_request_id';    # Save the Request ID returned from the API server
 
@@ -121,10 +115,6 @@ server {
         proxy_connect_timeout       5m;
         proxy_send_timeout          5m;
         proxy_read_timeout          5m;
-
-        ## Override the request headers to AWS to what S3 is expecting
-        # proxy_http_version     1.1;
-        # TODO s3 bits proxy_set_header       Connection "";
 
         ## Make sure we're sending the correct client information to the API server and not
         ## the NGINX server

--- a/spec/requests/iiif_request_spec.rb
+++ b/spec/requests/iiif_request_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+RSpec.describe "Iiifs", type: :request do
+  let(:user) { FactoryBot.create(:user) }
+  let(:public_work) { WORK_WITH_PUBLIC_VISIBILITY.merge({"child_oids_ssim": ["5555555"]}) }
+  let(:yale_work) do
+    {
+      "id": "1618909",
+      "title_tesim": ["[Map of China]. [yale-only copy]"],
+      "visibility_ssi": "Yale Community Only",
+      "child_oids_ssim": ["1111111"]
+    }
+  end
+  let(:no_visibility_work) do
+    {
+      "id": "1234567",
+      "title_tesim": ["Fake Work"],
+      "child_oids_ssim": ["2222222"]
+    }
+  end
+
+  before do
+    solr = Blacklight.default_index.connection
+    solr.add([public_work, yale_work, no_visibility_work])
+    solr.commit
+  end
+
+  context 'as an unauthenticated user' do
+    it 'display if set to public' do
+      get "/check-iiif/2/5555555/full/!200,200/0/default.jpg"
+
+      expect(response).to redirect_to("/authorized-iiif/2/5555555/full/!200,200/0/default.jpg")
+    end
+
+    it 'do not display if set to yale only' do
+      get "/check-iiif/2/1111111/full/!200,200/0/default.jpg"
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'returns a 404 if there is no visibility key' do
+      get "/check-iiif/2/2222222/full/!200,200/0/default.jpg"
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  context 'as an authenticated user' do
+    before do
+      sign_in user
+    end
+    it 'display if set to public' do
+      get "/check-iiif/2/5555555/full/!200,200/0/default.jpg"
+
+      expect(response).to redirect_to("/authorized-iiif/2/5555555/full/!200,200/0/default.jpg")
+    end
+
+    it 'do not display if set to yale only' do
+      get "/check-iiif/2/1111111/full/!200,200/0/default.jpg"
+
+      expect(response).to redirect_to("/authorized-iiif/2/1111111/full/!200,200/0/default.jpg")
+    end
+
+    it 'returns a 404 if there is no visibility key' do
+      get "/check-iiif/2/2222222/full/!200,200/0/default.jpg"
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+end

--- a/spec/requests/iiif_request_spec.rb
+++ b/spec/requests/iiif_request_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe "Iiifs", type: :request do
     solr = Blacklight.default_index.connection
     solr.add([public_work, yale_work, no_visibility_work])
     solr.commit
+    allow(User).to receive(:on_campus?).and_return(false)
   end
 
   context 'as an unauthenticated user' do

--- a/spec/requests/iiif_request_spec.rb
+++ b/spec/requests/iiif_request_spec.rb
@@ -1,8 +1,9 @@
+# frozen_string_literal: true
 require 'rails_helper'
 
 RSpec.describe "Iiifs", type: :request do
   let(:user) { FactoryBot.create(:user) }
-  let(:public_work) { WORK_WITH_PUBLIC_VISIBILITY.merge({"child_oids_ssim": ["5555555"]}) }
+  let(:public_work) { WORK_WITH_PUBLIC_VISIBILITY.merge({ "child_oids_ssim": ["5555555"] }) }
   let(:yale_work) do
     {
       "id": "1618909",
@@ -67,5 +68,4 @@ RSpec.describe "Iiifs", type: :request do
       expect(response).to have_http_status(:not_found)
     end
   end
-
 end

--- a/spec/requests/manifests_request_spec.rb
+++ b/spec/requests/manifests_request_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe 'Manifests', type: :request, clean: true do
     solr = Blacklight.default_index.connection
     solr.add([public_work, yale_work, no_visibility_work])
     solr.commit
+    allow(User).to receive(:on_campus?).and_return(false)
   end
 
   around do |example|


### PR DESCRIPTION
This commit adds a new route check-iiif which tests for authorization in whatever way other items test for authorization.
It also adds Nginx configs to allow the Cantaloupe service to be moved to authorized-iiif and for this app to server /iiif.

All upstream image transfer after authorization would then be streamed by nginx and would free the Rails application process.

See https://medium.com/@jefawks3/using-nginx-as-a-multi-step-reverse-proxy-to-authorize-requests-before-serving-content-on-s3-d4094577c60e

Fixes https://github.com/yalelibrary/YUL-DC/issues/708