### PR TITLE
1203 Add schema.org metadata to show page

### DIFF
--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -123,6 +123,10 @@ module BlacklightHelper
     Blacklight::SearchState.new(params, blacklight_config)
   end
 
+  def render_schema_org_metadata
+    render partial: 'catalog/schema_org_metadata', locals: { metadata: @document.to_schema_json_ld }
+  end
+
   private
 
   def language_code_to_english(language_code)

--- a/app/models/concerns/schema_org_solr_document.rb
+++ b/app/models/concerns/schema_org_solr_document.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# rubocop:disable Metrics/ModuleLength,Metrics/CyclomaticComplexity
+module SchemaOrgSolrDocument
+  extend ActiveSupport::Concern
+
+  def to_schema_json_ld
+    about = {
+      "name": self[:subjectName_ssim]&.join(", "),
+      "topic": self[:subjectGeographic_ssim]&.join(", "), # @self[:subjectTopic_ssim],
+      "place": self[:creationPlace_ssim]&.join(", ")
+    }.compact
+    about = nil if about.empty?
+    {
+      "@context": "https://schema.org/",
+      "@type": "CreativeWork",
+      "name": self[:title_tesim]&.join(", "),
+      "alternateName": self[:alternativeTitle_tesim]&.join(", "),
+      "description": self[:description_tesim]&.join(", "),
+      "url": "https://collections.library.yale.edu/catalog/#{id}",
+      "about": about,
+      "genre": self[:genre_ssim]&.join(", "),
+      "materialExtent": self[:extent_ssim]&.join(", "),
+      "temporal": self[:date_ssim]&.join(", "),
+      "thumbnailUrl": self[:visibility_ssi] == "Public" && self["thumbnail_path_ss"] || nil
+    }.compact
+  end
+end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -5,6 +5,7 @@ class SolrDocument
 
   include Blacklight::Gallery::OpenseadragonSolrDocument
   include ModsSolrDocument
+  include SchemaOrgSolrDocument
 
   # # The following shows how to setup this blacklight document to display marc documents
   # extension_parameters[:marc_source_field] = :marc_ss

--- a/app/views/catalog/_schema_org_metadata.html.erb
+++ b/app/views/catalog/_schema_org_metadata.html.erb
@@ -1,0 +1,3 @@
+<script type="application/ld+json">
+  <%= raw metadata.to_json %>
+</script>

--- a/app/views/catalog/_show_main_content.html.erb
+++ b/app/views/catalog/_show_main_content.html.erb
@@ -1,5 +1,8 @@
 <% @page_title = t('blacklight.search.show.title', :document_title => document_show_html_title, :application_name => application_name).html_safe %>
-<% content_for(:head) { render_link_rel_alternates } %>
+<% content_for(:head) do -%>
+  <%= render_link_rel_alternates %>
+  <%= render_schema_org_metadata %>
+<% end %>
 
 <div id="document" class="document <%= render_document_class %>" itemscope  itemtype="<%= @document.itemtype %>">
   <div id="doc_<%= @document.id.to_s.parameterize %>">

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SolrDocument, type: :model do
+  context "with public work" do
+    let(:solr_document) { described_class.new(WORK_WITH_PUBLIC_VISIBILITY) }
+    it "creates valid schema.org metadata" do
+      schema = solr_document.to_schema_json_ld
+      expect(schema[:@context]).to eq('https://schema.org/')
+      expect(schema[:@type]).to eq('CreativeWork')
+
+      expect(schema[:name]).to eq(WORK_WITH_PUBLIC_VISIBILITY[:title_tesim]&.join(", "))
+      expect(schema[:alternateName]).to eq(WORK_WITH_PUBLIC_VISIBILITY[:alternativeTitle_tesim]&.join(", "))
+      expect(schema[:description]).to eq(WORK_WITH_PUBLIC_VISIBILITY[:description_tesim]&.join(", "))
+      expect(schema[:url]).to eq("https://collections.library.yale.edu/catalog/#{WORK_WITH_PUBLIC_VISIBILITY[:id]}")
+      expect(schema[:genre]).to eq(WORK_WITH_PUBLIC_VISIBILITY[:genre_ssim]&.join(", "))
+      expect(schema[:materialExtent]).to eq(WORK_WITH_PUBLIC_VISIBILITY[:extent_ssim]&.join(", "))
+      expect(schema[:temporal]).to eq(WORK_WITH_PUBLIC_VISIBILITY[:date_ssim]&.join(", "))
+      expect(schema[:thumbnailUrl]).to eq(WORK_WITH_PUBLIC_VISIBILITY[:thumbnail_path_ss])
+
+      about = schema[:about]
+      expect(about[:name]).to eq(WORK_WITH_PUBLIC_VISIBILITY[:subjectName_ssim]&.join(", "))
+      expect(about[:topic]).to eq(WORK_WITH_PUBLIC_VISIBILITY[:subjectGeographic_ssim]&.join(", "))
+      expect(about[:place]).to eq(WORK_WITH_PUBLIC_VISIBILITY[:creationPlace_ssim]&.join(", "))
+    end
+  end
+
+  context "with yale only work" do
+    let(:solr_document) { described_class.new(WORK_WITH_YALE_ONLY_VISIBILITY) }
+    it "does not include thumbnail" do
+      schema = solr_document.to_schema_json_ld
+      expect(schema[:thumbnailUrl]).to be_nil
+    end
+  end
+end

--- a/spec/requests/catalog_controller_request_spec.rb
+++ b/spec/requests/catalog_controller_request_spec.rb
@@ -282,4 +282,16 @@ RSpec.describe "/catalog", clean: true, type: :request do
       expect(response.body).to include("You may have mistyped the address or provided an invalid Object ID (#{params[:id]})")
     end
   end
+
+  describe 'GET /catalog/<OID>' do
+    it 'contains schema.org heading' do
+      get "/catalog/#{WORK_WITH_PUBLIC_VISIBILITY[:id]}"
+
+      doc = Nokogiri::HTML::Document.parse(response.body)
+      json = doc.css('script[@type=\'application/ld+json\']')&.first&.text
+      expect(json).not_to be_nil
+      schema = SolrDocument.new(WORK_WITH_PUBLIC_VISIBILITY).to_schema_json_ld&.to_json
+      expect(json.strip).to eq(schema)
+    end
+  end
 end


### PR DESCRIPTION
Adds header with schema.org metadata.

View source of page to see metadata:

![image](https://user-images.githubusercontent.com/32851993/115271831-be0a7280-a10b-11eb-9a03-b4b688c3c6f3.png)

Json Validated at https://search.google.com/structured-data/testing-tool
![image](https://user-images.githubusercontent.com/32851993/115271974-e4c8a900-a10b-11eb-8df1-df9f89459f94.png)
