### PR TITLE
1047 advanced search link immutable sort

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -49,7 +49,7 @@ class CatalogController < ApplicationController
     # config.document_solr_path = 'get'
 
     # items to show per page, each number in the array represent another option to choose from.
-    # config.per_page = [10,20,50,100]1
+    # config.per_page = [10,20,50,100]
 
     # solr field configuration for search results/index views
     config.index.title_field = 'title_tesim'

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -49,7 +49,7 @@ class CatalogController < ApplicationController
     # config.document_solr_path = 'get'
 
     # items to show per page, each number in the array represent another option to choose from.
-    # config.per_page = [10,20,50,100]
+    # config.per_page = [10,20,50,100]1
 
     # solr field configuration for search results/index views
     config.index.title_field = 'title_tesim'

--- a/app/views/catalog/_per_page_widget.html.erb
+++ b/app/views/catalog/_per_page_widget.html.erb
@@ -1,0 +1,13 @@
+<% if show_sort_and_per_page? and !blacklight_config.per_page.blank? %>
+  <span class="sr-only"><%= t('blacklight.search.per_page.title') %></span>
+  <div id="per_page-dropdown" class="per-page-dropdown btn-group">
+    <button type="button" class="btn btn-outline-secondary dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
+      <%= t(:'blacklight.search.per_page.button_label_html', :count => current_per_page) %> <span class="caret"></span>
+    </button>
+    <div class="dropdown-menu dropdown-menu-right" role="menu">
+      <%- per_page_options_for_select.each do |(label, count)| %>
+        <%= link_to(label, url_for(pristine_search_state.params_for_search(per_page: count)), class: 'dropdown-item', role: 'menuitem') %>
+      <%- end -%>
+    </div>
+  </div>
+<% end %>

--- a/app/views/catalog/_sort_widget.html.erb
+++ b/app/views/catalog/_sort_widget.html.erb
@@ -1,0 +1,13 @@
+<% if show_sort_and_per_page? and active_sort_fields.many? %>
+  <div id="sort-dropdown" class="sort-dropdown btn-group">
+    <button type="button" class="btn btn-outline-secondary dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
+      <%= t('blacklight.search.sort.label_html', :field =>sort_field_label(current_sort_field.key)) %> <span class="caret"></span>
+    </button>
+
+    <div class="dropdown-menu" role="menu">
+      <%- active_sort_fields.each do |sort_key, field_config| %>
+        <%= link_to(sort_field_label(sort_key), url_for(pristine_search_state.params_for_search(sort: sort_key)), class: 'dropdown-item', role: 'menuitem') %>
+      <%- end -%>
+    </div>
+  </div>
+<% end %>

--- a/spec/system/advanced_search_spec.rb
+++ b/spec/system/advanced_search_spec.rb
@@ -127,6 +127,38 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: tr
       end
     end
 
+    it 'maintains search results after changing sort dropdown' do
+      fill_in 'oid_ssi', with: '11607445'
+      click_on 'SEARCH'
+      within '#documents' do
+        expect(page).to     have_content('Record 1')
+        expect(page).not_to have_content('Record 2')
+      end
+      within '#sort-dropdown' do
+        click_on 'Year (ascending)'
+      end
+      within '#documents' do
+        expect(page).to     have_content('Record 1')
+        expect(page).not_to have_content('Record 2')
+      end
+    end
+
+    it 'maintains search results after clicking per page' do
+      fill_in 'oid_ssi', with: '11607445'
+      click_on 'SEARCH'
+      within '#documents' do
+        expect(page).to     have_content('Record 1')
+        expect(page).not_to have_content('Record 2')
+      end
+      within '#per_page-dropdown' do
+        click_on '50'
+      end
+      within '#documents' do
+        expect(page).to     have_content('Record 1')
+        expect(page).not_to have_content('Record 2')
+      end
+    end
+
     it 'clears search results when re-querying' do
       fill_in 'oid_ssi', with: '11607445'
       click_on 'SEARCH'
@@ -165,42 +197,6 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: tr
   end
 
   context 'sorting' do
-    xit 'can sort by date from oldest to newest' do
-      within '#sort' do
-        find("option[value='dateStructured_ssim desc, title_si asc']").click
-      end
-
-      click_on 'SEARCH'
-      within '#documents' do
-        expect(page).to have_content("1.\nRecord 1")
-        expect(page).to have_content("2.\nRecord 2")
-      end
-    end
-
-    xit 'can sort by date from newest to oldest' do
-      within '#sort' do
-        find("option[value='dateStructured_ssim asc, title_si asc']").click
-      end
-
-      click_on 'SEARCH'
-      within '#documents' do
-        expect(page).to have_content("1.\nRecord 2")
-        expect(page).to have_content("2.\nRecord 1")
-      end
-    end
-
-    xit 'can sort by year' do
-      within '#sort' do
-        find("option[value='pub_date_si desc, title_si asc']").click
-      end
-
-      click_on 'SEARCH'
-      within '#documents' do
-        expect(page).to have_content("1.\nRecord 1")
-        expect(page).to have_content("2.\nRecord 2")
-      end
-    end
-
     it 'can sort by title' do
       within '#sort' do
         find("option[value='title_ssim asc, oid_ssi desc']").click


### PR DESCRIPTION
**Story**

When completing an advanced search, you then try to toggle from 10 results per page to 20, it seems to execute a search that brings back every item in the collection. It doesn't seem to be a function of how many results a linked search has, as even ones with more than 10 exhibit the same behavior (http://hdl.handle.net/10079/bibid/3660118).

Additionally, this bug occurs with the sort by function on the page

**Acceptance**
- [ ] Change the function for "sort by" and "per page" to hold the current search result state.