### PR TITLE
Update dropdown header caret cursor

### DIFF
--- a/app/assets/stylesheets/customOverrides/header.scss
+++ b/app/assets/stylesheets/customOverrides/header.scss
@@ -50,6 +50,7 @@ DEFAULT MOBILE STYLING
 
 .nav-link-title {
   margin-bottom: 0px;
+  cursor: pointer;
 }
 
 .navbar-brand {


### PR DESCRIPTION
The main menu in the blacklight app has a drop-down caret.  It has a text cursor.  Since it's a link, it should have a pointer cursor.

The requirements to update:
- [x] text cursor,  and caret, [completed in milestone 2020-50]
- [x] additional requirement of the space in between the text and the now arrow. 

![Screen Recording 2020-12-16 at 09 35 33 AM](https://user-images.githubusercontent.com/41123693/102363094-17f30400-3f83-11eb-94f3-97d85e3de292.gif)
