### PR TITLE
1204 search results no index

### DIFF
--- a/app/views/catalog/_search_results.html.erb
+++ b/app/views/catalog/_search_results.html.erb
@@ -2,6 +2,7 @@
 <% @page_title = t('blacklight.search.page_title.title', :constraints => render_search_to_page_title(params, @response), :application_name => application_name) %>
 
 <% content_for(:head) do -%>
+  <meta name="robots" content="noindex" />
   <%= render 'catalog/opensearch_response_metadata', response: @response %>
   <%= rss_feed_link_tag %>
   <%= atom_feed_link_tag %>

--- a/app/views/mirador/show.html.erb
+++ b/app/views/mirador/show.html.erb
@@ -3,7 +3,7 @@
 <head>
   <%= render partial: 'shared/ga_header' %>
   <title>Yale Digital Collections Mirador Viewer</title>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex"/>
   <script src="/mirador.js"></script>
 </head>
 <body>

--- a/spec/system/mirador_spec.rb
+++ b/spec/system/mirador_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Mirador viewer', type: :system do
     it 'contains a noindex tag' do
       value = 123_456
       visit "/mirador/#{value}"
-      expect(page.html).to include('<meta name="robots" content="noindex">')
+      expect(page).to have_css("meta[name=robots][content=noindex]", visible: false)
     end
 
     it 'builds a blank configuration given an invalid value' do

--- a/spec/system/search_result_spec.rb
+++ b/spec/system/search_result_spec.rb
@@ -50,6 +50,10 @@ RSpec.describe 'search result', type: :system, clean: true do
     it 'shows the index number' do
       expect(page).to have_selector '#documents > .document-position-0 span', visible: true
     end
+
+    it 'has a no index meta tag in header' do
+      expect(page).to have_css("meta[name=robots][content=noindex]", visible: false)
+    end
   end
 
   context 'in gallery view' do
@@ -67,6 +71,10 @@ RSpec.describe 'search result', type: :system, clean: true do
 
     it 'does not show the index number' do
       expect(page).not_to have_selector '#documents > .document.col:first-child span'
+    end
+
+    it 'has a no index meta tag in header' do
+      expect(page).to have_css("meta[name=robots][content=noindex]", visible: false)
     end
   end
 
@@ -119,6 +127,16 @@ RSpec.describe 'search result', type: :system, clean: true do
 
     it 'shows the index number' do
       expect(page).to have_selector '#documents > .document-position-0 span', visible: true
+    end
+  end
+
+  context 'on catalog page without results' do
+    before do
+      visit '/catalog'
+    end
+
+    it 'does not have a no index meta tag in header' do
+      expect(page).not_to have_css("meta[name=robots][content=noindex]", visible: false)
     end
   end
 end


### PR DESCRIPTION
Adds `<meta name="robots" content="noindex" />` tag to search results.  Does not include tag in /catalog (with no query).

![image](https://user-images.githubusercontent.com/32851993/114204649-6dcf2b80-9927-11eb-86e8-56b707759667.png)
