### PR TITLE
Remove unindexed solr fields

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -183,8 +183,6 @@ class CatalogController < ApplicationController
     config.add_show_field 'references_tesim', label: 'References', metadata: 'description'
     config.add_show_field 'projection_tesim', label: 'Projection', metadata: 'description'
     config.add_show_field 'scale_tesim', label: 'Scale', metadata: 'description'
-    config.add_show_field 'subtitle_tesim', label: 'Subtitle', metadata: 'description'
-    config.add_show_field 'subtitle_vern_ssim', label: 'Subtitle', metadata: 'description'
 
     # Keywords Group
     config.add_show_field 'format', label: 'Format', metadata: 'keyword', link_to_facet: true
@@ -205,7 +203,6 @@ class CatalogController < ApplicationController
     config.add_show_field 'language_ssim', label: 'Language', metadata: 'origin', helper_method: :language_codes_as_links
     config.add_show_field 'publicationPlace_ssim', label: 'Publication Place', metadata: 'origin'
     config.add_show_field 'publisher_ssim', label: 'Publisher', metadata: 'origin'
-    config.add_show_field 'published_ssim', label: 'Published', metadata: 'origin'
     config.add_show_field 'sourceCreated_tesim', label: 'Source Created', metadata: 'origin'
     config.add_show_field 'sourceDate_tesim', label: 'Source Date', metadata: 'origin'
     config.add_show_field 'sourceEdition_tesim', label: 'Source Edition', metadata: 'origin'
@@ -214,19 +211,15 @@ class CatalogController < ApplicationController
 
     # Identifiers Group
     config.add_show_field 'box_ssim', label: 'Box', metadata: 'identifier'
-    config.add_show_field 'children_ssim', label: 'Children', metadata: 'identifier'
     config.add_show_field 'findingAid_ssim', label: 'Finding Aid', metadata: 'identifier', helper_method: :link_to_url
     config.add_show_field 'folder_ssim', label: 'Folder', metadata: 'identifier'
     config.add_show_field 'identifierMfhd_ssim', label: 'Identifier MFHD', metadata: 'identifier'
     config.add_show_field 'identifierShelfMark_ssim', label: 'Call Number', metadata: 'identifier', link_to_facet: true
-    config.add_show_field 'importUrl_ssim', label: 'Import URL', metadata: 'identifier'
-    config.add_show_field 'isbn_ssim', label: 'ISBN', metadata: 'identifier'
     config.add_show_field 'orbisBarcode_ssi', label: 'Orbis Bar Code', metadata: 'identifier'
     config.add_show_field 'orbisBibId_ssi', label: 'Orbis Bib ID', metadata: 'identifier', helper_method: :link_to_orbis_bib_id
     config.add_show_field 'oid_ssi', label: 'OID', metadata: 'identifier'
     config.add_show_field 'partOf_ssim', label: 'Collection Name', metadata: 'identifier'
     config.add_show_field 'uri_ssim', label: 'URI', metadata: 'identifier'
-    config.add_show_field 'url_fulltext_ssim', label: 'URL', metadata: 'identifier'
     config.add_show_field 'url_suppl_ssim', label: 'More Information', metadata: 'identifier'
 
     # Usage Group

--- a/spec/presenters/yul/metadata_presenter_spec.rb
+++ b/spec/presenters/yul/metadata_presenter_spec.rb
@@ -71,10 +71,6 @@ RSpec.describe Yul::MetadataPresenter do
         it 'returns the Scale Key' do
           expect(fields.any? { |field| field.include? 'scale_tesim' }).to be_truthy
         end
-
-        it 'returns the Subtitle Key' do
-          expect(fields.any? { |field| field.include? 'subtitle_tesim' }).to be_truthy
-        end
       end
     end
   end
@@ -86,10 +82,6 @@ RSpec.describe Yul::MetadataPresenter do
       describe 'config' do
         it 'returns the Box Key' do
           expect(fields.any? { |field| field.include? 'box_ssim' }).to be_truthy
-        end
-
-        it 'returns the Children Key' do
-          expect(fields.any? { |field| field.include? 'children_ssim' }).to be_truthy
         end
 
         it 'returns the Finding Aid Key' do
@@ -106,14 +98,6 @@ RSpec.describe Yul::MetadataPresenter do
 
         it 'returns the Call Number Key' do
           expect(fields.any? { |field| field.include? 'identifierShelfMark_ssim' }).to be_truthy
-        end
-
-        it 'returns the Import URL Key' do
-          expect(fields.any? { |field| field.include? 'importUrl_ssim' }).to be_truthy
-        end
-
-        it 'returns the ISBN Key' do
-          expect(fields.any? { |field| field.include? 'isbn_ssim' }).to be_truthy
         end
 
         it 'returns the Orbis Barcode Key' do
@@ -134,10 +118,6 @@ RSpec.describe Yul::MetadataPresenter do
 
         it 'returns the URI Key' do
           expect(fields.any? { |field| field.include? 'uri_ssim' }).to be_truthy
-        end
-
-        it 'returns the URL Key' do
-          expect(fields.any? { |field| field.include? 'url_fulltext_ssim' }).to be_truthy
         end
 
         it 'returns the More Information Key' do
@@ -171,14 +151,6 @@ RSpec.describe Yul::MetadataPresenter do
 
         it 'returns the Resource Type Key' do
           expect(fields.any? { |field| field.include? 'resourceType_ssim' }).to be_truthy
-        end
-
-        it 'returns the Subject Name Key' do
-          expect(fields.any? { |field| field.include? 'subjectName_ssim' }).to be_truthy
-        end
-
-        it 'returns the Subject Topic Key' do
-          expect(fields.any? { |field| field.include? 'subjectTopic_tesim' }).to be_truthy
         end
       end
     end
@@ -236,10 +208,6 @@ RSpec.describe Yul::MetadataPresenter do
 
         it 'returns the Publisher Key' do
           expect(fields.any? { |field| field.include? 'publisher_ssim' }).to be_truthy
-        end
-
-        it 'returns the Published Key' do
-          expect(fields.any? { |field| field.include? 'published_ssim' }).to be_truthy
         end
 
         it 'returns the Source Created Key' do

--- a/spec/system/view_fields_in_display_spec.rb
+++ b/spec/system/view_fields_in_display_spec.rb
@@ -31,15 +31,10 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
     {
       id: '111',
       title_tesim: "Diversity Bull Dogs",
-      subtitle_tesim: "He's handsome",
-      subtitle_vern_ssim: "He's handsome",
       creator_ssim: ['Frederick,  Eric & Maggie'],
       format: 'three dimensional object',
-      url_fulltext_ssim: 'http://0.0.0.0:3000/catalog/111',
       url_suppl_ssim: 'http://0.0.0.0:3000/catalog/111',
-      published_ssim: "1997",
       language_ssim: ['en', 'eng', 'zz'],
-      isbn_ssim: '2321321389',
       description_tesim: "Handsome Dan is a bulldog who serves as Yale Univeristy's mascot.",
       visibility_ssi: 'Public',
       abstract_tesim: "this is an abstract",
@@ -62,8 +57,6 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       sourceNote_tesim: "this is the source note",
       references_tesim: "these are the references",
       date_ssim: "this is the date",
-      children_ssim: "these are the children",
-      importUrl_ssim: "this is the import URL",
       oid_ssi: '2345678',
       identifierMfhd_ssim: 'this is the identifier MFHD',
       identifierShelfMark_ssim: 'this is the call number',
@@ -92,15 +85,6 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
     end
     it 'displays Creator in results' do
       expect(document).to have_content("Frederick, Eric & Maggie")
-    end
-    it 'displays Subtitle in results' do
-      expect(document).to have_content("He's handsome")
-    end
-    it 'displays Url Fulltext in results' do
-      expect(document).to have_content("http://0.0.0.0:3000/catalog/111").twice
-    end
-    it 'displays Publishing in results' do
-      expect(document).to have_content("1997")
     end
     it 'displays format in results' do
       expect(document).to have_content("three dimensional object")
@@ -133,9 +117,6 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       expect(document).to have_content("English (en)")
       expect(document).to have_content("English (eng)")
       expect(document).to have_content("zz")
-    end
-    it 'displays ISBN in results' do
-      expect(document).to have_content("2321321389")
     end
     it 'displays description in results' do
       expect(document).to have_content("Handsome Dan is a bulldog who serves as Yale Univeristy's mascot.")
@@ -199,12 +180,6 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
     end
     it 'displays the Date in results' do
       expect(document).to have_content("this is the date")
-    end
-    it 'displays the Children in results' do
-      expect(document).to have_content("these are the children")
-    end
-    it 'displays the import URL in results' do
-      expect(document).to have_content("this is the import URL")
     end
     it 'displays the OID in results' do
       expect(document).to have_content("2345678")


### PR DESCRIPTION
# Ticket
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/826

# Summary
the following fields are no longer on the show page. there's no visual verification because only fields with a value were appearing on the show page anyway.
- Subtitle
- Published
- Children
- Import URL
- ISBN
- URL