### PR TITLE
Update yale only check

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,3 +26,4 @@ RSpec/RepeatedExample:
 RSpec/AnyInstance:
   Exclude:
     - spec/system/access_restrictions_spec.rb
+    - spec/system/view_images_in_search_spec.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,3 +22,7 @@ RSpec/InstanceVariable:
 RSpec/RepeatedExample:
   Exclude:
     - spec/system/access_restrictions_spec.rb
+
+RSpec/AnyInstance:
+  Exclude:
+    - spec/system/access_restrictions_spec.rb

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -106,7 +106,7 @@ module BlacklightHelper
 
   def render_thumbnail(document, _options)
     # return placeholder image if not logged in for yale only works
-    return image_tag('placeholder_restricted.png') if (document[:visibility_ssi].eql? 'Yale Community Only') && !user_signed_in?
+    return image_tag('placeholder_restricted.png') unless client_can_access(document)
     url = document[:thumbnail_path_ss]
     if ['Public', 'Yale Community Only'].include?(document[:visibility_ssi]) && url.present?
       error_image_url = image_url('image_not_found.png')

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -21,4 +21,15 @@ module CatalogHelper
 
     constraints.join(' / ')
   end
+
+  def client_can_access(document)
+    return false unless document.key?('visibility_ssi')
+    case document['visibility_ssi']
+    when 'Public'
+      true
+    when 'Yale Community Only'
+      return true if current_user || User.on_campus?(request.remote_ip)
+      false
+    end
+  end
 end

--- a/app/views/catalog/_show_main_content.html.erb
+++ b/app/views/catalog/_show_main_content.html.erb
@@ -7,7 +7,7 @@
 <div id="document" class="document <%= render_document_class %>" itemscope  itemtype="<%= @document.itemtype %>">
   <div id="doc_<%= @document.id.to_s.parameterize %>">
     <!-- Only render universal viewer if the work is public OR if the user is authenticated -->
-    <% if @document["visibility_ssi"] == "Public" || user_signed_in? %>
+    <% if client_can_access(@document) %>
       <%= render_document_partials @document, [:show_header, :uv] %>
       <%= render "grouped_metadata" %>
     <% else %>

--- a/ops/webapp.conf
+++ b/ops/webapp.conf
@@ -50,6 +50,7 @@ server {
         proxy_pass http://127.0.0.1:3000/check-iiif;	# authentication server
         proxy_pass_request_body off;				# no data is being transferred...
         proxy_set_header Content-Length '0';
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $host;				# Custom headers with authentication related data
         proxy_set_header X-Origin-URI $request_uri;
         proxy_set_header X-Forwarded-Host $host;

--- a/spec/system/access_restrictions_spec.rb
+++ b/spec/system/access_restrictions_spec.rb
@@ -24,6 +24,17 @@ RSpec.describe "access restrictions", type: :system, clean: true do
   end
 
   context "an unauthenticated user" do
+    around do |example|
+      original_yale_networks = ENV['YALE_NETWORK_IPS']
+      ENV['YALE_NETWORK_IPS'] = "101.10.5.4,3.4.2.3"
+      example.run
+      ENV['YALE_NETWORK_IPS'] = original_yale_networks
+    end
+
+    before do
+      allow_any_instance_of(ActionDispatch::Request).to receive(:remote_ip).and_return('109.10.5.4')
+    end
+
     it 'displays public and yale-only but NOT private works in search results' do
       visit '/catalog?search_field=all_fields&q='
 

--- a/spec/system/access_restrictions_spec.rb
+++ b/spec/system/access_restrictions_spec.rb
@@ -62,7 +62,37 @@ RSpec.describe "access restrictions", type: :system, clean: true do
     end
 
     it "displays universal viewer for yale-only works" do
+      visit solr_document_path(yale_work[:id])
+      expect(page.html).to match(/universal-viewer-iframe/)
+    end
+  end
+
+  context "an user on the network" do
+    around do |example|
+      original_yale_networks = ENV['YALE_NETWORK_IPS']
+      ENV['YALE_NETWORK_IPS'] = "101.10.5.4,3.4.2.3"
+      example.run
+      ENV['YALE_NETWORK_IPS'] = original_yale_networks
+    end
+
+    before do
+      allow_any_instance_of(ActionDispatch::Request).to receive(:remote_ip).and_return('101.10.5.4')
+    end
+
+    it 'displays public and yale-only but NOT private works in search results' do
+      visit '/catalog?search_field=all_fields&q='
+      expect(page).to have_content('A General dictionary of the English language')
+      expect(page).to have_content('[Map of China]. [yale-only copy]')
+      expect(page).not_to have_content('[Map of China]. [private copy]')
+    end
+
+    it "displays universal viewer for public works" do
       visit solr_document_path(public_work[:id])
+      expect(page.html).to match(/universal-viewer-iframe/)
+    end
+
+    it "displays universal viewer for yale-only works" do
+      visit solr_document_path(yale_work[:id])
       expect(page.html).to match(/universal-viewer-iframe/)
     end
   end

--- a/spec/system/view_images_in_search_spec.rb
+++ b/spec/system/view_images_in_search_spec.rb
@@ -66,6 +66,17 @@ RSpec.describe 'Search results displays images', type: :system, clean: true, js:
 
   describe 'Yale community only records', style: true do
     context 'as a logged out user' do
+      around do |example|
+        original_yale_networks = ENV['YALE_NETWORK_IPS']
+        ENV['YALE_NETWORK_IPS'] = "101.10.5.4,3.4.2.3"
+        example.run
+        ENV['YALE_NETWORK_IPS'] = original_yale_networks
+      end
+
+      before do
+        allow_any_instance_of(ActionDispatch::Request).to receive(:remote_ip).and_return('109.10.5.4')
+      end
+
       it 'displays the placeholder_restricted.png' do
         visit '/catalog?q=&search_field=all_fields'
         expect(page).to have_css("img[src ^= '/assets/placeholder_restricted']")


### PR DESCRIPTION
This updates a few places where the IPs were not being checked to determine if a user had access to Yale Only metadata/images.
It also adds the X-Forwarded-For header to the proxy check that goes to blacklight so the IP is passed.