### PR TITLE
1173 add language code to oai mods and change dc language to use code

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -492,7 +492,7 @@ class CatalogController < ApplicationController
         title: 'title_tesim',
         creator: 'creator_ssim',
         date: 'date_ssim',
-        language: 'language_ssim',
+        language: 'languageCode_ssim',
         description: %w[abstract_tesim description_tesim],
         format: 'format'
       }

--- a/app/models/concerns/mods_solr_document.rb
+++ b/app/models/concerns/mods_solr_document.rb
@@ -25,9 +25,10 @@ module ModsSolrDocument
           self[:format_tesim].select { |format| valid_formats.any? { |f| f.include?(format.downcase) } }.each { |type_resource| xml['mods'].typeOfResource type_resource.to_s }
         end
         self[:rights_ssim]&.each { |access_condition| xml['mods'].accessCondition({ type: 'restriction on access' }, access_condition.to_s) }
-        if self[:language_ssim]
+        if self[:language_ssim] || self[:languageCode_ssim]
           xml['mods'].language do
             self[:language_ssim]&.each { |language| xml['mods'].languageTerm({ type: 'text' }, language.to_s) }
+            self[:languageCode_ssim]&.each { |language_code| xml['mods'].languageTerm({ type: 'code', authority: 'iso639-2b' }, language_code.to_s) }
           end
         end
         if self[:creatorDisplay_tsim]

--- a/spec/requests/catalog_controller_request_spec.rb
+++ b/spec/requests/catalog_controller_request_spec.rb
@@ -120,8 +120,13 @@ RSpec.describe "/catalog", clean: true, type: :request do
       end
 
       it 'returns properly formatted language_ssim with GetRecord' do
-        language = xml.xpath('//mods:language/mods:languageTerm', ns_hash).first
+        language = xml.xpath('//mods:language/mods:languageTerm[@type=\'text\']', ns_hash).first
         expect(language.text).to eq(WORK_WITH_PUBLIC_VISIBILITY[:language_ssim].first)
+      end
+
+      it 'returns properly formatted languageCode_ssim with GetRecord' do
+        language = xml.xpath('//mods:language/mods:languageTerm[@type=\'code\']', ns_hash).first
+        expect(language.text).to eq(WORK_WITH_PUBLIC_VISIBILITY[:languageCode_ssim].first)
       end
 
       it 'returns properly formatted creatorDisplay_tsim with GetRecord' do

--- a/spec/requests/catalog_controller_request_spec.rb
+++ b/spec/requests/catalog_controller_request_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe "/catalog", clean: true, type: :request do
 
   def ns_hash
     { 'mods' => 'http://www.loc.gov/mods/v3',
-      'xlink' => "http://www.w3.org/1999/xlink" }
+      'xlink' => "http://www.w3.org/1999/xlink",
+      'dc' => "http://purl.org/dc/elements/1.1/" }
   end
 
   describe 'GET /oai?verb=ListRecords&metadataPrefix=oai_mods' do
@@ -280,6 +281,17 @@ RSpec.describe "/catalog", clean: true, type: :request do
         url_thumb = xml.xpath('//location/url[@access=\'preview\']', ns_hash).attr("href")
         expect(url_thumb.text).to eq(WORK_WITH_PUBLIC_VISIBILITY[:thumbnail_path_ss])
       end
+    end
+  end
+
+  context 'use GetRecord for dublin core' do
+    let(:xml) { Nokogiri::XML(response.body) }
+    before do
+      get "/catalog/oai?verb=GetRecord&metadataPrefix=oai_dc&identifier=oai:collections.library.yale.edu:#{WORK_WITH_PUBLIC_VISIBILITY[:id]}"
+    end
+
+    it "uses the language code for Language" do
+      expect(xml.xpath('//dc:language', ns_hash).text).to eq('eng')
     end
   end
 

--- a/spec/support/solr_documents/metadata_cloud_with_visibility.rb
+++ b/spec/support/solr_documents/metadata_cloud_with_visibility.rb
@@ -9,6 +9,7 @@ WORK_WITH_PUBLIC_VISIBILITY = {
   "format": ["text"],
   "format_tesim": ["text"],
   "language_ssim": ["English"],
+  "languageCode_ssim": ["eng"],
   "description_tesim": ["Four volume printer's proof with manuscript notes throughout."],
   "abstract_tesim": ["Published on April 15, 1755 and written largely single-handedly by Samuel Johnson. Sometimes published as \"Johnson's Dictionary.\" The first edition was published in two folio volumes; later editions were published in four volumes."],
   "accessRestrictions_tesim": ["public"],


### PR DESCRIPTION
Reindex is required to add languageCode to the solr index.

For Dublin Code, languageCode_ssim is used _**instead**_ of language_ssim.  There doesn't seem to be an easy way to have dublin core first try languageCode_ssim and fall back to language_ssim if languageCode_ssim is not available.

See: https://github.com/projectblacklight/blacklight/blob/master/app/models/concerns/blacklight/document/semantic_fields.rb#L36

