### PR TITLE
Update about property of CreativeWork.  Make property values arrays where appropriate.

### DIFF
--- a/app/models/concerns/schema_org_solr_document.rb
+++ b/app/models/concerns/schema_org_solr_document.rb
@@ -5,10 +5,11 @@ module SchemaOrgSolrDocument
   extend ActiveSupport::Concern
 
   def to_schema_json_ld
+    about_description = [self[:subjectTopic_ssim]&.join(", "), self[:subjectGeographic_ssim]&.join(", ")].compact
+    about_description = nil if about_description.empty?
     about = {
       "name": self[:subjectName_ssim]&.join(", "),
-      "topic": self[:subjectGeographic_ssim]&.join(", "), # @self[:subjectTopic_ssim],
-      "place": self[:creationPlace_ssim]&.join(", ")
+      "description": about_description&.join(", ")
     }.compact
     about = nil if about.empty?
     {

--- a/app/models/concerns/schema_org_solr_document.rb
+++ b/app/models/concerns/schema_org_solr_document.rb
@@ -5,24 +5,23 @@ module SchemaOrgSolrDocument
   extend ActiveSupport::Concern
 
   def to_schema_json_ld
-    about_description = [self[:subjectTopic_ssim]&.join(", "), self[:subjectGeographic_ssim]&.join(", ")].compact
-    about_description = nil if about_description.empty?
-    about = {
-      "name": self[:subjectName_ssim]&.join(", "),
-      "description": about_description&.join(", ")
-    }.compact
-    about = nil if about.empty?
+    about_names = []
+    about_names += self[:subjectName_ssim] if self[:subjectName_ssim]
+    about_names += self[:subjectTopic_ssim] if self[:subjectTopic_ssim]
+    about_names += self[:subjectGeographic_ssim] if self[:subjectGeographic_ssim]
+    about_names.compact!
+    about = { name: about_names } unless about_names.empty?
     {
       "@context": "https://schema.org/",
       "@type": "CreativeWork",
-      "name": self[:title_tesim]&.join(", "),
-      "alternateName": self[:alternativeTitle_tesim]&.join(", "),
-      "description": self[:description_tesim]&.join(", "),
+      "name": self[:title_tesim],
+      "alternateName": self[:alternativeTitle_tesim],
+      "description": self[:description_tesim],
       "url": "https://collections.library.yale.edu/catalog/#{id}",
       "about": about,
-      "genre": self[:genre_ssim]&.join(", "),
-      "materialExtent": self[:extent_ssim]&.join(", "),
-      "temporal": self[:date_ssim]&.join(", "),
+      "genre": self[:genre_ssim],
+      "materialExtent": self[:extent_ssim],
+      "temporal": self[:date_ssim],
       "thumbnailUrl": self[:visibility_ssi] == "Public" && self["thumbnail_path_ss"] || nil
     }.compact
   end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -7,21 +7,22 @@ RSpec.describe SolrDocument, type: :model do
     let(:solr_document) { described_class.new(WORK_WITH_PUBLIC_VISIBILITY) }
     it "creates valid schema.org metadata" do
       schema = solr_document.to_schema_json_ld
+
       expect(schema[:@context]).to eq('https://schema.org/')
       expect(schema[:@type]).to eq('CreativeWork')
 
-      expect(schema[:name]).to eq(WORK_WITH_PUBLIC_VISIBILITY[:title_tesim]&.join(", "))
-      expect(schema[:alternateName]).to eq(WORK_WITH_PUBLIC_VISIBILITY[:alternativeTitle_tesim]&.join(", "))
-      expect(schema[:description]).to eq(WORK_WITH_PUBLIC_VISIBILITY[:description_tesim]&.join(", "))
+      expect(schema[:name]).to eq(WORK_WITH_PUBLIC_VISIBILITY[:title_tesim])
+      expect(schema[:alternateName]).to eq(WORK_WITH_PUBLIC_VISIBILITY[:alternativeTitle_tesim])
+      expect(schema[:description]).to eq(WORK_WITH_PUBLIC_VISIBILITY[:description_tesim])
       expect(schema[:url]).to eq("https://collections.library.yale.edu/catalog/#{WORK_WITH_PUBLIC_VISIBILITY[:id]}")
-      expect(schema[:genre]).to eq(WORK_WITH_PUBLIC_VISIBILITY[:genre_ssim]&.join(", "))
-      expect(schema[:materialExtent]).to eq(WORK_WITH_PUBLIC_VISIBILITY[:extent_ssim]&.join(", "))
-      expect(schema[:temporal]).to eq(WORK_WITH_PUBLIC_VISIBILITY[:date_ssim]&.join(", "))
+      expect(schema[:genre]).to eq(WORK_WITH_PUBLIC_VISIBILITY[:genre_ssim])
+      expect(schema[:materialExtent]).to eq(WORK_WITH_PUBLIC_VISIBILITY[:extent_ssim])
+      expect(schema[:temporal]).to eq(WORK_WITH_PUBLIC_VISIBILITY[:date_ssim])
       expect(schema[:thumbnailUrl]).to eq(WORK_WITH_PUBLIC_VISIBILITY[:thumbnail_path_ss])
 
+      # work because the WORK_WITH_PUBLIC_VISIBILITY record has a value for each of these fields.
       about = schema[:about]
-      expect(about[:name]).to eq(WORK_WITH_PUBLIC_VISIBILITY[:subjectName_ssim]&.join(", "))
-      expect(about[:description]).to eq([WORK_WITH_PUBLIC_VISIBILITY[:subjectTopic_ssim]&.join(", "), WORK_WITH_PUBLIC_VISIBILITY[:subjectGeographic_ssim]&.join(", ")].join(", "))
+      expect(about[:name]).to eq(WORK_WITH_PUBLIC_VISIBILITY[:subjectName_ssim] + WORK_WITH_PUBLIC_VISIBILITY[:subjectTopic_ssim] + WORK_WITH_PUBLIC_VISIBILITY[:subjectGeographic_ssim])
     end
   end
 

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -21,8 +21,7 @@ RSpec.describe SolrDocument, type: :model do
 
       about = schema[:about]
       expect(about[:name]).to eq(WORK_WITH_PUBLIC_VISIBILITY[:subjectName_ssim]&.join(", "))
-      expect(about[:topic]).to eq(WORK_WITH_PUBLIC_VISIBILITY[:subjectGeographic_ssim]&.join(", "))
-      expect(about[:place]).to eq(WORK_WITH_PUBLIC_VISIBILITY[:creationPlace_ssim]&.join(", "))
+      expect(about[:description]).to eq([WORK_WITH_PUBLIC_VISIBILITY[:subjectTopic_ssim]&.join(", "), WORK_WITH_PUBLIC_VISIBILITY[:subjectGeographic_ssim]&.join(", ")].join(", "))
     end
   end
 


### PR DESCRIPTION
Updates schema.org metadata for about property so that it has name and description properties (removes topic and place properties and combines values in description):


e.g.
```
<script type="application/ld+json">
{
  "@context": "https://schema.org/",
  "@type": "CreativeWork",
  "name": [
    "The gold pen used by Lincoln to sign the Emancipation Proclamation in the Executive Mansion, Washington, D.C., 1863 Jan 1"
  ],
  "url": "https://collections.library.yale.edu/catalog/2005512",
  "genre": [
    "Artifacts"
  ],
  "materialExtent": [
    "1 pen + 1 case",
    "17.5 cm."
  ],
  "temporal": [
    "n.d."
  ],
  "thumbnailUrl": "http://localhost:8182/iiif/2/1030368/full/!200,200/0/default.jpg"
}
</script>
```