### PR TITLE
Fixed text alignment on the toolbar

### DIFF
--- a/app/assets/stylesheets/customOverrides/show_page.scss
+++ b/app/assets/stylesheets/customOverrides/show_page.scss
@@ -28,7 +28,7 @@ DEFAULT MOBILE STYLING
 .show-tools .list-group {
   flex-direction: row;
   flex-wrap: wrap;
-  padding-left: 15px;
+  margin-left: -1%;
 }
 
 .list-group-item {
@@ -89,7 +89,7 @@ DEFAULT MOBILE STYLING
 }
 
 .show-tools a.nav-link, .show-tools span.nav-link {
-  padding: 0.5rem 0.25rem;
+  padding: 0.5rem 0.25rem 1rem;
 }
 
 #citationLink:after, #manifestLink:after, #miradorLink:after, #pdfLink:after {
@@ -180,6 +180,9 @@ DEFAULT MOBILE STYLING
 
 h2.yale-restricted-work-text {
   font-size: 1.5em;
+}
+.tools-text-format{
+  margin-left: -3%;
 }
 
 @media screen and (min-width: $medium_device) {
@@ -272,6 +275,10 @@ h2.yale-restricted-work-text {
     justify-self: center;
   }
 
+  .tools-text-format{
+    margin-left: -2.5%;
+  }
+
   .item-page__tools-wrapper{
     max-width: 740px;
     margin-left: 19%;
@@ -328,5 +335,12 @@ h2.yale-restricted-work-text {
   .item-page__tools-wrapper{
     max-width: 890px;
     min-width: 880px;
+  }
+
+  .tools-text-format{
+    margin-left: -2.25%;
+  }
+  .show-tools.list-group{
+    margin-left: -0.5%;
   }
 }

--- a/app/views/catalog/_show_tools.html.erb
+++ b/app/views/catalog/_show_tools.html.erb
@@ -1,7 +1,7 @@
 <% if show_doc_actions? %>
     <div class="card show-tools item-page__tools-wrapper">
         <div class="card-header">
-            <h2 class="mb-0 h6"><%= t('blacklight.tools.title') %></h2>
+            <h2 class="mb-0 h6 tools-text-format"><%= t('blacklight.tools.title') %></h2>
         </div>
 
         <ul class="list-group list-group-flush">


### PR DESCRIPTION
![image.png](https://images.zenhubusercontent.com/5e6013c029e314c92afd4769/e39e5e17-63c8-44ba-9ec8-17f3fad67e37)

Acceptance
- [x] Align "Tools" text with gray line
- [x] Align "Cite >" text with gray line

-----
**Desired Alignment**

![ToolbarTextAlignment](https://user-images.githubusercontent.com/41123693/116460878-8ef3af80-a835-11eb-8ff7-77cbdcf58a84.gif)

