### PR TITLE
Add sort by year options to search results

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -452,6 +452,8 @@ class CatalogController < ApplicationController
     config.add_sort_field 'creator_ssim desc, title_ssim asc', label: 'Creator (Z --> A)'
     config.add_sort_field 'title_ssim asc, oid_ssi desc', label: 'Title (A --> Z)'
     config.add_sort_field 'title_ssim desc, oid_ssi desc', label: 'Title (Z --> A)'
+    config.add_sort_field 'year_isim asc, id desc', label: 'Year (ascending)'
+    config.add_sort_field 'year_isim desc, id desc', label: 'Year (descending)'
 
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.

--- a/spec/system/sort_in_search_spec.rb
+++ b/spec/system/sort_in_search_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'Search results should be sorted', type: :system, js: :true, clea
       resourceType_ssim: 'Maps, Atlases & Globes',
       creator_ssim: ['Anna Elizabeth Dewdney'],
       dateStructured_ssim: '1911-1954',
-      year_isim: '18th century.'
+      year_isim: [1690]
     }
   end
 
@@ -40,7 +40,7 @@ RSpec.describe 'Search results should be sorted', type: :system, js: :true, clea
       resourceType_ssim: 'Books, Journals & Pamphlets',
       creator_ssim: ['Andy Graves'],
       dateStructured_ssim: '1755-00-00T00:00:00Z',
-      year_isim: '[17--?]'
+      year_isim: [1755]
     }
   end
 
@@ -56,7 +56,7 @@ RSpec.describe 'Search results should be sorted', type: :system, js: :true, clea
       resourceType_ssim: 'Archives or Manuscripts',
       creator_ssim: ['Paulo Coelho'],
       dateStructured_ssim: '1972200',
-      year_isim: '1739-40 February 18'
+      year_isim: [1790]
     }
   end
 
@@ -72,7 +72,7 @@ RSpec.describe 'Search results should be sorted', type: :system, js: :true, clea
       resourceType_ssim: 'Archives or Manuscripts',
       creator_ssim: ['Andrew Norriss'],
       dateStructured_ssim: '1699',
-      year_isim: '1755'
+      year_isim: [1830]
     }
   end
 
@@ -165,28 +165,28 @@ RSpec.describe 'Search results should be sorted', type: :system, js: :true, clea
       click_on 'search'
       click_on 'Sort by relevance'
       within('div#sort-dropdown') do
-        click_on 'Year (Ascending)'
+        click_on 'Year (ascending)'
       end
 
       content = find(:css, '#content')
-      expect(content).to have_content("1.\nAquila Eccellenza")
+      expect(content).to have_content("1.\nAmor Llama")
       expect(content).to have_content("2.\nHandsomeDan Bulldog")
-      expect(content).to have_content("3.\nAmor Llama")
-      expect(content).to have_content("4.\nRhett Lecheire")
+      expect(content).to have_content("3.\nRhett Lecheire")
+      expect(content).to have_content("4.\nAquila Eccellenza")
     end
 
     it 'sorts by year desc' do
       click_on 'search'
       click_on 'Sort by relevance'
       within('div#sort-dropdown') do
-        click_on 'Year (Descending)'
+        click_on 'Year (descending)'
       end
 
       content = find(:css, '#content')
-      expect(content).to have_content("4.\nAquila Eccellenza")
+      expect(content).to have_content("1.\nAquila Eccellenza")
+      expect(content).to have_content("2.\nRhett Lecheire")
       expect(content).to have_content("3.\nHandsomeDan Bulldog")
-      expect(content).to have_content("2.\nAmor Llama")
-      expect(content).to have_content("1.\nRhett Lecheire")
+      expect(content).to have_content("4.\nAmor Llama")
     end
   end
 end

--- a/spec/system/sort_in_search_spec.rb
+++ b/spec/system/sort_in_search_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe 'Search results should be sorted', type: :system, js: :true, clea
       publicationPlace_ssim: 'Spain',
       resourceType_ssim: 'Maps, Atlases & Globes',
       creator_ssim: ['Anna Elizabeth Dewdney'],
-      dateStructured_ssim: '1911-1954'
+      dateStructured_ssim: '1911-1954',
+      year_isim: '18th century.'
     }
   end
 
@@ -38,7 +39,8 @@ RSpec.describe 'Search results should be sorted', type: :system, js: :true, clea
       publicationPlace_ssim: 'New Haven',
       resourceType_ssim: 'Books, Journals & Pamphlets',
       creator_ssim: ['Andy Graves'],
-      dateStructured_ssim: '1755-00-00T00:00:00Z'
+      dateStructured_ssim: '1755-00-00T00:00:00Z',
+      year_isim: '[17--?]'
     }
   end
 
@@ -53,7 +55,8 @@ RSpec.describe 'Search results should be sorted', type: :system, js: :true, clea
       publicationPlace_ssim: 'Constantinople or southern Italy',
       resourceType_ssim: 'Archives or Manuscripts',
       creator_ssim: ['Paulo Coelho'],
-      dateStructured_ssim: '1972200'
+      dateStructured_ssim: '1972200',
+      year_isim: '1739-40 February 18'
     }
   end
 
@@ -68,7 +71,8 @@ RSpec.describe 'Search results should be sorted', type: :system, js: :true, clea
       publicationPlace_ssim: 'White-Hall, printed upon the ice, on the River Thames',
       resourceType_ssim: 'Archives or Manuscripts',
       creator_ssim: ['Andrew Norriss'],
-      dateStructured_ssim: '1699'
+      dateStructured_ssim: '1699',
+      year_isim: '1755'
     }
   end
 
@@ -127,7 +131,7 @@ RSpec.describe 'Search results should be sorted', type: :system, js: :true, clea
   end
 
   context 'sorts by creator' do
-    it 'sorts by creater asc' do
+    it 'sorts by creator asc' do
       click_on 'search'
       click_on 'Sort by relevance'
       within('div#sort-dropdown') do
@@ -141,11 +145,41 @@ RSpec.describe 'Search results should be sorted', type: :system, js: :true, clea
       expect(content).to have_content("4.\nRhett Lecheire")
     end
 
-    it 'sorts by creater desc' do
+    it 'sorts by creator desc' do
       click_on 'search'
       click_on 'Sort by relevance'
       within('div#sort-dropdown') do
         click_on 'Creator (Z --> A)'
+      end
+
+      content = find(:css, '#content')
+      expect(content).to have_content("4.\nAquila Eccellenza")
+      expect(content).to have_content("3.\nHandsomeDan Bulldog")
+      expect(content).to have_content("2.\nAmor Llama")
+      expect(content).to have_content("1.\nRhett Lecheire")
+    end
+  end
+
+  context 'sorts by year' do
+    it 'sorts by year asc' do
+      click_on 'search'
+      click_on 'Sort by relevance'
+      within('div#sort-dropdown') do
+        click_on 'Year (Ascending)'
+      end
+
+      content = find(:css, '#content')
+      expect(content).to have_content("1.\nAquila Eccellenza")
+      expect(content).to have_content("2.\nHandsomeDan Bulldog")
+      expect(content).to have_content("3.\nAmor Llama")
+      expect(content).to have_content("4.\nRhett Lecheire")
+    end
+
+    it 'sorts by year desc' do
+      click_on 'search'
+      click_on 'Sort by relevance'
+      within('div#sort-dropdown') do
+        click_on 'Year (Descending)'
       end
 
       content = find(:css, '#content')


### PR DESCRIPTION
**IMAGE**
![Screen Shot 2020-12-02 at 10 37 45 AM](https://user-images.githubusercontent.com/41123693/100894457-82d41380-348a-11eb-8ebc-c9fac5badae4.png)

---

**ACCEPTANCE**
- [x] I have a sorting option "Year (ascending)" for search results
- [x] I have a sorting option "Year (descending)" for search results
- [x] The option sorts results by `year_isim` as the primary sort
- [x] The option sorts results by `id` as the disambiguation sort (i.e. if more than one item has the same year)