### PR TITLE
Modified statement on harmful content

### DIFF
--- a/app/views/application/landing.html.erb
+++ b/app/views/application/landing.html.erb
@@ -101,7 +101,7 @@
       </ul>
       <div id="content-statement">
        <h2>Statement on Potentially Harmful Content</h2>
-       <p>Yale University Library’s collections contain historical and contemporary materials documenting human expression and lived experience. Content may include images or language that library users may find harmful, offensive, or inappropriate. Some of these words or images are now recognized as offensive and unacceptable; some may have been viewed as unacceptable when they were created. Yale University Library staff are engaged in addressing or contextualizing this content and language; for more information, please see the <a href="https://guides.library.yale.edu/specialcollections/statementondescription">Yale Statement on Harmful Language in Archival Description</a>.</p>
+       <p>Yale University Library’s collections contain historical and contemporary materials documenting human expression and lived experience. Content may include images or language that library users may find harmful, offensive, or inappropriate. Some of these words or images are now recognized as offensive and unacceptable; some may have been viewed as unacceptable when they were created. Yale University Library staff are engaged in addressing or contextualizing this content and language; for more information, see the <a href="https://guides.library.yale.edu/specialcollections/statementondescription">Statement on Potentially Harmful Content</a>.</p>
       </div>
     </div>
   </main>


### PR DESCRIPTION
Co-Authored-By: Steve Fox <steve@curationexperts.com>

**Story**
From Alison: As you may recall, and as Rebecca knows, the statement on potentially harmful context at the bottom of http://collections.library.yale.edu/ was pending a link to a full statement on the YUL website when we posted it. The text on the YUL website is now in place. Would it be possible to update the statement on http://collections.library.yale.edu/ accordingly?:

**Acceptance**

- [x] Statement on collections.library.yale.edu homepage is changed to:
Yale University Library’s collections contain historical and contemporary materials documenting human expression and lived experience. Content may include images or language that library users may find harmful, offensive, or inappropriate. Some of these words or images are now recognized as offensive and unacceptable; some may have been viewed as unacceptable when they were created. Yale University Library staff are engaged in addressing or contextualizing this content and language; for more information, see the Statement on Potentially Harmful Content.


- [x] The last five words "Statement...Content" should be a link to https://guides.library.yale.edu/about/statement-on-content

---
Original Design

![Screen Shot 2021-04-21 at 1 28 24 PM](https://user-images.githubusercontent.com/41123693/115595917-7f102480-a2a5-11eb-99f7-c1e95b05c724.png)



Modified Design

![Screen Shot 2021-04-21 at 1 21 28 PM](https://user-images.githubusercontent.com/41123693/115595836-66a00a00-a2a5-11eb-9d02-98266e1ed09c.png)

