### PR TITLE
943 refactor visibility checks hide private metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,3 +212,9 @@ If styling is needed for a test to pass, tag the test with `style:true`
 ## Test coverage
 
 We use [coveralls](https://coveralls.io/github/yalelibrary/yul-dc-blacklight) to measure test coverage. More details [here](https://github.com/yalelibrary/yul-dc-blacklight/wiki/code-coverage).
+
+## Testing IP Access Restrictions
+
+By default, when running locally, your IP will not be considered "On Campus," so you will not be able to view Yale Community Only items unless you log in.
+
+To test having an IP which is considered "On Campus" so that you can view Yale Community Only items without logging in, start with `YALE_NETWORK_IPS=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,127.0.0.1 cam up`.

--- a/app/assets/stylesheets/customOverrides/show_page.scss
+++ b/app/assets/stylesheets/customOverrides/show_page.scss
@@ -175,6 +175,10 @@ DEFAULT MOBILE STYLING
   font-weight: 300;
 }
 
+h2.yale-restricted-work-text {
+  font-size: 1.5em;
+} 
+
 @media screen and (min-width: $medium_device) {
   .constraints-container {
     margin-left: -.5%;

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -4,10 +4,12 @@ class CatalogController < ApplicationController
   include Blacklight::Catalog
   include Blacklight::Marc::Catalog
   include BlacklightRangeLimit::ControllerOverride
+  include AccessHelper
 
   before_action :determine_per_page
 
   helper_method :gallery_view?
+  helper_method :restriction_message
 
   configure_blacklight do |config|
     # default advanced config values
@@ -471,5 +473,10 @@ class CatalogController < ApplicationController
   def determine_per_page
     grouping = gallery_view? ? [9, 30, 60, 99] : [10, 20, 50, 100]
     blacklight_config[:per_page] = grouping
+  end
+
+  def show
+    super
+    render "catalog/show_unauthorized" unless client_can_view_metadata(@document)
   end
 end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -9,7 +9,6 @@ class CatalogController < ApplicationController
   before_action :determine_per_page
 
   helper_method :gallery_view?
-  helper_method :restriction_message
 
   configure_blacklight do |config|
     # default advanced config values
@@ -477,6 +476,6 @@ class CatalogController < ApplicationController
 
   def show
     super
-    render "catalog/show_unauthorized" unless client_can_view_metadata(@document)
+    render "catalog/show_unauthorized", status: :unauthorized unless client_can_view_metadata?(@document)
   end
 end

--- a/app/controllers/concerns/check_authorization.rb
+++ b/app/controllers/concerns/check_authorization.rb
@@ -2,6 +2,8 @@
 
 module CheckAuthorization
   extend ActiveSupport::Concern
+  include AccessHelper
+
   included do
     before_action :check_authorization
   end
@@ -12,16 +14,7 @@ module CheckAuthorization
       render json: { error: 'not-found' }.to_json, status: 404
       return false
     end
-
-    # Handle when the 'visibility_ssi' key doesn't exist on the manifest
-    if @document.key?('visibility_ssi')
-      case @document['visibility_ssi']
-      when 'Public'
-        return true
-      when 'Yale Community Only'
-        return true if current_user || User.on_campus?(request.remote_ip)
-      end
-    end
+    return true if client_can_access(@document)
     render json: { error: 'unauthorized' }.to_json, status: 401
     false
   end

--- a/app/controllers/concerns/check_authorization.rb
+++ b/app/controllers/concerns/check_authorization.rb
@@ -14,7 +14,7 @@ module CheckAuthorization
       render json: { error: 'not-found' }.to_json, status: 404
       return false
     end
-    return true if client_can_access(@document)
+    return true if client_can_view_digital?(@document)
     render json: { error: 'unauthorized' }.to_json, status: 401
     false
   end

--- a/app/controllers/iiif_controller.rb
+++ b/app/controllers/iiif_controller.rb
@@ -18,7 +18,7 @@ class IiifController < ApplicationController
     search_state[:rows] = 1
     search_service_class.new(config: blacklight_config, search_state: search_state, user_params: search_state.to_h, **search_service_context)
     r, d = search_service.search_results do |builder|
-      builder.processor_chain.delete(:show_only_public_records)
+      builder.processor_chain.delete(:filter_by_visibility)
       builder
     end
     [r, d.first]

--- a/app/helpers/access_helper.rb
+++ b/app/helpers/access_helper.rb
@@ -4,7 +4,7 @@ module AccessHelper
     ["Public", "Yale Community Only"]
   end
 
-  def client_can_access(document)
+  def client_can_view_digital?(document)
     case document['visibility_ssi']
     when 'Public'
       return true
@@ -14,11 +14,19 @@ module AccessHelper
     false
   end
 
-  def client_can_view_metadata(document)
+  def client_can_view_metadata?(document)
     viewable_metadata_visibilities.include? document['visibility_ssi']
   end
 
   def restriction_message(document)
+    case document['visibility_ssi']
+    when 'Yale Community Only'
+      return "The digital version of this work is restricted to the Yale Community."
+    end
+    "The digital version is restricted."
+  end
+
+  def restriction_instructions(document)
     case document['visibility_ssi']
     when 'Yale Community Only'
       return "Please login using your Yale NetID or contact library staff to inquire about access to a physical copy."

--- a/app/helpers/access_helper.rb
+++ b/app/helpers/access_helper.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+module AccessHelper
+  def self.viewable_metadata_visibilities
+    ["Public", "Yale Community Only"]
+  end
+
+  def client_can_access(document)
+    case document['visibility_ssi']
+    when 'Public'
+      return true
+    when 'Yale Community Only'
+      return true if current_user || User.on_campus?(request.remote_ip)
+    end
+    false
+  end
+
+  def client_can_view_metadata(document)
+    AccessHelper.viewable_metadata_visibilities.include? document['visibility_ssi']
+  end
+
+  def restriction_message(document)
+    case document['visibility_ssi']
+    when 'Yale Community Only'
+      return "Please login using your Yale NetID or contact library staff to inquire about access to a physical copy."
+    end
+    "You are not authorized to view this item."
+  end
+end

--- a/app/helpers/access_helper.rb
+++ b/app/helpers/access_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module AccessHelper
-  def self.viewable_metadata_visibilities
+  def viewable_metadata_visibilities
     ["Public", "Yale Community Only"]
   end
 
@@ -15,7 +15,7 @@ module AccessHelper
   end
 
   def client_can_view_metadata(document)
-    AccessHelper.viewable_metadata_visibilities.include? document['visibility_ssi']
+    viewable_metadata_visibilities.include? document['visibility_ssi']
   end
 
   def restriction_message(document)

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -108,7 +108,7 @@ module BlacklightHelper
     # return placeholder image if not logged in for yale only works
     return image_tag('placeholder_restricted.png') unless client_can_access(document)
     url = document[:thumbnail_path_ss]
-    if ['Public', 'Yale Community Only'].include?(document[:visibility_ssi]) && url.present?
+    if url.present?
       error_image_url = image_url('image_not_found.png')
       return image_tag(url, onerror: "this.error=null;this.src='#{error_image_url}'")
     end

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -106,7 +106,7 @@ module BlacklightHelper
 
   def render_thumbnail(document, _options)
     # return placeholder image if not logged in for yale only works
-    return image_tag('placeholder_restricted.png') unless client_can_access(document)
+    return image_tag('placeholder_restricted.png') unless client_can_view_digital?(document)
     url = document[:thumbnail_path_ss]
     if url.present?
       error_image_url = image_url('image_not_found.png')

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -21,15 +21,4 @@ module CatalogHelper
 
     constraints.join(' / ')
   end
-
-  def client_can_access(document)
-    return false unless document.key?('visibility_ssi')
-    case document['visibility_ssi']
-    when 'Public'
-      return true
-    when 'Yale Community Only'
-      return true if current_user || User.on_campus?(request.remote_ip)
-    end
-    false
-  end
 end

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -20,16 +20,17 @@ class SearchBuilder < Blacklight::SearchBuilder
   self.default_processor_chain += [:add_advanced_parse_q_to_solr, :add_advanced_search_to_solr]
   # include BlacklightRangeLimit::RangeLimitBuilder
 
-  # Add the `show_only_public_records` method to the processor chain
-  self.default_processor_chain += [:show_only_public_records]
+  # Add the `filter_by_visibility` method to the processor chain
+  self.default_processor_chain += [:filter_by_visibility]
   self.default_processor_chain += [:highlight_fields]
 
   ##
   # Use the solr fq (filter query) parameter to limit search results to only those items
-  # explicitly marked Public or Yale Community Only. This should ensure that only
-  # records explicitly cleared for display are ever shown.
+  # which have a visibility_ssi in the set which allow all users to view the metadata.
+  # Currently, the ability to view metadata is not affected by the User or IP address.
+  # (@see AccessHelper#viewable_metadata_visibilities)
   # @param [Hash] solr_parameters a hash of parameters to be sent to Solr (via RSolr)
-  def show_only_public_records(solr_parameters)
+  def filter_by_visibility(solr_parameters)
     # add a new solr facet query ('fq') parameter that limits results to those with a 'public_b' field of 1
     solr_parameters[:fq] ||= []
     fq = viewable_metadata_visibilities.map { |visibility| "(visibility_ssi:\"#{visibility}\")" }.join(" OR ")

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -31,7 +31,8 @@ class SearchBuilder < Blacklight::SearchBuilder
   def show_only_public_records(solr_parameters)
     # add a new solr facet query ('fq') parameter that limits results to those with a 'public_b' field of 1
     solr_parameters[:fq] ||= []
-    solr_parameters[:fq] << '((visibility_ssi:Public) OR (visibility_ssi:"Yale Community Only"))'
+    fq = AccessHelper.viewable_metadata_visibilities.map { |visibility| "(visibility_ssi:\"#{visibility}\")" }.join(" OR ")
+    solr_parameters[:fq] << "(#{fq})"
   end
 
   def highlight_fields(solr_parameters)

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -15,6 +15,7 @@ class SearchBuilder < Blacklight::SearchBuilder
   include Blacklight::Solr::SearchBuilderBehavior
   include BlacklightAdvancedSearch::AdvancedSearchBuilder
   include BlacklightRangeLimit::RangeLimitBuilder
+  include AccessHelper
 
   self.default_processor_chain += [:add_advanced_parse_q_to_solr, :add_advanced_search_to_solr]
   # include BlacklightRangeLimit::RangeLimitBuilder
@@ -31,7 +32,7 @@ class SearchBuilder < Blacklight::SearchBuilder
   def show_only_public_records(solr_parameters)
     # add a new solr facet query ('fq') parameter that limits results to those with a 'public_b' field of 1
     solr_parameters[:fq] ||= []
-    fq = AccessHelper.viewable_metadata_visibilities.map { |visibility| "(visibility_ssi:\"#{visibility}\")" }.join(" OR ")
+    fq = viewable_metadata_visibilities.map { |visibility| "(visibility_ssi:\"#{visibility}\")" }.join(" OR ")
     solr_parameters[:fq] << "(#{fq})"
   end
 

--- a/app/views/catalog/_show_main_content.html.erb
+++ b/app/views/catalog/_show_main_content.html.erb
@@ -13,7 +13,7 @@
     <% else %>
       <%= render_document_partials @document, [:show_header] %>
       <h5 class='yale-restricted-work-text'>The digital version of this work is restricted to the Yale Community.</h5>
-      <p class='yale-restricted-work-text'>Please login using your Yale NetID or contact library staff to inquire about access to a physical copy.</p>
+      <p class='yale-restricted-work-text'><%= restriction_message(@document) %></p>
       <%= render "grouped_metadata" %>
     <% end %>
   </div>

--- a/app/views/catalog/_show_main_content.html.erb
+++ b/app/views/catalog/_show_main_content.html.erb
@@ -7,13 +7,13 @@
 <div id="document" class="document <%= render_document_class %>" itemscope  itemtype="<%= @document.itemtype %>">
   <div id="doc_<%= @document.id.to_s.parameterize %>">
     <!-- Only render universal viewer if the work is public OR if the user is authenticated -->
-    <% if client_can_access(@document) %>
+    <% if client_can_view_digital?(@document) %>
       <%= render_document_partials @document, [:show_header, :uv] %>
       <%= render "grouped_metadata" %>
     <% else %>
       <%= render_document_partials @document, [:show_header] %>
-      <h5 class='yale-restricted-work-text'>The digital version of this work is restricted to the Yale Community.</h5>
-      <p class='yale-restricted-work-text'><%= restriction_message(@document) %></p>
+      <h2 class='yale-restricted-work-text'><%= restriction_message(@document) %></h2>
+      <p class='yale-restricted-work-text'><%= restriction_instructions(@document) %></p>
       <%= render "grouped_metadata" %>
     <% end %>
   </div>

--- a/app/views/catalog/show_unauthorized.html.erb
+++ b/app/views/catalog/show_unauthorized.html.erb
@@ -1,0 +1,4 @@
+<div class='item-page__metadata-wrapper'>
+  The digital version of this work is restricted to <%= @document['visibility_ssi'] %>.<br />
+  <%= restriction_message(@document) %>
+</div>

--- a/app/views/catalog/show_unauthorized.html.erb
+++ b/app/views/catalog/show_unauthorized.html.erb
@@ -1,4 +1,4 @@
 <div class='item-page__metadata-wrapper'>
-  The digital version of this work is restricted to <%= @document['visibility_ssi'] %>.<br />
-  <%= restriction_message(@document) %>
+  <h2 class='yale-restricted-work-text'><%= restriction_message(@document) %></h2>
+  <p class='yale-restricted-work-text'><%= restriction_instructions(@document) %></p>
 </div>

--- a/spec/system/access_restrictions_spec.rb
+++ b/spec/system/access_restrictions_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe "access restrictions", type: :system, clean: true do
       expect(page.html).to match(/universal-viewer-iframe/)
     end
 
-    it "does not displays universal viewer or metadata for private works" do
+    it "does not display universal viewer or metadata for private works" do
       visit solr_document_path(private_work[:id])
       expect(page.html).not_to match(/universal-viewer-iframe/)
       expect(page.html).not_to have_content("[Map of China]. [private copy]")
@@ -125,7 +125,7 @@ RSpec.describe "access restrictions", type: :system, clean: true do
       expect(page.html).to have_content("[Map of China]. [yale-only copy]")
     end
 
-    it "does not displays universal viewer or metadata for private works" do
+    it "does not display universal viewer or metadata for private works" do
       visit solr_document_path(private_work[:id])
       expect(page.html).not_to match(/universal-viewer-iframe/)
       expect(page.html).not_to have_content("[Map of China]. [private copy]")

--- a/spec/system/access_restrictions_spec.rb
+++ b/spec/system/access_restrictions_spec.rb
@@ -51,6 +51,15 @@ RSpec.describe "access restrictions", type: :system, clean: true do
     it "does NOT display universal viewer for yale-only works" do
       visit solr_document_path(yale_work[:id])
       expect(page.html).not_to match(/universal-viewer-iframe/)
+      expect(page.html).to have_content('Please login using your Yale NetID or contact library staff to inquire about access to a physical copy.')
+      expect(page.html).to have_content("[Map of China]. [yale-only copy]")
+    end
+
+    it "does NOT display universal viewer for private works" do
+      visit solr_document_path(private_work[:id])
+      expect(page.html).to have_content("You are not authorized to view this item.")
+      expect(page.html).not_to match(/universal-viewer-iframe/)
+      expect(page.html).not_to have_content("[Map of China]. [private copy]")
     end
   end
 
@@ -78,7 +87,7 @@ RSpec.describe "access restrictions", type: :system, clean: true do
     end
   end
 
-  context "an user on the network" do
+  context "a user on the network" do
     around do |example|
       original_yale_networks = ENV['YALE_NETWORK_IPS']
       ENV['YALE_NETWORK_IPS'] = "101.10.5.4,3.4.2.3"
@@ -105,6 +114,13 @@ RSpec.describe "access restrictions", type: :system, clean: true do
     it "displays universal viewer for yale-only works" do
       visit solr_document_path(yale_work[:id])
       expect(page.html).to match(/universal-viewer-iframe/)
+      expect(page.html).to have_content("[Map of China]. [yale-only copy]")
+    end
+
+    it "displays universal viewer for private works" do
+      visit solr_document_path(private_work[:id])
+      expect(page.html).not_to match(/universal-viewer-iframe/)
+      expect(page.html).not_to have_content("[Map of China]. [private copy]")
     end
   end
 end

--- a/spec/system/access_restrictions_spec.rb
+++ b/spec/system/access_restrictions_spec.rb
@@ -95,6 +95,7 @@ RSpec.describe "access restrictions", type: :system, clean: true do
     end
   end
 
+  # For information about testing locally with browser, see README.md#testing-ip-access-restrictions
   context "a user on the network" do
     around do |example|
       original_yale_networks = ENV['YALE_NETWORK_IPS']

--- a/spec/system/access_restrictions_spec.rb
+++ b/spec/system/access_restrictions_spec.rb
@@ -60,6 +60,7 @@ RSpec.describe "access restrictions", type: :system, clean: true do
       expect(page.html).to have_content("You are not authorized to view this item.")
       expect(page.html).not_to match(/universal-viewer-iframe/)
       expect(page.html).not_to have_content("[Map of China]. [private copy]")
+      expect(page).to have_http_status(:unauthorized)
     end
   end
 
@@ -90,6 +91,7 @@ RSpec.describe "access restrictions", type: :system, clean: true do
       visit solr_document_path(private_work[:id])
       expect(page.html).not_to match(/universal-viewer-iframe/)
       expect(page.html).not_to have_content("[Map of China]. [private copy]")
+      expect(page).to have_http_status(:unauthorized)
     end
   end
 
@@ -127,6 +129,7 @@ RSpec.describe "access restrictions", type: :system, clean: true do
       visit solr_document_path(private_work[:id])
       expect(page.html).not_to match(/universal-viewer-iframe/)
       expect(page.html).not_to have_content("[Map of China]. [private copy]")
+      expect(page).to have_http_status(:unauthorized)
     end
   end
 end

--- a/spec/system/access_restrictions_spec.rb
+++ b/spec/system/access_restrictions_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "access restrictions", type: :system, clean: true do
       expect(page.html).to have_content("[Map of China]. [yale-only copy]")
     end
 
-    it "does NOT display universal viewer for private works" do
+    it "does NOT display universal viewer or metadata for private works" do
       visit solr_document_path(private_work[:id])
       expect(page.html).to have_content("You are not authorized to view this item.")
       expect(page.html).not_to match(/universal-viewer-iframe/)
@@ -84,6 +84,12 @@ RSpec.describe "access restrictions", type: :system, clean: true do
     it "displays universal viewer for yale-only works" do
       visit solr_document_path(yale_work[:id])
       expect(page.html).to match(/universal-viewer-iframe/)
+    end
+
+    it "does not displays universal viewer or metadata for private works" do
+      visit solr_document_path(private_work[:id])
+      expect(page.html).not_to match(/universal-viewer-iframe/)
+      expect(page.html).not_to have_content("[Map of China]. [private copy]")
     end
   end
 
@@ -117,7 +123,7 @@ RSpec.describe "access restrictions", type: :system, clean: true do
       expect(page.html).to have_content("[Map of China]. [yale-only copy]")
     end
 
-    it "displays universal viewer for private works" do
+    it "does not displays universal viewer or metadata for private works" do
       visit solr_document_path(private_work[:id])
       expect(page.html).not_to match(/universal-viewer-iframe/)
       expect(page.html).not_to have_content("[Map of China]. [private copy]")

--- a/spec/system/metadata_line_breaks_spec.rb
+++ b/spec/system/metadata_line_breaks_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe 'Metadata line breaks', type: :system, clean: true do
   let(:llama) do
     {
       id: '11111',
+      visibility_ssi: "Public",
       subjectTopic_tesim: ['subject1', 'subject2'],
       subjectName_ssim: ['Langston Hughes', 'James Weldon Johnson'],
       subjectGeographic_tesim: ['New Haven', 'New York City', 'Boston']

--- a/spec/system/view_images_in_search_spec.rb
+++ b/spec/system/view_images_in_search_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe 'Search results displays images', type: :system, clean: true, js:
         visit '/catalog?q=&search_field=all_fields'
         click_link 'test_record_2'
 
-        expect(page).to have_content('The digital version of this work is restricted')
+        expect(page).to have_content('The digital version of this work is restricted to the Yale Community.')
         expect(page).to have_content('Please login using your Yale NetID or contact library staff to inquire about access to a physical copy.')
       end
     end

--- a/spec/system/view_images_in_search_spec.rb
+++ b/spec/system/view_images_in_search_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe 'Search results displays images', type: :system, clean: true, js:
         visit '/catalog?q=&search_field=all_fields'
         click_link 'test_record_2'
 
-        expect(page).to have_content('The digital version of this work is restricted to the Yale Community.')
+        expect(page).to have_content('The digital version of this work is restricted')
         expect(page).to have_content('Please login using your Yale NetID or contact library staff to inquire about access to a physical copy.')
       end
     end


### PR DESCRIPTION
Hides metadata for items with private or unknown visibility.
Refactors access checking code to consolidate.
Adds helper for restriction information displayed to user when digital is restricted or digital/metadata is restricted.