### PR TITLE
Update font face formatting

### DIFF
--- a/app/assets/stylesheets/theme/typography.scss
+++ b/app/assets/stylesheets/theme/typography.scss
@@ -12,9 +12,9 @@ FONT FILE TYPES
 @font-face {
   font-family: 'YaleDesign-SmallCaps';
   src: url(https://static.library.yale.edu/fonts/yalenew/YaleDesign-smacap/yaledessmacap-webfont.eot);
-  src: url(https://static.library.yale.edu/fonts/yalenew/YaleDesign-smacap/yaledessmacap-webfont.eot?#iefix) format(embedded-opentype),
-       url(https://static.library.yale.edu/fonts/yalenew/YaleDesign-smacap/yaledessmacap-webfont.ttf) format(truetype),
-       url(https://static.library.yale.edu/fonts/yalenew/YaleDesign-smacap/yaledessmacap-webfont.woff) format(woff);
+  src: url(https://static.library.yale.edu/fonts/yalenew/YaleDesign-smacap/yaledessmacap-webfont.eot?#iefix) format('embedded-opentype'),
+       url(https://static.library.yale.edu/fonts/yalenew/YaleDesign-smacap/yaledessmacap-webfont.ttf) format('truetype'),
+       url(https://static.library.yale.edu/fonts/yalenew/YaleDesign-smacap/yaledessmacap-webfont.woff) format('woff');
   font-weight: normal;
   font-style: normal;
 }
@@ -24,10 +24,10 @@ FONT FILE TYPES
 @font-face {
   font-family: 'YaleDisplay-Roman';
   src: url(https://static.library.yale.edu/fonts/yaledisplay/YaleDisplay-Roman.eot);
-  src: url(https://static.library.yale.edu/fonts/yaledisplay/YaleDisplay-Roman.eot?#iefix) format(embedded-opentype),
-       url(https://static.library.yale.edu/fonts/yaledisplay/YaleDisplay-Roman.ttf) format(truetype),
-       url(https://static.library.yale.edu/fonts/yaledisplay/YaleDisplay-Roman.woff) format(woff),
-       url(https://static.library.yale.edu/fonts/yaledisplay/YaleDisplay-Roman.svg#yaledisplay) format(svg);
+  src: url(https://static.library.yale.edu/fonts/yaledisplay/YaleDisplay-Roman.eot?#iefix) format('embedded-opentype'),
+       url(https://static.library.yale.edu/fonts/yaledisplay/YaleDisplay-Roman.ttf) format('truetype'),
+       url(https://static.library.yale.edu/fonts/yaledisplay/YaleDisplay-Roman.woff) format('woff'),
+       url(https://static.library.yale.edu/fonts/yaledisplay/YaleDisplay-Roman.svg#yaledisplay) format('svg');
   font-weight: normal;
   font-style: normal;
 }
@@ -37,10 +37,10 @@ FONT FILE TYPES
 @font-face {
   font-family: 'YaleMarks';
   src: url(https://static.library.yale.edu/fonts/yalenew/YaleNew-marks/yalemarks-webfont.eot);
-  src: url(https://static.library.yale.edu/fonts/yalenew/YaleNew-marks/yalemarks-webfont.eot?#iefix) format(embedded-opentype),
-       url(https://static.library.yale.edu/fonts/yalenew/YaleNew-marks/yalemarks-webfont.ttf) format(truetype),
-       url(https://static.library.yale.edu/fonts/yalenew/YaleNew-marks/yalemarks-webfont.woff) format(woff),
-       url(https://static.library.yale.edu/fonts/yalenew/YaleNew-marks/yalemarks-webfont.svg#yalenewmarks) format(svg);
+  src: url(https://static.library.yale.edu/fonts/yalenew/YaleNew-marks/yalemarks-webfont.eot?#iefix) format('embedded-opentype'),
+       url(https://static.library.yale.edu/fonts/yalenew/YaleNew-marks/yalemarks-webfont.ttf) format('truetype'),
+       url(https://static.library.yale.edu/fonts/yalenew/YaleNew-marks/yalemarks-webfont.woff) format('woff'),
+       url(https://static.library.yale.edu/fonts/yalenew/YaleNew-marks/yalemarks-webfont.svg#yalenewmarks) format('svg');
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
# Ticket
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/948

# Expected Behavior
- all Yale fonts should also display in Firefox and Chrome
- the console in Firefox and Chrome shows a CORS error for the `.ttf` font, but it displays correctly in the browser
- `.ttf` is used in Safari. I've confirmed that Safari's console doesn't show font related errors and the correct fonts display on the website

# Demo
| | firefox dev edition (check underlined font) | chrome | safari |
| --- | --- | --- | --- |
| before | ![Screen Shot 2020-12-17 at 11 13 52 AM](https://user-images.githubusercontent.com/29032869/102543999-fcfabf80-4068-11eb-9ba3-182f266e07be.png)| <img width="946" alt="Screen Shot 2020-12-17 at 1 15 51 PM" src="https://user-images.githubusercontent.com/29032869/102544749-1ea87680-406a-11eb-804a-a5f0fd0fb5d7.png"> |![Screen Shot 2020-12-17 at 1 12 47 PM](https://user-images.githubusercontent.com/29032869/102544691-09cbe300-406a-11eb-8fcb-243bd656f218.png)| 
| after | ![Screen Shot 2020-12-17 at 11 14 30 AM](https://user-images.githubusercontent.com/29032869/102544012-03893700-4069-11eb-937d-1fc598302dd4.png) | ![Screen Shot 2020-12-17 at 1 12 47 PM](https://user-images.githubusercontent.com/29032869/102545126-ac846180-406a-11eb-8c26-2759356dd834.png)| ![Screen Shot 2020-12-17 at 1 12 47 PM](https://user-images.githubusercontent.com/29032869/102545253-dccc0000-406a-11eb-8bbf-c1f11ca8a3de.png) |

# Resources
- https://support.mozilla.org/nl/questions/913498
- https://stackoverflow.com/a/6542939