### PR TITLE
724 subjects clickable show page

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -194,7 +194,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'material_tesim', label: 'Material', metadata: 'keyword'
     config.add_show_field 'resourceType_ssim', label: 'Resource Type', metadata: 'keyword', link_to_facet: true
     config.add_show_field 'subjectName_ssim', label: 'Subject (Name)', metadata: 'keyword', helper_method: :join_with_br
-    config.add_show_field 'subjectTopic_tesim', label: 'Subject (Topic)', metadata: 'keyword', helper_method: :join_with_br
+    config.add_show_field 'subjectTopic_tesim', label: 'Subject (Topic)', metadata: 'keyword', link_to_facet: true, helper_method: :faceted_join_with_br
 
     # Origin Group
     config.add_show_field 'creator_ssim', label: 'Creator', metadata: 'origin', link_to_facet: true

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -194,7 +194,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'material_tesim', label: 'Material', metadata: 'keyword'
     config.add_show_field 'resourceType_ssim', label: 'Resource Type', metadata: 'keyword', link_to_facet: true
     config.add_show_field 'subjectName_ssim', label: 'Subject (Name)', metadata: 'keyword', helper_method: :join_with_br
-    config.add_show_field 'subjectTopic_tesim', label: 'Subject (Topic)', metadata: 'keyword', link_to_facet: true, helper_method: :faceted_join_with_br
+    config.add_show_field 'subjectTopic_ssim', label: 'Subject (Topic)', metadata: 'keyword', link_to_facet: true, helper_method: :faceted_join_with_br
 
     # Origin Group
     config.add_show_field 'creator_ssim', label: 'Creator', metadata: 'origin', link_to_facet: true

--- a/spec/system/metadata_line_breaks_spec.rb
+++ b/spec/system/metadata_line_breaks_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe 'Metadata line breaks', type: :system, clean: true do
     {
       id: '11111',
       visibility_ssi: "Public",
-      subjectTopic_tesim: ['subject1', 'subject2'],
       subjectName_ssim: ['Langston Hughes', 'James Weldon Johnson'],
       subjectGeographic_tesim: ['New Haven', 'New York City', 'Boston']
     }
@@ -23,7 +22,6 @@ RSpec.describe 'Metadata line breaks', type: :system, clean: true do
   describe 'add line breaks to subjects' do
     it 'adds a line break when multiple subjects' do
       visit "/catalog/#{llama[:id]}"
-      expect(page.html).to match(llama[:subjectTopic_tesim].join('<br/>'))
       expect(page.html).to match(llama[:subjectName_ssim].join('<br/>'))
       expect(page.html).to match(llama[:subjectGeographic_tesim].join('<br/>'))
     end

--- a/spec/system/view_fields_in_display_spec.rb
+++ b/spec/system/view_fields_in_display_spec.rb
@@ -43,7 +43,7 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       subjectGeographic_tesim: "this is the geo subject",
       resourceType_ssim: "this is the resource type",
       subjectName_ssim: "this is the subject name",
-      subjectTopic_tesim: ["this is the subject topic", "these are the subject topics"],
+      subjectTopic_ssim: ['this is the subject topic', 'these are the subject topics'],
       extentOfDigitization_ssim: 'this is the extent of digitization',
       rights_ssim: "these are the rights",
       creationPlace_ssim: "this is the publication place",
@@ -129,6 +129,7 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
     end
     it 'displays the Subject (Topic) in results' do
       expect(document).to have_content("this is the subject topic")
+      expect(document).to have_content("these are the subject topics")
     end
     it 'displays the Resource Type in results' do
       expect(document).to have_content("this is the resource type")

--- a/spec/system/view_fields_in_display_spec.rb
+++ b/spec/system/view_fields_in_display_spec.rb
@@ -43,7 +43,7 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       subjectGeographic_tesim: "this is the geo subject",
       resourceType_ssim: "this is the resource type",
       subjectName_ssim: "this is the subject name",
-      subjectTopic_tesim: "this is the subject topic",
+      subjectTopic_tesim: ["this is the subject topic", "these are the subject topics"],
       extentOfDigitization_ssim: 'this is the extent of digitization',
       rights_ssim: "these are the rights",
       creationPlace_ssim: "this is the publication place",
@@ -230,6 +230,10 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
     end
     it 'contains a link on the Finding Aid to the Finding Aid catalog record' do
       expect(page).to have_link('this is the finding aid', href: 'this is the finding aid')
+    end
+    it 'contains a link on subject (topic) to its facet' do
+      expect(page).to have_link('this is the subject topic', href: '/catalog?f%5BsubjectTopic_tesim%5D%5B%5D=this is the subject topic')
+      expect(page).to have_link('these are the subject topics', href: '/catalog?f%5BsubjectTopic_tesim%5D%5B%5D=these are the subject topics')
     end
   end
 

--- a/spec/system/view_fields_in_display_spec.rb
+++ b/spec/system/view_fields_in_display_spec.rb
@@ -232,8 +232,8 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       expect(page).to have_link('this is the finding aid', href: 'this is the finding aid')
     end
     it 'contains a link on subject (topic) to its facet' do
-      expect(page).to have_link('this is the subject topic', href: '/catalog?f%5BsubjectTopic_tesim%5D%5B%5D=this is the subject topic')
-      expect(page).to have_link('these are the subject topics', href: '/catalog?f%5BsubjectTopic_tesim%5D%5B%5D=these are the subject topics')
+      expect(page).to have_link('this is the subject topic', href: '/catalog?f%5BsubjectTopic_ssim%5D%5B%5D=this is the subject topic')
+      expect(page).to have_link('these are the subject topics', href: '/catalog?f%5BsubjectTopic_ssim%5D%5B%5D=these are the subject topics')
     end
   end
 


### PR DESCRIPTION
As a user, I want to be able to click on a subject term to get a search showing me other things with that associated subject term.

**Before**
![Screen Shot 2021-01-07 at 1.33.48 PM.png](https://images.zenhubusercontent.com/5e6013c029e314c92afd4769/67048140-ef47-4f80-a5fc-7873024e2a09)


**After**
![Screen Shot 2021-01-07 at 1.38.25 PM.png](https://images.zenhubusercontent.com/5e6013c029e314c92afd4769/366a2bdf-fda6-4817-9772-9b183a9a2c57)