### PR TITLE
Create a sitemap in Blacklight

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,10 +8,10 @@ ruby '2.6.6'
 gem 'awesome_print'
 gem 'aws-sdk-s3'
 gem 'blacklight', '>= 7.0'
-gem 'blacklight_dynamic_sitemap'
 gem 'blacklight-gallery'
 gem 'blacklight-marc', '>= 7.0.0.rc1', '< 8'
 gem "blacklight_advanced_search"
+gem 'blacklight_dynamic_sitemap'
 gem 'blacklight_oai_provider', git: 'https://github.com/projectblacklight/blacklight_oai_provider.git'
 gem 'blacklight_range_limit'
 gem 'bootsnap', '>= 1.4.2', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ ruby '2.6.6'
 gem 'awesome_print'
 gem 'aws-sdk-s3'
 gem 'blacklight', '>= 7.0'
+gem 'blacklight_dynamic_sitemap'
 gem 'blacklight-gallery'
 gem 'blacklight-marc', '>= 7.0.0.rc1', '< 8'
 gem "blacklight_advanced_search"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -267,7 +267,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,6 +128,9 @@ GEM
     blacklight_advanced_search (7.0.0)
       blacklight (~> 7.0)
       parslet
+    blacklight_dynamic_sitemap (0.4.0)
+      blacklight (> 6.0)
+      rails (<= 6.1)
     blacklight_range_limit (7.8.2)
       blacklight (>= 7.0)
     bootsnap (1.4.9)
@@ -394,7 +397,6 @@ GEM
       rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
     rubyzip (2.3.0)
-    safe_yaml (1.0.5)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.4.0)
@@ -515,6 +517,7 @@ DEPENDENCIES
   blacklight-gallery
   blacklight-marc (>= 7.0.0.rc1, < 8)
   blacklight_advanced_search
+  blacklight_dynamic_sitemap
   blacklight_oai_provider!
   blacklight_range_limit
   bootsnap (>= 1.4.2)

--- a/app/models/blacklight_dynamic_sitemap/sitemap.rb
+++ b/app/models/blacklight_dynamic_sitemap/sitemap.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+module BlacklightDynamicSitemap
+  ##
+  #
+  class Sitemap
+    delegate :hashed_id_field, :unique_id_field, :last_modified_field, to: :engine_config
+
+    def get(id)
+      # if someone's hacking URLs (in ways that could potentially generate enormous requests),
+      # just return an empty response
+      return [] if id.length != exponent
+
+      index_connection.select(
+        params: show_params(id, {
+                              q: '*:*',
+                              fq: ["{!prefix f=#{hashed_id_field} v=#{id}}"],
+                              fl: [unique_id_field, last_modified_field, 'visibility_ssi', 'thumbnail_path_ss'].join(','),
+                              rows: 2_000_000, # Ensure that we do not page this result
+                              facet: false,
+                              defType: 'lucene'
+                            })
+      ).dig('response', 'docs')
+    end
+
+    def list
+      access_list
+    end
+
+    private
+
+    def show_params(id, default_params)
+      engine_config.modify_show_params&.call(id, default_params) || default_params
+    end
+
+    def index_params(default_params)
+      engine_config.modify_index_params&.call(default_params) || default_params
+    end
+
+    def index_connection
+      @index_connection ||= Blacklight.default_index.connection
+    end
+
+    def engine_config
+      BlacklightDynamicSitemap::Engine.config
+    end
+
+    def max_documents
+      key = 'blacklight_dynamic_sitemap.index_max_docs'
+      expiration = engine_config.max_documents_expiration
+      Rails.cache.fetch(key, expires_in: expiration) do
+        index_connection.select(
+          params: index_params({ q: '*:*', rows: 0, facet: false })
+        )['response']['numFound']
+      end
+    end
+
+    def average_chunk
+      [engine_config.minimum_average_chunk, max_documents].min # Sufficiently less than 50,000 max per sitemap
+    end
+
+    ##
+    # Exponent used to calculate the needed number of prefix spaces to query
+    # that will effectively chunk the entire number of documents. 16 is the
+    # number of characters in hex space (0-9, a-f)
+    # Example: 16**1 = 16, 16**2 = 256, 16**3 = 4096
+    # x = b**y
+    # y = logb(x)
+    # y = logb(x) = ln(x) / ln(b)
+    def exponent
+      @exponent ||= [
+        (Math.log(max_documents / average_chunk) / Math.log(16)).ceil,
+        1
+      ].max
+    end
+
+    ##
+    # Expand the number of documents used off of calculated exponent to create
+    # list of sitemaps to access in hex space (0-9, a-f)
+    # Example: (exponent as 4)
+    # ["0000", "0001", "0002", "0003"..."af74", "af75", "af76", "af77"..."fffc", "fffd", "fffe", "ffff"]
+    def access_list
+      (0...(16**exponent))
+        .to_a
+        .map { |v| v.to_s(16).rjust(exponent, '0') }
+    end
+  end
+end

--- a/app/models/blacklight_dynamic_sitemap/sitemap.rb
+++ b/app/models/blacklight_dynamic_sitemap/sitemap.rb
@@ -1,20 +1,21 @@
 # frozen_string_literal: true
-
+#
 module BlacklightDynamicSitemap
   ##
   #
   class Sitemap
     delegate :hashed_id_field, :unique_id_field, :last_modified_field, to: :engine_config
+    include AccessHelper
 
     def get(id)
       # if someone's hacking URLs (in ways that could potentially generate enormous requests),
       # just return an empty response
       return [] if id.length != exponent
-
+      fq = viewable_metadata_visibilities.map { |visibility| "(visibility_ssi:\"#{visibility}\")" }.join(" OR ")
       index_connection.select(
         params: show_params(id, {
                               q: '*:*',
-                              fq: ["{!prefix f=#{hashed_id_field} v=#{id}}"],
+                              fq: ["{!prefix f=#{hashed_id_field} v=#{id}}", fq],
                               fl: [unique_id_field, last_modified_field, 'visibility_ssi', 'thumbnail_path_ss'].join(','),
                               rows: 2_000_000, # Ensure that we do not page this result
                               facet: false,

--- a/app/views/blacklight_dynamic_sitemap/sitemap/show.xml.builder
+++ b/app/views/blacklight_dynamic_sitemap/sitemap/show.xml.builder
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+xml.instruct! :xml, version: '1.0', encoding: 'UTF-8'
+xml.urlset(
+  'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
+  'xsi:schemaLocation' => 'http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd',
+  'xmlns' => 'http://www.sitemaps.org/schemas/sitemap/0.9'
+) do
+  config = BlacklightDynamicSitemap::Engine.config
+  @sitemap_entries.each do |doc|
+    xml.url do
+      xml.loc(main_app.solr_document_url(doc[config.unique_id_field]))
+      last_modified = doc[config.last_modified_field]
+      xml.lastmod(config.format_last_modified&.call(last_modified) || last_modified)
+      xml.image doc['thumbnail_path_ss'] if doc['visibility_ssi'] == "Public" && doc['thumbnail_path_ss']
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,8 @@ Rails.application.routes.draw do
   root to: 'application#landing'
 
   mount Blacklight::Engine => '/'
+  mount BlacklightDynamicSitemap::Engine => '/'
+
   mount BlacklightAdvancedSearch::Engine => '/'
 
   concern :searchable, Blacklight::Routes::Searchable.new

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@rails/actioncable": "^6.0.0",
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",
-    "@rails/webpacker": "4.2.2",
+    "@rails/webpacker": "4.3.0",
     "node-forge": "^0.10.0",
     "serialize-javascript": "^3.1.0",
     "turbolinks": "^5.2.0",
@@ -21,6 +21,6 @@
   "version": "0.1.0",
   "devDependencies": {
     "shx": "^0.3.2",
-    "webpack-dev-server": "^3.10.3"
+    "webpack-dev-server": "^3.11.2"
   }
 }

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,1 +1,2 @@
 # See https://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
+Sitemap: https://collections.library.yale.edu/sitemap

--- a/spec/system/sitemap_show_spec.rb
+++ b/spec/system/sitemap_show_spec.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Sitemap Show', type: :feature do
+  before do
+    solr = Blacklight.default_index.connection
+    solr.add([test_record_0, test_record_1, test_record_2, test_record_3, test_record_4])
+    solr.commit
+  end
+
+  let(:test_record_0) do
+    {
+      id: '111',
+      subtitle_tesim: "He's Handsome",
+      creator_tesim: 'Eric & Frederick',
+      format: 'three dimensional object',
+      url_fulltext_ssim: 'http://0.0.0.0:3000/catalog/211',
+      url_suppl_ssim: 'http://0.0.0.0:3000/catalog/211',
+      published_ssim: "1997",
+      hashed_id_ssi: '082c8d1619ad8176d665453cfb2e55f0',
+      language_ssim: ['en', 'eng', 'zz'],
+      isbn_ssim: '2321321389',
+      timestamp: "2021-04-05T17:43:23.382Z",
+      description_tesim: "Handsome Dan is a bulldog who serves as Yale Univeristy's mascot.",
+      thumbnail_path_ss: "http://localhost:8182/iiif/2/10962176/full/!200,200/0/default.jpg",
+      visibility_ssi: 'Public',
+      year_isim: (600..1050).to_a
+    }
+  end
+
+  let(:test_record_1) do
+    {
+      id: '211',
+      subtitle_tesim: "He's Handsome",
+      creator_tesim: 'Eric & Frederick',
+      format: 'three dimensional object',
+      url_fulltext_ssim: 'http://0.0.0.0:3000/catalog/211',
+      url_suppl_ssim: 'http://0.0.0.0:3000/catalog/211',
+      published_ssim: "1997",
+      hashed_id_ssi: '182c8d1619ad8176d65453cfb2e776f0',
+      language_ssim: ['en', 'eng', 'zz'],
+      isbn_ssim: '2321321389',
+      timestamp: "2021-04-05T17:43:23.382Z",
+      description_tesim: "Handsome Dan is a bulldog who serves as Yale Univeristy's mascot.",
+      visibility_ssi: 'Public',
+      thumbnail_path_ss: "http://localhost:8182/iiif/2/10962124/full/!200,200/0/default.jpg",
+      year_isim: (1920..2000).to_a
+    }
+  end
+
+  let(:test_record_2) do
+    {
+      id: '311',
+      subtitle_tesim: "He's Dan",
+      creator_tesim: 'Eric & Frederick',
+      format: 'three dimensional object',
+      url_fulltext_ssim: 'http://0.0.0.0:3000/catalog/311',
+      url_suppl_ssim: 'http://0.0.0.0:3000/catalog/311',
+      published_ssim: "1997",
+      hashed_id_ssi: '282c8d1619ad8176d65453cfb2e776f0',
+      language_ssim: ['en', 'eng', 'zz'],
+      isbn_ssim: '2321321389',
+      timestamp: "2021-04-05T17:43:23.382Z",
+      description_tesim: "Handsome Dan is a bulldog who serves as Yale Univeristy's mascot.",
+      visibility_ssi: 'Public',
+      thumbnail_path_ss: "http://localhost:8182/iiif/2/10962124/full/!200,200/0/default.jpg",
+      year_isim: [1900]
+    }
+  end
+
+  let(:test_record_3) do
+    {
+      id: '411',
+      subtitle_tesim: "He's Handsome Dan",
+      creator_tesim: 'Eric & Frederick',
+      format: 'three dimensional object',
+      url_fulltext_ssim: 'http://0.0.0.0:3000/catalog/411',
+      url_suppl_ssim: 'http://0.0.0.0:3000/catalog/411',
+      published_ssim: "1997",
+      hashed_id_ssi: '082c8d1619ad8176d665453cfb2e55f0',
+      language_ssim: ['en', 'eng', 'zz'],
+      isbn_ssim: '2321321389',
+      timestamp: "2021-04-05T17:43:23.382Z",
+      description_tesim: "Handsome Dan is a bulldog who serves as Yale Univeristy's mascot.",
+      visibility_ssi: 'Yale Community Only',
+      thumbnail_path_ss: "http://localhost:8182/iiif/2/10962334/full/!200,200/0/default.jpg",
+      year_isim: [2020, 2021]
+    }
+  end
+
+  let(:test_record_4) do
+    {
+      id: '511',
+      subtitle_tesim: "He's Handsome Dan",
+      creator_tesim: 'Eric & Frederick',
+      format: 'three dimensional object',
+      url_fulltext_ssim: 'http://0.0.0.0:3000/catalog/411',
+      url_suppl_ssim: 'http://0.0.0.0:3000/catalog/411',
+      published_ssim: "1997",
+      hashed_id_ssi: '082c8d1619ad8176d665453cfb2e55f0',
+      language_ssim: ['en', 'eng', 'zz'],
+      isbn_ssim: '2321321389',
+      timestamp: "2021-04-05T17:43:23.382Z",
+      description_tesim: "Handsome Dan is a bulldog who serves as Yale Univeristy's mascot.",
+      visibility_ssi: 'Private',
+      thumbnail_path_ss: "http://localhost:8182/iiif/2/10962664/full/!200,200/0/default.jpg",
+      year_isim: [2020, 2021]
+    }
+  end
+
+  it 'renders XML with a root element for record 2' do
+    visit blacklight_dynamic_sitemap.sitemap_path('1')
+    expect(page).to have_xpath('//urlset')
+  end
+  it 'renders record 2 elements' do
+    visit blacklight_dynamic_sitemap.sitemap_path('1')
+    expect(page).to have_xpath('//url', count: 1)
+  end
+  it 'renders XML with a root element for record 1' do
+    visit blacklight_dynamic_sitemap.sitemap_path('0')
+    expect(page).to have_xpath('//urlset')
+  end
+  it 'renders record 1 elements' do
+    visit blacklight_dynamic_sitemap.sitemap_path('0')
+    expect(page).to have_xpath('//url', count: 2)
+  end
+  it 'does render a thumbnail for public images' do
+    visit blacklight_dynamic_sitemap.sitemap_path('2')
+    expect(page).to have_content('http://localhost:8182/iiif/2/10962124/full/!200,200/0/default.jpg')
+  end
+  it 'does not render a thumbnail for non-public images' do
+    visit blacklight_dynamic_sitemap.sitemap_path('0')
+    expect(page).not_to have_content('http://localhost:8182/iiif/2/10962334/full/!200,200/0/default.jpg')
+  end
+  it 'does not display a private record' do
+    visit blacklight_dynamic_sitemap.sitemap_path('0')
+    expect(page).not_to have_content '511'
+  end
+end


### PR DESCRIPTION
Co-author: Martin Lovell <martin.lovell@yale.edu>

Management Application branch: 
https://github.com/yalelibrary/yul-dc-management/pull/584

**Story**

We'd like users to be able to discover all of the content via Google.  To improve the chances that our content will be indexed, we should offer a sitemap.

**Acceptance**
- [x] The site makes a sitemap available
- [x] The sitemap includes only objects with `Public` and `Yale Community Only` access. (see #1179 for a similar issue for the OAI provider)
- [x] The sitemap does not include objects with `Private`.

- For each item, the sitemap includes:
   - [x] URI
   - [x] last modified date
   - [x] the thumbnail image **if publicly accessible** as the first `<image>` 
   - [x] additional images **if publicly accessible** (number TBD) as subsequent image entries
- [x] Sitemap linked to from `robots.txt` (see https://developers.google.com/search/docs/advanced/sitemaps/build-sitemap#addsitemap )
