### PR TITLE
1219 return 404 on invalid pages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,9 +9,7 @@ class ApplicationController < ActionController::Base
   layout :determine_layout if respond_to? :layout
 
   rescue_from Blacklight::Exceptions::RecordNotFound do
-    # redirect_to 'errors#not_found', status: 404
     render template: 'errors/not_found'
-    # render :file => "#{Rails.root}/public/404.html", layout: false, status: :not_found
   end
 
   def landing

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,12 @@ class ApplicationController < ActionController::Base
 
   layout :determine_layout if respond_to? :layout
 
+  rescue_from Blacklight::Exceptions::RecordNotFound do
+    # redirect_to 'errors#not_found', status: 404
+    render template: 'errors/not_found'
+    # render :file => "#{Rails.root}/public/404.html", layout: false, status: :not_found
+  end
+
   def landing
     render layout: false
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,16 +41,21 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
     end
   end
 
-  # Custom error pages
-  get '/404', to: 'errors#not_found', via: :all
-
   get '/check-iiif', to: 'iiif#show', as: :iiif
   get '/pdfs/not_found.html', to: 'pdfs#not_found'
 
-  # Thes routes use wildcards for the ids. They need to be after any other /manifests or /pdfs routes.
+  # Custom error page
+  get '/404', to: 'errors#not_found', via: :all
+
+  # These routes use wildcards for the ids. They need to be after any other /manifests or /pdfs routes.
   get '/manifests/*id', to: 'manifests#show', as: :manifest
   get '/pdfs/*id', to: 'pdfs#show', as: :pdf
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+
+  # Match all unknown paths to the 404 page
+  Rails.application.routes.draw do
+    match '*path' => 'errors#not_found', via: :all
+  end
 
   # Stop throwing 404s on missing map files. This route should be LAST as it will match anything that ends in .map
   get '/*path/*file.map', to: proc { [200, {}, ['']] }

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -3,8 +3,22 @@
 require 'rails_helper'
 
 RSpec.describe 'Errors', type: :request do
-  describe ':not found' do
-    before(:all) { get '/404' }
+  describe ':not_found' do
+    context 'for a 404 page' do
+      before(:all) { get '/404' }
+
+      it 'have an http status of 404' do
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it 'redirect to the custom not_found error page' do
+        expect(response.body).to include("The page you were looking for doesn't exist.")
+      end
+    end
+  end
+
+  context 'for invalid paths' do
+    before(:all) { get '/alpha' }
 
     it 'have an http status of 404' do
       expect(response).to have_http_status(:not_found)


### PR DESCRIPTION
co-author: dylan salay <dylan@notch8.com>

# Ticket
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1219

# Expected behavior
- invalid url's from the root endpoint will show the branded 404 page
- invalid endpoints that come after `/catalog` will still show the branded page with the invalid oid

# Demo
![Screen Shot 2021-04-20 at 12 11 57 PM](https://user-images.githubusercontent.com/29032869/115451181-b90ff680-a1d1-11eb-944e-399a34b88224.png)

# Resources
- https://stackoverflow.com/questions/1013152/one-controller-rendering-using-another-controllers-views