### PR TITLE
Add banner to top of pages

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -58,3 +58,34 @@ $(document).on('turbolinks:load', function() {
         if (href) Turbolinks.visit(href);
     });
 })
+
+
+$(document).on('turbolinks:load', function() {
+    renderBanner();
+})
+
+function renderBanner() {
+    fetch("https://banner.library.yale.edu/banner.json")
+        .then(response => response.json())
+        .then(data => {
+            let allBanners = data.banners;
+            if ("global" in allBanners) {
+                let banners = allBanners.global;
+                if (banners.length > 0) {
+                    let banner = banners[0];
+                    let container = document.getElementById("banner");
+                    // Code to apply text and background color directly
+                    container.style.backgroundColor = banner.backgroundColor;
+                    container.style.color = banner.textColor;
+                    container.innerHTML += "<h3>" + banner.header + "</h3>";
+                    container.innerHTML += "<p>" + banner.message + "</p>";
+                    container.style.display = "block";
+                }
+            }
+        })
+        .catch(error => {
+            console.error('Error:', error);
+            $("#banner").remove();
+        });
+}
+

--- a/app/assets/stylesheets/customOverrides/header.scss
+++ b/app/assets/stylesheets/customOverrides/header.scss
@@ -210,3 +210,8 @@ DEFAULT MOBILE STYLING
     padding-bottom: 0.15rem;
   }
 }
+
+#banner {
+  margin-bottom: 0;
+  display: none;
+}

--- a/app/views/application/landing.html.erb
+++ b/app/views/application/landing.html.erb
@@ -17,6 +17,7 @@
     <%= content_for(:head) %>
   </head>
   <body class="<%= render_body_class %>">
+  <div id="banner" class="alert alert-warning hidden"></div>
   <nav id="skip-link" role="navigation" aria-label="<%= t('blacklight.skip_links.label') %>">
     <%= link_to t('blacklight.skip_links.search_field'), '#search_field', class: 'element-invisible element-focusable rounded-bottom py-2 px-3', data: { turbolinks: 'false' } %>
     <%= link_to t('blacklight.skip_links.main_content'), '#main-container', class: 'element-invisible element-focusable rounded-bottom py-2 px-3', data: { turbolinks: 'false' } %>

--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -17,6 +17,7 @@
     <%= content_for(:head) %>
   </head>
   <body class="<%= render_body_class %>">
+  <div id="banner" class="alert alert-warning hidden"></div>
   <nav id="skip-link" role="navigation" aria-label="<%= t('blacklight.skip_links.label') %>">
     <%= link_to t('blacklight.skip_links.search_field'), '#search_field', class: 'element-invisible element-focusable rounded-bottom py-2 px-3', data: { turbolinks: 'false' } %>
     <%= link_to t('blacklight.skip_links.main_content'), '#main-container', class: 'element-invisible element-focusable rounded-bottom py-2 px-3', data: { turbolinks: 'false' } %>


### PR DESCRIPTION
Banner is on landing, index, and show pages.
Adds banner to the top of all pages (except mirador viewer, since it is full screen.)


Co-authored-by: Lakeisha Robinson <lakeisha.robinson@yale.edu>