### PR TITLE
Connect year_isim to dateslider. Fix dateslider going out of range

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@
 /tmp/*
 !/log/.keep
 !/tmp/.keep
-
+r
 # Ignore uploaded files in development.
 /storage/*
 !/storage/.keep

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,10 @@ RSpec/DescribeClass:
     - spec/system/search_result_pagination_spec.rb
     - spec/system/date_slider_spec.rb
 
+RSpec/InstanceVariable:
+  Exclude:
+    - spec/helpers/blacklight_helper_spec.rb
+
 RSpec/RepeatedExample:
   Exclude:
     - spec/system/access_restrictions_spec.rb

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -109,13 +109,14 @@ class CatalogController < ApplicationController
     config.add_facet_field 'publicationPlace_ssim', label: 'Publication Place', limit: true
     config.add_facet_field 'partOf_ssim', label: 'Digital Collection', limit: true
     config.add_facet_field 'pub_date_ssim', label: 'Publication Year', single: true
-    config.add_facet_field 'dateStructured_ssim', label: 'Date Created',
-                                                  range: {
-                                                    num_segments: 6,
-                                                    assumed_boundaries: [800, Time.current.year + 2],
-                                                    segments: true,
-                                                    maxlength: 4
-                                                  }, solr_params: { 'facet.pivot.mincount' => 2 }
+    config.add_facet_field 'year_isim', label: 'Date Created',
+                                        range: {
+                                          segments: true,
+                                          maxlength: 4
+                                        },
+                                        if: lambda { |_context, _field_config, facet|
+                                              facet.items.length > 1
+                                            }
 
     # the facets below are set to false because we aren't filtering on them from the main search page
     # but we need to be able to provide a label when they are filtered upon from an individual show page

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -7,6 +7,41 @@ module BlacklightHelper
     "/mirador/#{oid}"
   end
 
+  # sets up date params for constraint partial
+  def render_date_constraint(params)
+    label = "Date"
+
+    # if date is unknown
+    if params["range"].try(:[], "dateStructured_ssim").try(:[], "missing")
+      value = "Unknown"
+      remove_url = range_unknown_remove_url
+    else
+      beg_date = params["range"].values[0]["begin"]
+      end_date = params["range"].values[0]["end"]
+
+      value ||= "#{beg_date} - #{end_date}"
+      remove_url = range_remove_url
+    end
+
+    options = {
+      remove: remove_url,
+      classes: ["dateStructured_ssim"]
+    }
+    render partial: "constraints_element", locals: { value: value, label: label, options: options }
+  end
+
+  # removes date range params from link with unknown date
+  def range_unknown_remove_url
+    url = request.url.gsub(/[?&]range%5BdateStructured_.*%5D%5Bmissing%5D=true&commit=Apply/, '')
+    url.gsub!(/[?&]range%5BdateStructured_.*%5D%5Bmissing%5D=true/, '')
+  end
+
+  # removes date range params from link
+  def range_remove_url
+    url = request.url.gsub(/[&?]range%5BdateStructured_.*%5D%5Bbegin%5D=[\d]{3,4}&range%5BdateStructured_.*%5D%5Bend%5D=[\d]{3,4}&commit=Apply/, '')
+    url.gsub(/[&?]range%5BdateStructured_.*%5D%5Bbegin%5D=[\d]{3,4}&range%5BdateStructured_.*5D%5Bend%5D=[\d]{3,4}/, '')
+  end
+
   def language_codes(args)
     language_values = args[:document][args[:field]]
     language_values.map do |language_code|

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -8,38 +8,40 @@ module BlacklightHelper
   end
 
   # sets up date params for constraint partial
-  def render_date_constraint(params)
+  def get_date_constraint_params(params, url)
     label = "Date"
 
     # if date is unknown
-    if params["range"].try(:[], "dateStructured_ssim").try(:[], "missing")
+    if params["range"].try(:[], "year_isim").try(:[], "missing")
       value = "Unknown"
-      remove_url = range_unknown_remove_url
+      remove_url = range_unknown_remove_url(url)
     else
       beg_date = params["range"].values[0]["begin"]
       end_date = params["range"].values[0]["end"]
 
       value ||= "#{beg_date} - #{end_date}"
-      remove_url = range_remove_url
+      remove_url = range_remove_url(url)
     end
 
     options = {
       remove: remove_url,
-      classes: ["dateStructured_ssim"]
+      classes: ["year_isim"]
     }
-    render partial: "constraints_element", locals: { value: value, label: label, options: options }
+    [value, label, options]
   end
 
   # removes date range params from link with unknown date
-  def range_unknown_remove_url
-    url = request.url.gsub(/[?&]range%5BdateStructured_.*%5D%5Bmissing%5D=true&commit=Apply/, '')
-    url.gsub!(/[?&]range%5BdateStructured_.*%5D%5Bmissing%5D=true/, '')
+  def range_unknown_remove_url(url_in)
+    url = url_in.gsub(/[?&]range%5Byear_.*%5D%5Bmissing%5D=true/, '')
+    url.gsub!("&commit=Apply", '')
+    url.gsub(/[?&]range%5Byear_.*%5D%5Bmissing%5D=true/, '')
   end
 
   # removes date range params from link
-  def range_remove_url
-    url = request.url.gsub(/[&?]range%5BdateStructured_.*%5D%5Bbegin%5D=[\d]{3,4}&range%5BdateStructured_.*%5D%5Bend%5D=[\d]{3,4}&commit=Apply/, '')
-    url.gsub(/[&?]range%5BdateStructured_.*%5D%5Bbegin%5D=[\d]{3,4}&range%5BdateStructured_.*5D%5Bend%5D=[\d]{3,4}/, '')
+  def range_remove_url(url_in)
+    url = url_in.gsub(/[&?]range%5Byear_.*%5D%5Bbegin%5D=[\d]{3,4}&range%5Byear_.*%5D%5Bend%5D=[\d]{3,4}/, '')
+    url.gsub!("&commit=Apply", '')
+    url.gsub(/[&?]range%5Byear_.*%5D%5Bbegin%5D=[\d]{1,4}&range%5Byear_.*5D%5Bend%5D=[\d]{1,4}/, '')
   end
 
   def language_codes(args)

--- a/app/views/catalog/_constraints.html.erb
+++ b/app/views/catalog/_constraints.html.erb
@@ -2,7 +2,7 @@
   <div id="appliedParams" class="clearfix constraints-container constraints-container-index">
     <h2 class="sr searched-heading"><%= t('blacklight.search.search_constraints_header') %></h2>
 
-
+    <%= render_date_constraint(params) if params["range"].present? %>
     <%= render_constraints(controller.params != params ? params : search_state) %>
     <%= render 'start_over', show_icon: true%>
   </div>

--- a/app/views/catalog/_constraints.html.erb
+++ b/app/views/catalog/_constraints.html.erb
@@ -1,8 +1,11 @@
 <% if Deprecation.silence(Blacklight::RenderConstraintsHelperBehavior) { query_has_constraints? } %>
   <div id="appliedParams" class="clearfix constraints-container constraints-container-index">
     <h2 class="sr searched-heading"><%= t('blacklight.search.search_constraints_header') %></h2>
+    <% if params["range"].present? %>
+      <% value,label, options = get_date_constraint_params(params, request.url)%>
+      <%= render partial: "constraints_element", locals: { value: value, label: label, options: options } %>
+    <%end %>
 
-    <%= render_date_constraint(params) if params["range"].present? %>
     <%= render_constraints(controller.params != params ? params : search_state) %>
     <%= render 'start_over', show_icon: true%>
   </div>

--- a/app/views/catalog/_constraints_element.html.erb
+++ b/app/views/catalog/_constraints_element.html.erb
@@ -7,7 +7,7 @@
     options ||= {}
 %>
 
-<span class="btn-group applied-filter constraint query <%= options[:classes].join(" ") if options[:classes] %>">
+<span class="btn-group applied-filter constraint query <%= options[:classes].join if options[:classes] %>">
   <button class="constraint-value btn btn-outline-secondary">
     <% unless label.blank? %>
       <span class="filter-name"><%= label %> </span>
@@ -18,7 +18,8 @@
       <!-- icon to remove-->
       <%= link_to(content_tag(:span, image_tag('x2x.png', alt: ""),
                               class: 'remove-icon') ,
-                  options[:remove], class: 'btn btn-outline-secondary remove',
+                  options[:remove],
+                  class: "btn btn-outline-secondary remove #{("remove-" +options[:classes].join) if options[:classes]} ",
                   'aria-label' => 'Remove'
           ) %>
        <% end %>

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -85,7 +85,6 @@ RSpec.describe BlacklightHelper, helper: true, style: true do
         let(:clean_url) { %r{catalog[?&]search_field=all_fields} }
 
         it 'filters out missing when x is clicked' do
-
           expect(helper.range_unknown_remove_url(missing_url)).to match clean_url
         end
       end
@@ -95,7 +94,6 @@ RSpec.describe BlacklightHelper, helper: true, style: true do
         let(:clean_url) { %r{catalog[?&]search_field=all_fields} }
 
         it 'filters out date range when x is clicked' do
-
           expect(helper.range_remove_url(date_facet_url)).to match clean_url
         end
       end
@@ -106,13 +104,13 @@ RSpec.describe BlacklightHelper, helper: true, style: true do
         let(:clean_url) { %r{catalog[?&]search_field=all_fields} }
 
         context 'with missing date facet applied' do
-          let(:params){
+          let(:params) do
             params = Hash.new { |h, k| h[k] = h.dup.clear }
             params["range"]["year_isim"]["missing"] = true
             params
-          }
+          end
           it 'assigns the correct values to options' do
-            value, label, options = helper.get_date_constraint_params(params,missing_url)
+            value, label, options = helper.get_date_constraint_params(params, missing_url)
             expect(value).to eq "Unknown"
             expect(label).to eq "Date"
             expect(options[:classes]).to match ["year_isim"]
@@ -120,21 +118,21 @@ RSpec.describe BlacklightHelper, helper: true, style: true do
           end
         end
         context 'with a date range face applied' do
-          let(:params) {
+          let(:params) do
             params = Hash.new { |h, k| h[k] = h.dup.clear }
             params["range"]["year_isim"]["missing"] = false
             params["range"] = Object.new
             params["range"].define_singleton_method(:values) do
-             @values||= [Hash.new { |h, k| h[k] = h.dup.clear }]
-             @values
+              @values ||= [Hash.new { |h, k| h[k] = h.dup.clear }]
+              @values
             end
             params["range"].values[0]["begin"] = 1500
             params["range"].values[0]["end"] = 2000
 
             params
-          }
+          end
           it 'assigns the correct values to options' do
-            value, label, options = helper.get_date_constraint_params(params,date_facet_url)
+            value, label, options = helper.get_date_constraint_params(params, date_facet_url)
             expect(value).to eq "1500 - 2000"
             expect(label).to eq "Date"
             expect(options[:classes]).to match ["year_isim"]

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -29,3 +29,16 @@ RSpec.configure do |config|
     driven_by :chrome_headless
   end
 end
+
+module CapybaraExtension
+  delegate :drag_by, to: :base
+end
+
+module CapybaraSeleniumExtension
+  def drag_by(right_by, down_by)
+    driver.browser.action.drag_and_drop_by(native, right_by, down_by).perform
+  end
+end
+
+::Capybara::Selenium::Node.send :include, CapybaraSeleniumExtension
+::Capybara::Node::Element.send :include, CapybaraExtension

--- a/spec/system/date_slider_spec.rb
+++ b/spec/system/date_slider_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 RSpec.describe "Blacklight Range Limit", type: :system, clean: true, js: true do
   before do
     solr = Blacklight.default_index.connection
-    solr.add([dog, cat, bird, rabbit, elephant])
+    solr.add([dog, cat, bird, rabbit, elephant, turtle])
     solr.commit
   end
 
@@ -25,7 +25,7 @@ RSpec.describe "Blacklight Range Limit", type: :system, clean: true, js: true do
     {
       id: '212',
       title_tesim: 'Handsome Dan is not a cat.',
-      year_isim: [1600],
+      year_isim: [1600, 1601, 1603],
       creator_tesim: 'Frederick & Eric',
       sourceTitle_tesim: "this is the source title",
       orbisBibId_ssi: '1234567',
@@ -37,7 +37,7 @@ RSpec.describe "Blacklight Range Limit", type: :system, clean: true, js: true do
     {
       id: '313',
       title_tesim: 'Handsome Dan is not a bird.',
-      year_isim: [1100],
+      year_isim: [1100, 1101, 1102],
       creator_tesim: 'Frederick & Eric',
       sourceTitle_tesim: "this is the source title",
       orbisBibId_ssi: '1234567',
@@ -50,7 +50,7 @@ RSpec.describe "Blacklight Range Limit", type: :system, clean: true, js: true do
       id: '400',
       identifierShelfMark_ssim: 'call number',
       title_tesim: 'Handsome Dan is not a rabbit.',
-      year_isim: [1555],
+      year_isim: [1555, 1556, 1557],
       creator_tesim: 'Frederick & Eric',
       sourceTitle_tesim: "this is the source title",
       orbisBibId_ssi: '1234567',
@@ -64,6 +64,18 @@ RSpec.describe "Blacklight Range Limit", type: :system, clean: true, js: true do
       identifierShelfMark_ssim: 'call number',
       title_tesim: 'Handsome Dan is not a elephant.',
       year_isim: [1555],
+      creator_tesim: 'Frederick & Eric',
+      sourceTitle_tesim: "this is the source title",
+      orbisBibId_ssi: '1234567',
+      visibility_ssi: 'Public'
+    }
+  end
+
+  let(:turtle) do
+    {
+      id: '402',
+      title_tesim: 'Handsome Dan is not a turtle.',
+      year_isim: (1555..1800).to_a,
       creator_tesim: 'Frederick & Eric',
       sourceTitle_tesim: "this is the source title",
       orbisBibId_ssi: '1234567',
@@ -118,6 +130,7 @@ RSpec.describe "Blacklight Range Limit", type: :system, clean: true, js: true do
       expect(page.text).to match(/Date 12\d\d - 16\d\d/)
     end
 
-    expect(page).to have_content '1 - 3'
+    # makes sure that it includes the turtle record with years: 1555-1800
+    expect(page).to have_content '1 - 4'
   end
 end

--- a/spec/system/date_slider_spec.rb
+++ b/spec/system/date_slider_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Blacklight Range Limit", type: :system, clean: true, js: true do
     {
       id: '111',
       title_tesim: 'Handsome Dan is a bull dog.',
-      dateStructured_ssim: '2022',
+      year_isim: [2022],
       creator_tesim: 'Eric & Frederick',
       subjectName_ssim: "this is the subject name",
       sourceTitle_tesim: "this is the source title",
@@ -25,7 +25,7 @@ RSpec.describe "Blacklight Range Limit", type: :system, clean: true, js: true do
     {
       id: '212',
       title_tesim: 'Handsome Dan is not a cat.',
-      dateStructured_ssim: '1600',
+      year_isim: [1600],
       creator_tesim: 'Frederick & Eric',
       sourceTitle_tesim: "this is the source title",
       orbisBibId_ssi: '1234567',
@@ -37,7 +37,7 @@ RSpec.describe "Blacklight Range Limit", type: :system, clean: true, js: true do
     {
       id: '313',
       title_tesim: 'Handsome Dan is not a bird.',
-      dateStructured_ssim: '1100',
+      year_isim: [1100],
       creator_tesim: 'Frederick & Eric',
       sourceTitle_tesim: "this is the source title",
       orbisBibId_ssi: '1234567',
@@ -50,7 +50,7 @@ RSpec.describe "Blacklight Range Limit", type: :system, clean: true, js: true do
       id: '400',
       identifierShelfMark_ssim: 'call number',
       title_tesim: 'Handsome Dan is not a rabbit.',
-      dateStructured_ssim: '1555',
+      year_isim: [1555],
       creator_tesim: 'Frederick & Eric',
       sourceTitle_tesim: "this is the source title",
       orbisBibId_ssi: '1234567',
@@ -63,7 +63,7 @@ RSpec.describe "Blacklight Range Limit", type: :system, clean: true, js: true do
       id: '401',
       identifierShelfMark_ssim: 'call number',
       title_tesim: 'Handsome Dan is not a elephant.',
-      dateStructured_ssim: '1555',
+      year_isim: [1555],
       creator_tesim: 'Frederick & Eric',
       sourceTitle_tesim: "this is the source title",
       orbisBibId_ssi: '1234567',
@@ -90,24 +90,32 @@ RSpec.describe "Blacklight Range Limit", type: :system, clean: true, js: true do
   end
 
   it "does not show the date slider if only one date" do
-    visit '/catalog?search_field=identifierShelfMark_tesim&q="call number"'
-    expect(page).not_to have_css('.card.facet-limit.blacklight-dateStructured_ssim')
+    visit '/catalog?search_field=identifierShelfMark_ssim&q="call number"'
+    expect(page).not_to have_css('.card.facet-limit.blacklight-year_isim')
   end
 
-  xit "should be able to search with the slider" do
+  it "is able to search with the slider", :style do
     visit search_catalog_path
     click_button 'Date Created'
-    within '.card.facet-limit.blacklight-dateStructured_ssim' do
-      source = page.find('.slider-handle.round').last
-      source.drag_by(30, 0)
+    within '#facet-year_isim' do
+      sliders = find_all('.slider-handle.round')
+
+      beg_slider = sliders.first
+      beg_slider.drag_by(30, 0)
+
+      end_slider = sliders.last
+      end_slider.drag_by(-105, 0)
+    end
+    within '#facet-year_isim' do
+      click_on "Apply"
     end
 
-    within '.blacklight-dateStructured_ssim' do
-      expect(page).to have_content "1100 to 1600"
+    within '.blacklight-year_isim' do
+      expect(page.text).to match(/12\d\d to 16\d\d/)
     end
 
     within '.constraints-container' do
-      expect(page).to have_content '1100 to 1600'
+      expect(page.text).to match(/Date 12\d\d - 16\d\d/)
     end
 
     expect(page).to have_content '1 - 3'

--- a/spec/system/facet_by_year_spec.rb
+++ b/spec/system/facet_by_year_spec.rb
@@ -4,12 +4,29 @@ require 'rails_helper'
 RSpec.feature "View Search Results", type: :system, clean: true, js: false do
   before do
     solr = Blacklight.default_index.connection
-    solr.add([test_record_0, test_record_1, test_record_2])
+    solr.add([test_record_0, test_record_1, test_record_2, test_record_3])
     solr.commit
     # visit '/catalog/211'
   end
 
   let(:test_record_0) do
+    {
+      id: '111',
+      subtitle_tesim: "He's Handsome",
+      creator_tesim: 'Eric & Frederick',
+      format: 'three dimensional object',
+      url_fulltext_ssim: 'http://0.0.0.0:3000/catalog/211',
+      url_suppl_ssim: 'http://0.0.0.0:3000/catalog/211',
+      published_ssim: "1997",
+      language_ssim: ['en', 'eng', 'zz'],
+      isbn_ssim: '2321321389',
+      description_tesim: "Handsome Dan is a bulldog who serves as Yale Univeristy's mascot.",
+      visibility_ssi: 'Public',
+      year_isim: (600..1050).to_a
+    }
+  end
+
+  let(:test_record_1) do
     {
       id: '211',
       subtitle_tesim: "He's Handsome",
@@ -26,7 +43,7 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
     }
   end
 
-  let(:test_record_1) do
+  let(:test_record_2) do
     {
       id: '311',
       subtitle_tesim: "He's Dan",
@@ -43,7 +60,7 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
     }
   end
 
-  let(:test_record_2) do
+  let(:test_record_3) do
     {
       id: '411',
       subtitle_tesim: "He's Handsome Dan",
@@ -65,6 +82,7 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
     click_on 'search'
 
     within '#documents' do
+      expect(page).to have_content("111")
       expect(page).to have_content("211")
       expect(page).to have_content("311")
       expect(page).to have_content("411")
@@ -76,6 +94,31 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
 
     within '#documents' do
       expect(page).to     have_content("211")
+
+      expect(page).not_to have_content("111")
+      expect(page).not_to have_content("311")
+      expect(page).not_to have_content('411')
+    end
+  end
+  it 'can get years with less than 4 digits' do
+    visit root_path
+    click_on 'search'
+
+    within '#documents' do
+      expect(page).to have_content("111")
+      expect(page).to have_content("211")
+      expect(page).to have_content("311")
+      expect(page).to have_content("411")
+    end
+
+    fill_in 'range_year_isim_begin', with: '610'
+    fill_in 'range_year_isim_end', with: '950'
+    click_on 'Apply'
+
+    within '#documents' do
+      expect(page).to have_content("111")
+
+      expect(page).not_to have_content("211")
       expect(page).not_to have_content("311")
       expect(page).not_to have_content('411')
     end

--- a/spec/system/facet_by_year_spec.rb
+++ b/spec/system/facet_by_year_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       isbn_ssim: '2321321389',
       description_tesim: "Handsome Dan is a bulldog who serves as Yale Univeristy's mascot.",
       visibility_ssi: 'Public',
-      year_isim: [1920]
+      year_isim: (1920..2000).to_a
     }
   end
 

--- a/spec/system/facet_by_year_spec.rb
+++ b/spec/system/facet_by_year_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       isbn_ssim: '2321321389',
       description_tesim: "Handsome Dan is a bulldog who serves as Yale Univeristy's mascot.",
       visibility_ssi: 'Public',
-      dateStructured_ssim: "1920"
+      year_isim: [1920]
     }
   end
 
@@ -39,7 +39,7 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       isbn_ssim: '2321321389',
       description_tesim: "Handsome Dan is a bulldog who serves as Yale Univeristy's mascot.",
       visibility_ssi: 'Public',
-      dateStructured_ssim: "1900"
+      year_isim: [1900]
     }
   end
 
@@ -56,12 +56,12 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       isbn_ssim: '2321321389',
       description_tesim: "Handsome Dan is a bulldog who serves as Yale Univeristy's mascot.",
       visibility_ssi: 'Public',
-      dateStructured_ssim: "2020"
+      year_isim: [2020, 2021]
     }
   end
 
   it 'gets correct search results using year ranges' do
-    visit search_catalog_path
+    visit root_path
     click_on 'search'
 
     within '#documents' do
@@ -70,8 +70,8 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       expect(page).to have_content("411")
     end
 
-    fill_in 'range_dateStructured_ssim_begin', with: '1910'
-    fill_in 'range_dateStructured_ssim_end', with: '1950'
+    fill_in 'range_year_isim_begin', with: '1910'
+    fill_in 'range_year_isim_end', with: '1950'
     click_on 'Apply'
 
     within '#documents' do


### PR DESCRIPTION
**STORY**
We initially implemented the date slider on a field that did meet Blacklight Range Limit's data requirements (see https://github.com/projectblacklight/blacklight_range_limit#requirements).  We now have a year field that contains integer data and need to update the date facet.

**ACCEPTANCE**
- [ ] I can limit my search results by their year - i.e. `year_isim`
