### PR TITLE
Use helper method to better determine if in Gallery view

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -7,6 +7,8 @@ class CatalogController < ApplicationController
 
   before_action :determine_per_page
 
+  helper_method :gallery_view?
+
   configure_blacklight do |config|
     # default advanced config values
     config.advanced_search ||= Blacklight::OpenStructWithHashAccess.new
@@ -456,8 +458,12 @@ class CatalogController < ApplicationController
     # config.autocomplete_suggester = 'mySuggester'
   end
 
+  def gallery_view?
+    params[:view] == 'gallery' || (params[:view].nil? && session['preferred_view'].eql?("gallery"))
+  end
+
   def determine_per_page
-    grouping = params[:view] == 'gallery' ? [9, 30, 60, 99] : [10, 20, 50, 100]
+    grouping = gallery_view? ? [9, 30, 60, 99] : [10, 20, 50, 100]
     blacklight_config[:per_page] = grouping
   end
 end

--- a/app/views/catalog/_index_header.html.erb
+++ b/app/views/catalog/_index_header.html.erb
@@ -28,21 +28,13 @@
   view = parsed_url.query_values['view']
 -%>
 
-<%if view == 'gallery' %>
-  <div class='documentHeader row'>
-    <h3 class='index_title document-title-heading <%= title_class %>'>
-      <div class='document-title'>
-        <%= link_to_document document, document.highlight_field('title_tesim').try(:[],0) || document['title_tesim'] %>
-      </div>
-    </h3>
-  </div>
-<%else %>
-  <div class='documentHeader row'>
-    <h3 class='index_title document-title-heading <%= title_class %>'>
-     <span class='counter_no_show' ><%= counter %> </span>
-      <div class='document-title'>
-        <%= link_to_document document, document.highlight_field('title_tesim').try(:[],0) || document['title_tesim'], counter:document_counter %>
-      </div>
-    </h3>
-  </div>
-<%end%>
+<div class='documentHeader row'>
+  <h3 class='index_title document-title-heading <%= title_class %>'>
+    <% if !gallery_view? %>
+      <span class='counter_no_show' ><%= counter %> </span>
+    <% end %>
+    <div class='document-title'>
+      <%= link_to_document document, document.highlight_field('title_tesim').try(:[],0) || document['title_tesim'], counter:document_counter %>
+    </div>
+  </h3>
+</div>

--- a/spec/system/search_result_spec.rb
+++ b/spec/system/search_result_spec.rb
@@ -69,4 +69,56 @@ RSpec.describe 'search result', type: :system, clean: true do
       expect(page).not_to have_selector '#documents > .document.col:first-child span'
     end
   end
+
+  context 'in gallery view by session' do
+    before do
+      visit '/catalog?q=&search_field=all_fields&view=gallery'
+      visit '/catalog?q=&search_field=all_fields'
+    end
+
+    it 'has expected css' do
+      expect(page).to have_css '.caption'
+    end
+
+    it 'has the correct "per page" options' do
+      expect(page).to have_text '9 per page 30 per page 60 per page 99 per page'
+    end
+
+    it 'does not show the index number' do
+      expect(page).not_to have_selector '#documents > .document.col:first-child span'
+    end
+  end
+
+  context 'in list view after gallery view set in session' do
+    before do
+      visit '/catalog?q=&search_field=all_fields&view=gallery'
+      visit '/catalog?search_field=all_fields&view=list'
+    end
+    it 'has expected css', js: true, style: true do
+      within '.documents-list' do
+        expect(page).to have_css '.dl-invert'
+        expect(page).to have_css '.document-metadata'
+        expect(page).to have_css '.document-title'
+        expect(page).to have_css '.document-title-heading'
+        expect(page).to have_css '.documentHeader'
+        expect(page).to have_css '.row'
+        expect(page).to have_css '.document'
+        expect(page).to have_css '.document-metadata.dl-invert.row'
+        expect(page).to have_css '#documents > article.document > dl > dt'
+        expect(page).to have_css '.document-metadata.dl-invert > dt'
+        expect(page).to have_css '.document-metadata.dl-invert > dd'
+        expect(page).to have_css '.document-metadata'
+        expect(page).to have_css '.document-thumbnail'
+        expect(page).to have_css '.col-md-9'
+      end
+    end
+
+    it 'has the correct "per page" options' do
+      expect(page).to have_text '10 per page 20 per page 50 per page 100 per page'
+    end
+
+    it 'shows the index number' do
+      expect(page).to have_selector '#documents > .document-position-0 span', visible: true
+    end
+  end
 end


### PR DESCRIPTION
This adds a gallery_view? method to catalog and exposes it as a helper method.
gallery_view? checks parameters and session to determine if page is in gallery mode.

This fixes issues with numbers showing up on results page when gallery is displayed because of the session rather than because of the parameter.
It uses the same method to determine the number of items per page options.