### PR TITLE
Fix issues with nested and unclosed quotes

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -22,6 +22,7 @@ class CatalogController < ApplicationController
     config.view.gallery.partials = [:index_header]
     config.show.tile_source_field = :content_metadata_image_iiif_info_ssm
     config.show.partials.insert(1, :openseadragon)
+    config.http_method = :post
 
     ## Class for sending and receiving requests from a search index
     # config.repository_class = Blacklight::Solr::Repository

--- a/config/initializers/blacklight_advanced_search_patch.rb
+++ b/config/initializers/blacklight_advanced_search_patch.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+require 'parsing_nesting/tree'
+module BlacklightAdvancedSearch::ParsingNestingParser
+  def process_query(_params, config)
+    queries = keyword_queries.map do |field, query|
+      query = sanitize_quotes(query)
+      ParsingNesting::Tree.parse(query, config.advanced_search[:query_parser]).to_query(local_param_hash(field, config))
+    end
+    queries.join(" #{keyword_op} ")
+  end
+
+  # remove double "" and remove all quotes if ANY are unclosed
+  def sanitize_quotes(query)
+    query.gsub!('""', '"')
+    query.delete!('"') if query.count('"').odd?
+    query = "" if query.blank?
+
+    query
+  end
+end

--- a/spec/system/advanced_search_spec.rb
+++ b/spec/system/advanced_search_spec.rb
@@ -143,6 +143,27 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: tr
     end
   end
 
+  describe 'sanitizing quotes' do
+    context 'when quotes are consecutive' do
+      it 'removes one quote' do
+        fill_in 'all_fields_advanced', with: '""nested""'
+        click_on 'SEARCH'
+
+        searched_text = find 'span .filter-value'
+        expect(searched_text).to have_content '"nested"'
+      end
+    end
+    context 'when a quote is not closed' do
+      it 'removes all quotes' do
+        fill_in 'all_fields_advanced', with: '"not" "closed'
+        click_on 'SEARCH'
+
+        searched_text = find 'span .filter-value'
+        expect(searched_text).to have_content 'not closed'
+      end
+    end
+  end
+
   context 'sorting' do
     xit 'can sort by date from oldest to newest' do
       within '#sort' do


### PR DESCRIPTION
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1065

**Acceptance**
Wherever the redirect app adds quotes:
- [ ] Advanced search does not add a second set of quotes (?)
