### PR TITLE
Manifests return a 401/404 for unauthorized/not found respectively

### DIFF
--- a/app/controllers/manifests_controller.rb
+++ b/app/controllers/manifests_controller.rb
@@ -10,7 +10,7 @@ class ManifestsController < ApplicationController
     response.set_header('Access-Control-Allow-Origin', '*')
     render json: download_from_s3(remote_path)
   rescue ArgumentError
-    render json: { error: "not-found" }.to_json, status: 404
+    render json: { error: 'unauthorized' }.to_json, status: 401
   end
 
   private
@@ -41,7 +41,7 @@ class ManifestsController < ApplicationController
     when 'Yale Community Only'
       return true if current_user
 
-      render json: { error: 'not-found' }.to_json, status: 404
+      render json: { error: 'unauthorized' }.to_json, status: 401
       false
     end
   end

--- a/spec/requests/manifests_request_spec.rb
+++ b/spec/requests/manifests_request_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe 'Manifests', type: :request, clean: true do
       get '/manifests/1618909'
       manifest = JSON.parse(response.body)
 
-      expect(manifest['error']).to eq('not-found')
+      expect(manifest['error']).to eq('unauthorized')
     end
 
     it 'returns a 404 if there is no visibility key' do


### PR DESCRIPTION
# Related To
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/705

# Summary
- if a manifest does not show because it does not have the `visibility_ssi` property, the user gets a 404 error
- if the user is not on campus or logged in with cas, they'll get a 401 error when viewing "yale community only" manifests