### PR TITLE
1103 rights field escape link

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -177,8 +177,9 @@ class CatalogController < ApplicationController
     #     'description',
     #     'subjects_,_formats_and_genres',
     #     'collection_information',
-    #     'access_and_usage',
+    #     'access_and_usage_rights',
     #     'identifier'
+    # ]
 
     # Description Group
     config.add_show_field 'title_tesim', label: 'Title', metadata: 'description'
@@ -221,7 +222,7 @@ class CatalogController < ApplicationController
 
     # Access and Usage Rights Group
     config.add_show_field 'visibility_ssi', label: 'Access', metadata: 'access_and_usage_rights'
-    config.add_show_field 'rights_ssim', label: 'Rights', metadata: 'access_and_usage_rights'
+    config.add_show_field 'rights_ssim', label: 'Rights', metadata: 'access_and_usage_rights', helper_method: :html_safe_converter
     config.add_show_field 'preferredCitation_tesim', label: 'Citation', metadata: 'access_and_usage_rights'
 
     # Identifiers Group

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -93,6 +93,10 @@ module BlacklightHelper
     link_to(arg[:value][0], arg[:value][0])
   end
 
+  def html_safe_converter(arg)
+    sanitize arg[:value][0], tags: %w[a], attributes: %w[href]
+  end
+
   def search_field_value_link(args)
     field_value = args[:document][args[:field]]
     link_text = "/?q=#{field_value}&search_field=#{args[:field]}"

--- a/app/views/catalog/record/_item_metadata.html.erb
+++ b/app/views/catalog/record/_item_metadata.html.erb
@@ -5,13 +5,13 @@
     <dl class='metadata-block__group'>
 
       <% doc_presenter.metadata_fields_to_render(metadata).each do |field_name, field, field_presenter| %>
+        <!-- KEY -->
         <dt class='blacklight-<%= field_name.parameterize %> metadata-block__label-key'>
-          <!-- KEY -->
           <%= (render_document_show_field_label document, field: field_name).tr(':', '') %>
-          <!-- VALUE -->
         </dt>
+        <!-- VALUE -->
         <dd class='blacklight-<%= field_name.parameterize %> metadata-block__label-value metadata-block__label-value--yul'>
-          <%= field_presenter.render%>
+          <%= field_presenter.render %>
         </dd>
       <% end %>
     </dl>


### PR DESCRIPTION
co-author: dylan salay <dylan@notch8.com>
co-author: leaann bradford <leaann@notch8.com>

# Ticket
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1103

# Expected behavior
- links that are part of a rights statement will be sanitized to only show the `a` tag and `href` atttribute
- that same link will display as a link instead of plain text
- if we desire the same behavior for other fields on the page, the `html_safe_converter` helper can be used

# Demo
![image](https://user-images.githubusercontent.com/29032869/113906807-7e499f80-9789-11eb-8721-e581ac1251c1.png)

# Resources
- https://api.rubyonrails.org/classes/ActionView/Helpers/SanitizeHelper.html#method-i-sanitize