### PR TITLE
Fixed alignment of "New Search" button

### DIFF
--- a/app/assets/stylesheets/customOverrides/show_page.scss
+++ b/app/assets/stylesheets/customOverrides/show_page.scss
@@ -49,7 +49,6 @@ DEFAULT MOBILE STYLING
 
 .show-buttons {
   justify-self: center;
-  margin-right: 137px;
 }
 
 .show-links {
@@ -216,13 +215,14 @@ h2.yale-restricted-work-text {
 
   .show-buttons {
     justify-self: center;
-    margin-right: 176px;
   }
+
 }
 
 
 @media screen and (min-width: $large_device) {
   .constraints-container {
+    margin-left: 0.5%;
     width: 140%;
     justify-self: center;
     justify-content: space-between;
@@ -265,14 +265,16 @@ h2.yale-restricted-work-text {
 
   .show-buttons {
     justify-self: center;
-    margin-right: 52%;
+  }
+
+  #appliedParams {
+    width: 130%;
   }
 }
 
 
 @media screen and (min-width: $xlarge_device) {
   .constraints-container {
-    margin-left: -1%;
     width: 144%;
     justify-self: center;
     justify-content: space-between;

--- a/app/assets/stylesheets/customOverrides/subheader_users.scss
+++ b/app/assets/stylesheets/customOverrides/subheader_users.scss
@@ -5,7 +5,7 @@ DEFAULT MOBILE STYLING
 .user-subheader {
   margin-left: 15px;
   margin-right: 15px;
-  margin-bottom: 25px;
+  margin-bottom: 10px;
   display: flex;
   border-bottom: .5px solid $light_grey;
   padding-bottom: 6px;

--- a/app/views/catalog/_constraints.html.erb
+++ b/app/views/catalog/_constraints.html.erb
@@ -1,5 +1,5 @@
 <% if Deprecation.silence(Blacklight::RenderConstraintsHelperBehavior) { query_has_constraints? } %>
-  <div id="appliedParams" class="clearfix constraints-container constraints-container-index">
+  <div id="appliedParams" class="row constraints-container constraints-container-index">
     <h2 class="sr searched-heading"><%= t('blacklight.search.search_constraints_header') %></h2>
     <% if params["range"].present? %>
       <% value,label, options = get_date_constraint_params(params, request.url)%>

--- a/app/views/catalog/_previous_next_doc.html.erb
+++ b/app/views/catalog/_previous_next_doc.html.erb
@@ -6,7 +6,7 @@
                           counter: @search_context[:counter].to_i - 1 )
     %>
 
-    <span class="page-info-show">|<%= item_page_entry_info %>|</span>
+    <span class="page-info-show"> | <%= item_page_entry_info %>|</span>
 
     <%= link_to_document(@search_context[:next] , " Next >",class: "page-items-show", counter: @search_context[:counter].to_i + 1) if @search_context[:next] %>
   </div>

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -1,5 +1,5 @@
 <% if current_search_session %>
-  <div id="appliedParams" class="clearfix constraints-container">
+  <div id="appliedParams" class="row constraints-container">
     <div id="showSearchButtons" class="show-buttons" >
       <%= render 'start_over' %>
       <%= link_back_to_catalog class: 'btn btn-primary btn-show convert-to-button', "role" => "button" %>


### PR DESCRIPTION
Co-Authored-By: Tracy MacMath <tracy.macmath@yale.edu>

**Story**

The addition/update of the "New Search" button in https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1218 seems to have an alignment issue where it bumps "Back to Search Results" below instead of on the same line.  This seems to be happening at full screen, not just at reduced breakpoints.  Update this alignment to keep both buttons aligned side-by-side.
![a67f19a0-fc12-4f6d-9bf3-7245f42e1280.png](https://images.zenhubusercontent.com/5e5d4b9fe308104eddc52c88/29a74a97-cebb-49bd-901a-810824eac61e)

**Acceptance**

- [ ] "New Search" and "Back to Search Results" button are aligned side by side as in the "before" image.   



https://user-images.githubusercontent.com/41123693/115457853-02247280-a1f3-11eb-92fc-d77a05d98d95.mov

