### PR TITLE
Add use of child oid as parameter to open uv to specific page

### DIFF
--- a/app/views/catalog/_uv.html.erb
+++ b/app/views/catalog/_uv.html.erb
@@ -1,10 +1,15 @@
 <% oid = @document.id %>
-
+<%
+  order_param = ""
+  if @document[:child_oids_ssim]
+    order_param= "&cv=#{@document[:child_oids_ssim].index(params[:child_oid])|| 0}"
+  end
+%>
 <div class="uv-container">
 <iframe
     class="universal-viewer-iframe"
     title="Universal Viewer"
-    src="<%= request&.base_url %>/uv/uv.html#?manifest=<%= manifest_url(oid) %>"
+    src="<%= request&.base_url %>/uv/uv.html#?manifest=<%= manifest_url(oid) %><%= order_param %>"
     width="924"
     height="668"
     allowfullscreen

--- a/spec/system/show_page_spec.rb
+++ b/spec/system/show_page_spec.rb
@@ -5,8 +5,15 @@ RSpec.describe 'Show Page', type: :system, js: true, clean: true do
   before do
     stub_request(:get, 'https://yul-dc-development-samples.s3.amazonaws.com/manifests/11/11/111.json')
       .to_return(status: 200, body: File.open(File.join('spec', 'fixtures', '2041002.json')).read)
+    stub_request(:get, 'https://yul-dc-development-samples.s3.amazonaws.com/manifests/11/11/112.json')
+      .to_return(status: 200, body: File.open(File.join('spec', 'fixtures', '2041002.json')).read)
+    stub_request(:get, 'https://yul-dc-development-samples.s3.amazonaws.com/manifests/11/11/113.json')
+      .to_return(status: 200, body: File.open(File.join('spec', 'fixtures', '2041002.json')).read)
+
     solr = Blacklight.default_index.connection
     solr.add([llama,
+              llama_child_1,
+              llama_child_2,
               dog,
               eagle,
               puppy])
@@ -19,6 +26,32 @@ RSpec.describe 'Show Page', type: :system, js: true, clean: true do
     {
       id: '111',
       title_tesim: ['Amor Llama'],
+      format: 'text',
+      language_ssim: 'la',
+      visibility_ssi: 'Public',
+      genre_ssim: 'Maps',
+      resourceType_ssim: 'Maps, Atlases & Globes',
+      creator_ssim: ['Anna Elizabeth Dewdney'],
+      child_oids_ssim: [112, 113]
+    }
+  end
+
+  let(:llama_child_1) do
+    {
+      id: '112',
+      title_tesim: ['Baby Llama'],
+      format: 'text',
+      language_ssim: 'la',
+      visibility_ssi: 'Public',
+      genre_ssim: 'Maps',
+      resourceType_ssim: 'Maps, Atlases & Globes',
+      creator_ssim: ['Anna Elizabeth Dewdney']
+    }
+  end
+  let(:llama_child_2) do
+    {
+      id: '113',
+      title_tesim: ['Baby Llama 2: The Sequel'],
       format: 'text',
       language_ssim: 'la',
       visibility_ssi: 'Public',
@@ -93,6 +126,19 @@ RSpec.describe 'Show Page', type: :system, js: true, clean: true do
     it 'does not have a .json extension in the src attribute' do
       src = find('.universal-viewer-iframe')['src']
       expect(src).not_to include('.json')
+    end
+
+    context 'sending child oid as a parameter' do
+      it 'uses child\'s page when oid is valid' do
+        visit 'catalog/111?child_oid=113'
+        src = find('.universal-viewer-iframe')['src']
+        expect(src).to include '&cv=1'
+      end
+      it 'uses first page when oid is invalid' do
+        visit 'catalog/111?child_oid=11312321'
+        src = find('.universal-viewer-iframe')['src']
+        expect(src).to include '&cv=0'
+      end
     end
   end
 end


### PR DESCRIPTION
**Issue**
yalelibrary/YUL-DC#1193

**Acceptance**
- [x] Passing the `child_oid` parameter (with a valid child OID of the parent) to an individual object's page will cause the Universal Viewer to display/focus on that image.
- [x] Passing an invalid OID (e.g., not a member of the parent) will result in UV opening normally (i.e., showing the first page of the object)

**Validation**
Compare 
http://localhost:3000/catalog/2012036?child_oid=1052762
to 
http://localhost:3000/catalog/2012036