### PR TITLE
Link to IIIF Manifest without .json extension

### DIFF
--- a/app/views/catalog/_show_tools.html.erb
+++ b/app/views/catalog/_show_tools.html.erb
@@ -14,7 +14,7 @@
             <% oid = @document.id %>
             <li class="list-group-item manifestItem">
                 <span class='nav-link'>
-                  <%= link_to(image_tag('iiif.png', alt: '') + t('blacklight.sidebar.manifest'), manifest_url(oid, format: 'json'), target: '_blank', id: 'manifestLink', class: 'iiif-logo')
+                  <%= link_to(image_tag('iiif.png', alt: '') + t('blacklight.sidebar.manifest'), manifest_url(oid), target: '_blank', id: 'manifestLink', class: 'iiif-logo')
                   %>
                 </span>
             </li>

--- a/spec/views/catalog/_show_tools.html.erb_spec.rb
+++ b/spec/views/catalog/_show_tools.html.erb_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'catalog/_show_tools.html.erb' do
   describe 'links' do
     it 'renders the iiif manifest link' do
       render partial: 'catalog/show_tools'
-      expect(rendered).to have_link 'Manifest Link', href: "http://test.host/manifests/xyz.json"
+      expect(rendered).to have_link 'Manifest Link', href: "http://test.host/manifests/xyz"
     end
 
     it 'renders the mirador link' do


### PR DESCRIPTION
The URL of the IIIF Manifest should not have a `.json` extension, to match the value in the `@id` field in the Manifest file itself.