### PR TITLE
1218 change "start over" to "new search"

### DIFF
--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -6,6 +6,10 @@
     </div>
     <%= render 'previous_next_doc' if @search_context %>
   </div>
+<% else %>
+  <div id="showSearchButtons" class="show-buttons" >
+      <%= render 'start_over' %>
+  </div>
 <% end %>
 
 <%= render_document_main_content_partial %>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -21,4 +21,5 @@ en:
       page_title:
         results: '%{count} results for %{q}'
         results_with_constraint: '%{count} results for %{label}: %{value}'
+      start_over: 'New Search'
     back_to_search: 'Back to Search Results'

--- a/config/locales/blacklight_advanced_search.en.yml
+++ b/config/locales/blacklight_advanced_search.en.yml
@@ -8,5 +8,4 @@ en:
       limit_criteria_heading_html: "<strong>AND</strong> have these attributes"
       query_criteria_heading_html: "<label for=\"op\">Find items that match</label> %{select_menu}"
       sort_label: "Sort results by"
-      start_over: "Start over"
       search_btn: 'Search'

--- a/spec/system/show_page_spec.rb
+++ b/spec/system/show_page_spec.rb
@@ -114,11 +114,11 @@ RSpec.describe 'Show Page', type: :system, js: true, clean: true do
     end
   end
 
-  context '"Start Over" button' do
+  context '"New Search" button' do
     it 'returns user to homepage' do
-      expect(page).to have_button "Start Over"
+      expect(page).to have_button "New Search"
       expect(page).to have_xpath("//button[@href='/catalog']")
-      expect(page.first('button.catalog_startOverLink').text).to eq 'Start Over'
+      expect(page.first('button.catalog_startOverLink').text).to eq 'New Search'
     end
   end
 


### PR DESCRIPTION
# Ticket
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1218

# Expected behavior
- the button on a show page says "new search" whether there is an active search or not
- I tested this by changing the conditional statement in the code. unsure how to test this otherwise because I seem to always have a `current_search_session`

# Demo
![image](https://user-images.githubusercontent.com/29032869/114631929-62a33500-9c72-11eb-9e68-95498eb943b0.png)