### PR TITLE
remove json format from UV src

### DIFF
--- a/app/views/catalog/_uv.html.erb
+++ b/app/views/catalog/_uv.html.erb
@@ -4,7 +4,7 @@
 <iframe
     class="universal-viewer-iframe"
     title="Universal Viewer"
-    src="<%= request&.base_url %>/uv/uv.html#?manifest=<%= manifest_url(oid, format: 'json') %>"
+    src="<%= request&.base_url %>/uv/uv.html#?manifest=<%= manifest_url(oid) %>"
     width="924"
     height="668"
     allowfullscreen

--- a/spec/system/show_page_spec.rb
+++ b/spec/system/show_page_spec.rb
@@ -73,17 +73,26 @@ RSpec.describe 'Show Page', type: :system, js: true, clean: true do
     expect(page).to have_css '.show-buttons'
     expect(page).to have_css '.manifestItem'
   end
+
   context '"Back to Search Results" button' do
     it 'returns user to search results' do
       expect(page).to have_button("Back to Search Results")
       expect(page).to have_xpath("//button[@href='/catalog?page=1&per_page=10&search_field=all_fields']")
     end
   end
+
   context '"Start Over" button' do
     it 'returns user to homepage' do
       expect(page).to have_button "Start Over"
       expect(page).to have_xpath("//button[@href='/catalog']")
       expect(page.first('button.catalog_startOverLink').text).to eq 'Start Over'
+    end
+  end
+
+  context 'Universal Viewer' do
+    it 'does not have a .json extension in the src attribute' do
+      src = find('.universal-viewer-iframe')['src']
+      expect(src).not_to include('.json')
     end
   end
 end


### PR DESCRIPTION
co-author: dylan salay <dylan@notch8.com>
co-author: alisha evans <alisha@notch8.com>

# Ticket
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1194

# Expected behavior
- The URL of the IIIF Manifests should not include the .json extension.

# Demo
| before | after |
|---|---|
|![Screen Shot 2021-04-07 at 10 42 23 AM](https://user-images.githubusercontent.com/50561476/113910737-07fb6c00-978e-11eb-9017-78bbf36eb888.png)|![Screen Shot 2021-04-07 at 10 42 44 AM](https://user-images.githubusercontent.com/50561476/113910766-1053a700-978e-11eb-927a-8595aeb1b78d.png)|

