### PR TITLE
1160 mods oai updates

### DIFF
--- a/app/models/concerns/mods_solr_document.rb
+++ b/app/models/concerns/mods_solr_document.rb
@@ -7,7 +7,7 @@ module ModsSolrDocument
   # rubocop:disable Metrics/BlockLength,Metrics/MethodLength,Metrics/PerceivedComplexity,Metrics/AbcSize
   def to_oai_mods
     builder = Nokogiri::XML::Builder.new do |xml|
-      xml.mods('xmlns:mods' => 'http://www.loc.gov/mods/v3', 'version' => '3.4') do
+      xml.mods('xmlns:mods' => 'http://www.loc.gov/mods/v3', 'version' => '3.4', 'xmlns:xlink' => 'http://www.w3.org/1999/xlink') do
         xml['mods'].identifier({ type: 'ladybird' }, "oid#{self[:id]}")
         xml['mods'].identifier({ displayLabel: 'Accession Number', type: 'local' }, self[:accessionNumber_ssi]) if self[:accessionNumber_ssi].present?
         xml['mods'].identifier({ displayLabel: 'Barcode', type: 'local' }, self[:orbisBarcode_ssi]) if self[:orbisBarcode_ssi].present?

--- a/spec/requests/catalog_controller_request_spec.rb
+++ b/spec/requests/catalog_controller_request_spec.rb
@@ -37,6 +37,11 @@ RSpec.describe "/catalog", clean: true, type: :request do
         get "/catalog/oai?verb=GetRecord&metadataPrefix=oai_mods&identifier=oai:collections.library.yale.edu:#{WORK_WITH_PUBLIC_VISIBILITY[:id]}"
       end
 
+      it 'has xlink ns' do
+        node = xml.xpath('//mods:identifier[@type=\'ladybird\']', ns_hash).first
+        expect(node.namespaces["xmlns:xlink"]).to eq("http://www.w3.org/1999/xlink")
+      end
+
       it 'returns properly formatted identifier with GetRecord' do
         identifier = xml.xpath('//mods:identifier[@type=\'ladybird\']', ns_hash)
         expect(identifier.text).to eq("oid#{WORK_WITH_PUBLIC_VISIBILITY[:id]}")
@@ -133,17 +138,20 @@ RSpec.describe "/catalog", clean: true, type: :request do
       end
 
       it 'returns properly formatted findingAid_ssim with GetRecord' do
-        value = xml.xpath('//mods:relatedItem[@displayLabel=\'Finding Aid\']', ns_hash).attr("xlink:href")
+        xml.remove_namespaces!
+        value = xml.xpath('//relatedItem[@displayLabel=\'Finding Aid\']', ns_hash).attr("href")
         expect(value.text).to eq(WORK_WITH_PUBLIC_VISIBILITY[:findingAid_ssim].first)
       end
 
       it 'returns properly formatted url_suppl_ssim with GetRecord' do
-        value = xml.xpath('//mods:relatedItem[@displayLabel=\'Related Resource\']', ns_hash).attr("xlink:href")
+        xml.remove_namespaces!
+        value = xml.xpath('//relatedItem[@displayLabel=\'Related Resource\']', ns_hash).attr("href")
         expect(value.text).to eq(WORK_WITH_PUBLIC_VISIBILITY[:url_suppl_ssim].first)
       end
 
       it 'returns properly formatted partOf_tesim with GetRecord' do
-        value = xml.xpath('//mods:relatedItem[@displayLabel=\'Related Exhibition or Resource\']', ns_hash).attr("xlink:href")
+        xml.remove_namespaces!
+        value = xml.xpath('//relatedItem[@displayLabel=\'Related Exhibition or Resource\']', ns_hash).attr("href")
         expect(value.text).to eq(WORK_WITH_PUBLIC_VISIBILITY[:partOf_tesim].first)
       end
     end


### PR DESCRIPTION
Added xlink namespace to mods element.
Updated tests.

Before update, listing records in some browsers (Firefox) displayed an XML error:
http://localhost:3000/catalog/oai?verb=ListRecords&metadataPrefix=oai_mods or
https://collections-test.library.yale.edu/catalog/oai?verb=ListRecords&metadataPrefix=oai_mods
![image](https://user-images.githubusercontent.com/32851993/112536946-7a2e8280-8d84-11eb-915a-9197fa2c0c89.png)

After update the XML should appear in HTML format.
