### PR TITLE
Added opengraph support

### DIFF
--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -127,6 +127,14 @@ module BlacklightHelper
     render partial: 'catalog/schema_org_metadata', locals: { metadata: @document.to_schema_json_ld }
   end
 
+  def render_ogp_metadata
+    @document.to_ogp_metadata
+  end
+
+  def html_tag_attributes
+    { lang: I18n.locale, prefix: "og: https://ogp.me/ns#" }
+  end
+
   private
 
   def language_code_to_english(language_code)

--- a/app/models/concerns/ogp_solr_document.rb
+++ b/app/models/concerns/ogp_solr_document.rb
@@ -8,7 +8,7 @@ module OgpSolrDocument
     description = ogp_description
 
     ogp_metadata =
-      { 'og:title': self[:title_tesim].join(', '),
+      { 'og:title': self[:title_tesim]&.join(', '),
         'og:url': "https://collections.library.yale.edu/catalog/#{id}",
         'og:type': 'website',
         'og:description': description,
@@ -30,6 +30,6 @@ module OgpSolrDocument
     description_value += self[:creator_tesim] if self[:creator_tesim]
     description_value += self[:date_ssim] if self[:date_ssim]
     description_value.compact!
-    !description_value.empty? && description_value.join(', ') || nil
+    !description_value.empty? && description_value.join('; ') || nil
   end
 end

--- a/app/models/concerns/ogp_solr_document.rb
+++ b/app/models/concerns/ogp_solr_document.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+# rubocop:disable Metrics/ModuleLength,Metrics/CyclomaticComplexity
+module OgpSolrDocument
+  extend ActiveSupport::Concern
+  include ActionView::Helpers::TagHelper
+
+  def to_ogp_metadata
+    description = ogp_description
+
+    ogp_metadata =
+      { 'og:title': self[:title_tesim].join(', '),
+        'og:url': "https://collections.library.yale.edu/catalog/#{id}",
+        'og:type': 'website',
+        'og:description': description,
+        'og:image': self[:visibility_ssi] == "Public" && self["thumbnail_path_ss"] || nil,
+        'og:image:type': self[:visibility_ssi] == "Public" && 'image/jpeg' || nil }.compact
+
+    meta_tag = []
+    ogp_metadata.each do |key, value|
+      meta_tag << tag.meta({ property: key, content: value })
+    end
+    meta_tag
+  end
+
+  private
+
+  def ogp_description
+    description_value = []
+    description_value += self[:alternativeTitle_tesim] if self[:alternativeTitle_tesim]
+    description_value += self[:creator_tesim] if self[:creator_tesim]
+    description_value += self[:date_ssim] if self[:date_ssim]
+    description_value.compact!
+    !description_value.empty? && description_value.join(', ') || nil
+  end
+end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -6,6 +6,7 @@ class SolrDocument
   include Blacklight::Gallery::OpenseadragonSolrDocument
   include ModsSolrDocument
   include SchemaOrgSolrDocument
+  include OgpSolrDocument
 
   # # The following shows how to setup this blacklight document to display marc documents
   # extension_parameters[:marc_source_field] = :marc_ss

--- a/app/views/catalog/_show_main_content.html.erb
+++ b/app/views/catalog/_show_main_content.html.erb
@@ -2,6 +2,7 @@
 <% content_for(:head) do -%>
   <%= render_link_rel_alternates %>
   <%= render_schema_org_metadata %>
+  <%= safe_join(render_ogp_metadata, "\n") %>
 <% end %>
 
 <div id="document" class="document <%= render_document_class %>" itemscope  itemtype="<%= @document.itemtype %>">

--- a/spec/system/show_page_spec.rb
+++ b/spec/system/show_page_spec.rb
@@ -32,7 +32,10 @@ RSpec.describe 'Show Page', type: :system, js: true, clean: true do
       genre_ssim: 'Maps',
       resourceType_ssim: 'Maps, Atlases & Globes',
       creator_ssim: ['Anna Elizabeth Dewdney'],
-      child_oids_ssim: [112, 113]
+      creator_tesim: ['Anna Elizabeth Dewdney'],
+      child_oids_ssim: [112, 113],
+      oid_ssi: 111,
+      thumbnail_path_ss: 'https://this/is/an/image'
     }
   end
 
@@ -100,6 +103,21 @@ RSpec.describe 'Show Page', type: :system, js: true, clean: true do
     }
   end
 
+  let(:train) do
+    {
+      id: '555',
+      title_tesim: ['The Boiler Makers'],
+      format: 'text',
+      language_ssim: 'fr',
+      visibility_ssi: 'Yale Community Only',
+      genre_ssim: 'Animation',
+      resourceType_ssim: 'Archives or Manuscripts',
+      creator_ssim: ['France A. Cordova'],
+      oid_ssi: 555,
+      thumbnail_path_ss: 'https://this/is/an/image'
+    }
+  end
+
   it 'has expected css' do
     expect(page).to have_css '.btn-show'
     expect(page).to have_css '.constraints-container'
@@ -139,6 +157,30 @@ RSpec.describe 'Show Page', type: :system, js: true, clean: true do
         src = find('.universal-viewer-iframe')['src']
         expect(src).to include '&cv=0'
       end
+    end
+  end
+
+  context 'with public works' do
+    it 'Metadata og tags are in the header of html' do
+      expect(page).to have_css("meta[property='og:title'][content='Amor Llama']", visible: false)
+      expect(page).to have_css("meta[property='og:url'][content='https://collections.library.yale.edu/catalog/111']", visible: false)
+      expect(page).to have_css("meta[property='og:type'][content='website']", visible: false)
+      expect(page).to have_css("meta[property='og:description'][content='Anna Elizabeth Dewdney']", visible: false)
+      expect(page).to have_css("meta[property='og:image'][content='https://this/is/an/image']", visible: false)
+      expect(page).to have_css("meta[property='og:image:type'][content='image/jpeg']", visible: false)
+    end
+    it 'has og namespace' do
+      expect(page).to have_css("html[prefix='og: https://ogp.me/ns#']", visible: false)
+    end
+  end
+
+  context 'with yale-only works' do
+    before do
+      visit 'catalog/555'
+    end
+    it 'does not have image of og tag' do
+      expect(page).not_to have_css("meta[property='og:image'][content='https://this/is/an/image']", visible: false)
+      expect(page).not_to have_css("meta[property='og:image:type'][content='image/jpeg']", visible: false)
     end
   end
 end


### PR DESCRIPTION
Co-Authored-By: Martin Lovell <martin.lovell@yale.edu>

**Story**

As a user, I'd like links to the site to display properly when pasted into Facebook.   Use OpenGraph to accomplish this: https://ogp.me

**Acceptance**
- Tags are present on an object page
  - [x] `og:title` contains the title
  - [x] `og:url` is the page URL
  - [x] `og:type` is `website`
  - [x] `og:description` contains the alternative title, creator, and publication date
  - [x] Image tags, if the object visibility is `Public`:
   - [x] `og:image` has a link to the thumbnail image JPEG
   - [x] `og:image:type` has the mime type `image/jpeg`
- [x] `og` namespaces defined in the `<html>` element (if required)
  
----
Namespace: 
![Screen Shot 2021-04-23 at 1.37.20 PM.png](https://images.zenhubusercontent.com/5e6013c029e314c92afd4769/d37ca1a7-6c09-4652-a49d-03d17c86f8ae)

Object page tags:
![Screen Shot 2021-04-23 at 1 54 44 PM](https://user-images.githubusercontent.com/41123693/115911248-dc3dde80-a43b-11eb-97ef-0ffa763f7e5b.png)
