### PR TITLE
Change hero image on page refresh

### DIFF
--- a/app/assets/stylesheets/customOverrides/landing.scss
+++ b/app/assets/stylesheets/customOverrides/landing.scss
@@ -20,7 +20,7 @@ DEFAULT MOBILE STYLING
     }
   }
 
-  .hero-image {
+  #hero-image {
     height: 100%;
     object-fit: cover;
     position: absolute;
@@ -178,7 +178,7 @@ DEFAULT MOBILE STYLING
       height: 300px;
     }
 
-    .hero-image {
+    #hero-image {
       object-position: 0 -45px;
     }
   }
@@ -197,7 +197,7 @@ DEFAULT MOBILE STYLING
       height: 325px;
     }
 
-    .hero-image {
+    #hero-image {
       object-position: 0 -65px;
     }
   }
@@ -222,7 +222,7 @@ DEFAULT MOBILE STYLING
       height: 354px;
     }
 
-    .hero-image {
+    #hero-image {
       object-position: 0 -85px;
     }
   }
@@ -264,7 +264,7 @@ DEFAULT MOBILE STYLING
       height: 472px;
     }
 
-    .hero-image {
+    #hero-image {
       object-position: 0 -105px;
     }
   }

--- a/app/views/application/landing.html.erb
+++ b/app/views/application/landing.html.erb
@@ -38,10 +38,10 @@
         </div>
 <%
 =end%>
-      <%= image_tag("landing/hero-images/camp-spingarn.jpg", class: "d-block w-100 hero-image", alt: 'Conference attendees at "Camp Spingarn," Amenia, N.Y., August 24-26, 1916') %>
+      <%= image_tag("", class: "d-block w-100", id: "hero-image", alt: "") %>
       <div class="image-overlay"></div>
       <div class="hero-caption d-md-block">
-        <p>Conference at "Camp Spingarn," Amenia, N.Y.” </p>
+        <p id="hero-image-caption"></p>
       </div>
       <%
 =begin%>
@@ -123,5 +123,22 @@
   </body>
 <% end %>
 
+<script>
+  $(document).ready(function() {
 
+    const images = [
+      {
+        alt: 'Conference attendees at "Camp Spingarn," Amenia, N.Y., August 24-26, 1916',
+        caption: 'Conference at "Camp Spingarn," Amenia, N.Y.',
+        src: '../../assets/landing/hero-images/camp-spingarn.jpg',
+      },
+    ]
 
+    const alt = images[0].alt;
+    const caption = images[0].caption;
+    const src = images[0].src;
+
+    $('#hero-image').attr({ 'src': src, 'alt': alt });
+    $('#hero-image-caption').text(caption);
+  })
+</script>

--- a/app/views/application/landing.html.erb
+++ b/app/views/application/landing.html.erb
@@ -28,31 +28,11 @@
 
   <div id='hero'>
     <div class="intro">
-      <%
-=begin%>
-<div class="carousel-item active">
-          <%= image_tag("landing/hero-gutenberg.png", class: "d-block w-100", alt: " Prologue the Gutenberg Bible") %>
-          <div class="carousel-caption d-none d-md-block">
-            <p>From Gutenberg Bible, 1454</p>
-          </div>
-        </div>
-<%
-=end%>
       <%= image_tag("", class: "d-block w-100", id: "hero-image", alt: "") %>
       <div class="image-overlay"></div>
       <div class="hero-caption d-md-block">
         <p id="hero-image-caption"></p>
       </div>
-      <%
-=begin%>
- <div class="carousel-item">
-          <%= image_tag("landing/hero-chart.png", class: "d-block w-100", alt: 'Portolan Chart of the Mediterranean Sea') %>
-          <div class="carousel-caption d-none d-md-block">
-            <p>Portolan Chart of the Mediterranean Sea</p>
-          </div>
-        </div>
-<%
-=end%>
     </div>
 
     <div id='hero-search' class="container d-flex h-100">
@@ -125,18 +105,35 @@
 
 <script>
   $(document).ready(function() {
-
     const images = [
       {
         alt: 'Conference attendees at "Camp Spingarn," Amenia, N.Y., August 24-26, 1916',
         caption: 'Conference at "Camp Spingarn," Amenia, N.Y.',
         src: '../../assets/landing/hero-images/camp-spingarn.jpg',
       },
+      {
+        alt: 'Prologue the Gutenberg Bible',
+        caption: 'From Gutenberg Bible, 1454',
+        src: '../../assets/landing/hero-images/gutenberg-bible.jpg',
+      },
+      {
+        alt: 'Portolan Chart of the Mediterranean Sea',
+        caption: 'Portolan Chart of the Mediterranean Sea',
+        src: '../../assets/landing/hero-images/portolan-chart.jpg',
+      },
     ]
 
-    const alt = images[0].alt;
-    const caption = images[0].caption;
-    const src = images[0].src;
+    const lastIndex = window.localStorage.getItem('lastIndex') || 0
+
+    let index = Math.floor(Math.random() * images.length)
+    while (index == lastIndex) {
+      index = Math.floor(Math.random() * images.length)
+    }
+    window.localStorage.setItem('lastIndex', JSON.stringify(index))
+
+    const alt = images[index].alt;
+    const caption = images[index].caption;
+    const src = images[index].src;
 
     $('#hero-image').attr({ 'src': src, 'alt': alt });
     $('#hero-image-caption').text(caption);


### PR DESCRIPTION
# Ticket
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/913

# Summary
- the hero image changes on page refresh
- while you won't get the same image back to back, you may get image 1, then image 2 and then image 1 again
- making sure that the new image is not the same as the last one may on occasion take a few seconds as the computation runs again

# Demo
https://share.getcloudapp.com/6quxYl2J