### PR TITLE
1103-rights-field-escape-link-2

### DIFF
--- a/app/assets/stylesheets/customOverrides/show_page.scss
+++ b/app/assets/stylesheets/customOverrides/show_page.scss
@@ -43,6 +43,10 @@ DEFAULT MOBILE STYLING
   position: relative;
 }
 
+.page-sidebar {
+  display: none;
+}
+
 .show-buttons {
   justify-self: center;
   margin-right: 137px;
@@ -177,7 +181,7 @@ DEFAULT MOBILE STYLING
 
 h2.yale-restricted-work-text {
   font-size: 1.5em;
-} 
+}
 
 @media screen and (min-width: $medium_device) {
   .constraints-container {

--- a/app/assets/stylesheets/customOverrides/show_page.scss
+++ b/app/assets/stylesheets/customOverrides/show_page.scss
@@ -43,10 +43,6 @@ DEFAULT MOBILE STYLING
   position: relative;
 }
 
-.page-sidebar {
-  display: none;
-}
-
 .show-buttons {
   justify-self: center;
   margin-right: 137px;

--- a/app/views/layouts/catalog_result.html.erb
+++ b/app/views/layouts/catalog_result.html.erb
@@ -1,0 +1,6 @@
+<% content_for(:content) do %>
+  <section class='<%= show_content_classes %>'>
+    <%= yield %>
+  </section>
+<% end %>
+<%= render template: 'layouts/blacklight/base' %>


### PR DESCRIPTION
co-author: alisha evans <alisha@notch8.com>
co-author: dylan salay <dylan@notch8.com>

# Ticket
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1103

# Related PR
https://github.com/yalelibrary/yul-dc-blacklight/pull/501

# Summary of issue
Test branch: `Branch:1103-rights-field-escape-link,Deployed:2021-04-07T13:32:39-04:00 `

Noticed on test that different window lengths make the link in the rights statement behave differently. Either all of the link is clickable, various parts of it are clickable, or none of it is clickable.

The text in question is "WATCH File"

| width | clickable portion of text |
| --- | --- |
| 1700px | WATCH File|
|1648px | WATCH Fi |
|1640px | WATCH F |
| 1591px | WATC |
| 1541px| W |
|1218px | n/a |
| 1055px | WATCH File|
| 753px | WATCH File|
| 376px | WATCH File|


# Expected behavior
- all links that show on the right side of a show page should be clickable despite the window width
- we discovered that there was a `section` on the right side at certain widths, and that's what was covering the link. there's nothing in it anymore, so we removed it

# Testing instructions
- open the browser to some of the widths above (or close it it) and verify you can still click the link

# Resource
- https://github.com/projectblacklight/blacklight/blob/c310fc8cb07635cac8e2474b1afa9fafdb6c89de/app/views/layouts/catalog_result.html.erb