### PR TITLE
Fix the use of subject as a search field

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -381,12 +381,12 @@ class CatalogController < ApplicationController
     # Specifying a :qt only to show it's possible, and so our internal automated
     # tests can test it. In this case it's the same as
     # config[:default_solr_parameters][:qt], so isn't actually neccesary.
-    config.add_search_field('subjectName_ssim', label: 'Subject') do |field|
+    config.add_search_field('subjectName_tesim', label: 'Subject') do |field|
       field.qt = 'search'
       field.include_in_advanced_search = false
       field.solr_parameters = {
-        qf: '',
-        pf: 'subjectName_ssim'
+        qf: 'subjectName_tesim',
+        pf: ''
       }
     end
 

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe CatalogController, type: :controller do
          "genre_fields",
          "oid_ssi",
          "orbisBibId_ssi",
-         "subjectName_ssim",
+         "subjectName_tesim",
          "subject_fields",
          "title_tesim"]
       end

--- a/spec/system/search_fields_spec.rb
+++ b/spec/system/search_fields_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Search results displays field', type: :system, clean: true, js: 
   let(:search_fields) { CatalogController.blacklight_config.search_fields.keys }
   let(:expected_search_fields) do
     ["all_fields", "all_fields_advanced", "creator_tesim", "child_oids_ssim", "date_fields", "genre_fields",
-     "callNumber_tesim", "oid_ssi", "orbisBibId_ssi", "subjectName_ssim", "subject_fields", "title_tesim"]
+     "callNumber_tesim", "oid_ssi", "orbisBibId_ssi", "subjectName_tesim", "subject_fields", "title_tesim"]
   end
 
   let(:dog) do
@@ -20,9 +20,9 @@ RSpec.describe 'Search results displays field', type: :system, clean: true, js: 
       id: '111',
       title_tesim: 'Handsome Dan is a bull dog.',
       creator_tesim: 'Eric & Frederick',
-      subjectName_ssim: "this is the subject name",
+      subjectName_tesim: "this is the subject name",
       sourceTitle_tesim: "this is the source title",
-      callNumber_tesim: 'WA MSS 987',
+      callNumber_tesim: 'WAMSS987',
       orbisBibId_ssi: '1238901',
       visibility_ssi: 'Public'
     }
@@ -35,6 +35,7 @@ RSpec.describe 'Search results displays field', type: :system, clean: true, js: 
       creator_tesim: 'Frederick & Eric',
       sourceTitle_tesim: "this is the source title",
       orbisBibId_ssi: '1234567',
+      subjectName_tesim: "WAMSS987",
       callNumber_tesim: 'Yale MS 123',
       visibility_ssi: 'Public'
     }
@@ -45,31 +46,37 @@ RSpec.describe 'Search results displays field', type: :system, clean: true, js: 
       expect(search_fields).to contain_exactly(*expected_search_fields)
     end
 
-    it 'contains displays the correct record when searching by call number' do
-      visit '/catalog?search_field=callNumber_tesim&q=WA+MSS+987'
+    it 'displays the correct record when searching by call number' do
+      visit '/catalog?search_field=callNumber_tesim&q=WAMSS987'
       expect(page).to have_content 'Handsome Dan is a bull dog.'
       expect(page).not_to have_content 'Handsome Dan is not a cat.'
     end
 
-    it 'contains displays the correct record when searching by BibId' do
+    it 'displays the correct record when searching by BibId' do
       visit '/catalog?search_field=orbisBibId_ssi&q=1238901'
       expect(page).to have_content 'Handsome Dan is a bull dog.'
       expect(page).not_to have_content 'Handsome Dan is not a cat.'
     end
 
-    it 'contains displays the correct record when searching by creator' do
+    it 'displays the correct record when searching by creator' do
       visit '/catalog?search_field=creator&q=Eric'
       expect(page).to have_content 'Handsome Dan is a bull dog.'
       expect(page).to have_content 'Handsome Dan is not a cat.'
     end
 
-    it 'contains displays the correct record when searching by subject' do
-      visit '/catalog?search_field=subjectName_ssim&q=this+is+the+subject+name'
+    it 'displays the correct record when searching by subject' do
+      visit '/catalog?search_field=subjectName_tesim&q=this+is+the+subject+name'
       expect(page).to have_content 'Handsome Dan is a bull dog.'
       expect(page).not_to have_content 'Handsome Dan is not a cat.'
     end
 
-    it 'contains displays the correct record when searching by title' do
+    it 'displays the correct record when searching by a subject name that appears in call number' do
+      visit '/catalog?search_field=subjectName_tesim&q=WAMSS987'
+      expect(page).not_to have_content 'Handsome Dan is a bull dog.'
+      expect(page).to have_content 'Handsome Dan is not a cat.'
+    end
+
+    it 'displays the correct record when searching by title' do
       visit '/catalog?search_field=title_tesim&q=handsome'
       expect(page).to have_content 'Handsome Dan is a bull dog.'
       expect(page).to have_content 'Handsome Dan is not a cat.'


### PR DESCRIPTION
yalelibrary/YUL-DC#1275

*Story**

Searches on Subject appears to return too many results.   I can return results for a match on Call Number using a Subject search:
https://collections.library.yale.edu/catalog?search_field=subjectName_ssim&q=landberg. Results like this one seem only to match the record's Call Number:
![Screen Shot 2021-05-07 at 7.19.53 PM.png](https://images.zenhubusercontent.com/5e5d472f410278efd81466ab/28b291c9-bd50-4dae-8583-18ce8e43b27d)*

**Acceptance**
- [x] Identify which specific searches exhibit this issue (is it only Subject?)
- [x] Restrict the searches to the correct field