### PR TITLE
Use SearchBuilder access for OAI provider

### DIFF
--- a/config/initializers/oai_security_patch.rb
+++ b/config/initializers/oai_security_patch.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+module BlacklightOaiProvider
+  class SolrDocumentWrapper < ::OAI::Provider::Model
+    def find(selector, options = {})
+      return next_set(options[:resumption_token]) if options[:resumption_token]
+
+      if selector == :all
+        response = search_service.repository.search(conditions(options))
+
+        return select_partial(BlacklightOaiProvider::ResumptionToken.new(options.merge(last: 0), nil, response.total)) if limit && response.total > limit
+        response.documents
+      else
+        # search_service.fetch(selector).first.documents.first
+        query = search_service.search_builder.where(id: selector).query
+        search_service.repository.search(query).documents.first
+      end
+    end
+  end
+end


### PR DESCRIPTION
The system should respect the access control settings on an object.  OAI provider would not generate a DC record; it will act like it doesn't exist.

**Acceptance**
- [x] If a record's access status is not Public or Yale Community Only, the OAI provider should not vend a record for that object.


https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1179