### PR TITLE
1303 access control for iiif search

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -6,6 +6,8 @@ class CatalogController < ApplicationController
   include Blacklight::Marc::Catalog
   include BlacklightRangeLimit::ControllerOverride
   include AccessHelper
+  include CheckAuthorization
+  before_action :check_authorization, only: [:iiif_search, :iiif_suggest]
   before_action :determine_per_page
   helper_method :gallery_view?
 
@@ -528,6 +530,11 @@ class CatalogController < ApplicationController
         format: 'format'
       }
     )
+  end
+
+  # This is for iiif_search
+  def search_for_item
+    search_service.fetch(params[:solr_document_id])
   end
 
   def gallery_view?

--- a/app/controllers/concerns/check_authorization.rb
+++ b/app/controllers/concerns/check_authorization.rb
@@ -4,10 +4,6 @@ module CheckAuthorization
   extend ActiveSupport::Concern
   include AccessHelper
 
-  included do
-    before_action :check_authorization
-  end
-
   def check_authorization
     # checking authorization
     Rails.logger.warn("starting authorization check for #{request.env['HTTP_X_ORIGIN_URI']}")

--- a/app/controllers/iiif_controller.rb
+++ b/app/controllers/iiif_controller.rb
@@ -5,6 +5,9 @@ class IiifController < ApplicationController
   include Blacklight::Catalog
   include CheckAuthorization
 
+  before_action :check_authorization
+
+
   def show
     render plain: 'success', status: 200
   end

--- a/app/controllers/iiif_controller.rb
+++ b/app/controllers/iiif_controller.rb
@@ -7,7 +7,6 @@ class IiifController < ApplicationController
 
   before_action :check_authorization
 
-
   def show
     render plain: 'success', status: 200
   end

--- a/app/controllers/manifests_controller.rb
+++ b/app/controllers/manifests_controller.rb
@@ -5,6 +5,8 @@ class ManifestsController < ApplicationController
   include Blacklight::Catalog
   include CheckAuthorization
 
+  before_action :check_authorization
+
   def show
     remote_path = pairtree_path
     response.set_header('Access-Control-Allow-Origin', '*')

--- a/app/controllers/pdfs_controller.rb
+++ b/app/controllers/pdfs_controller.rb
@@ -6,6 +6,8 @@ class PdfsController < ApplicationController
   include Blacklight::Catalog
   include CheckAuthorization
 
+  before_action :check_authorization
+
   def show
     send_pdf
   end

--- a/spec/system/access_restrictions_spec.rb
+++ b/spec/system/access_restrictions_spec.rb
@@ -62,6 +62,21 @@ RSpec.describe "access restrictions", type: :system, clean: true do
       expect(page.html).not_to have_content("[Map of China]. [private copy]")
       expect(page).to have_http_status(:unauthorized)
     end
+
+    it 'does allow iiif_search for public works' do
+      visit solr_document_iiif_search_path(public_work[:id], {q: 'blacklight'})
+      expect(page).to have_http_status(200)
+    end
+  
+    it 'does NOT allow iiif_search for yale-only works' do
+      visit solr_document_iiif_search_path(yale_work[:id], {q: 'blacklight'})
+      expect(page).to have_http_status(:unauthorized)
+    end
+  
+    it 'does NOT allow iiif_search for private works' do
+      visit solr_document_iiif_search_path(private_work[:id], {q: 'blacklight'})
+      expect(page).to have_http_status(:unauthorized)
+    end
   end
 
   context "an authenticated user" do
@@ -91,6 +106,21 @@ RSpec.describe "access restrictions", type: :system, clean: true do
       visit solr_document_path(private_work[:id])
       expect(page.html).not_to match(/universal-viewer-iframe/)
       expect(page.html).not_to have_content("[Map of China]. [private copy]")
+      expect(page).to have_http_status(:unauthorized)
+    end
+
+    it 'does allow iiif_search for public works' do
+      visit solr_document_iiif_search_path(public_work[:id], {q: 'blacklight'})
+      expect(page).to have_http_status(200)
+    end
+  
+    it 'does allow iiif_search for yale-only works' do
+      visit solr_document_iiif_search_path(yale_work[:id], {q: 'blacklight'})
+      expect(page).to have_http_status(200)
+    end
+  
+    it 'does NOT allow iiif_search for private works' do
+      visit solr_document_iiif_search_path(private_work[:id], {q: 'blacklight'})
       expect(page).to have_http_status(:unauthorized)
     end
   end
@@ -130,6 +160,21 @@ RSpec.describe "access restrictions", type: :system, clean: true do
       visit solr_document_path(private_work[:id])
       expect(page.html).not_to match(/universal-viewer-iframe/)
       expect(page.html).not_to have_content("[Map of China]. [private copy]")
+      expect(page).to have_http_status(:unauthorized)
+    end
+
+    it 'does allow iiif_search for public works' do
+      visit solr_document_iiif_search_path(public_work[:id], {q: 'blacklight'})
+      expect(page).to have_http_status(200)
+    end
+  
+    it 'does allow iiif_search for yale-only works' do
+      visit solr_document_iiif_search_path(yale_work[:id], {q: 'blacklight'})
+      expect(page).to have_http_status(200)
+    end
+  
+    it 'does NOT allow iiif_search for private works' do
+      visit solr_document_iiif_search_path(private_work[:id], {q: 'blacklight'})
       expect(page).to have_http_status(:unauthorized)
     end
   end

--- a/spec/system/access_restrictions_spec.rb
+++ b/spec/system/access_restrictions_spec.rb
@@ -77,6 +77,21 @@ RSpec.describe "access restrictions", type: :system, clean: true do
       visit solr_document_iiif_search_path(private_work[:id], {q: 'blacklight'})
       expect(page).to have_http_status(:unauthorized)
     end
+  
+    xit 'does allow iiif_suggest for public works' do
+      visit solr_document_iiif_suggest_path(public_work[:id], {q: 'blacklight'})
+      expect(page).to have_http_status(200)
+    end
+  
+    xit 'does NOT allow iiif_suggest for yale-only works' do
+      visit solr_document_iiif_suggest_path(yale_work[:id], {q: 'blacklight'})
+      expect(page).to have_http_status(:unauthorized)
+    end
+  
+    xit 'does NOT allow iiif_suggest for private works' do
+      visit solr_document_iiif_suggest_path(private_work[:id], {q: 'blacklight'})
+      expect(page).to have_http_status(:unauthorized)
+    end
   end
 
   context "an authenticated user" do
@@ -121,6 +136,21 @@ RSpec.describe "access restrictions", type: :system, clean: true do
   
     it 'does NOT allow iiif_search for private works' do
       visit solr_document_iiif_search_path(private_work[:id], {q: 'blacklight'})
+      expect(page).to have_http_status(:unauthorized)
+    end
+
+    xit 'does allow iiif_suggest for public works' do
+      visit solr_document_iiif_suggest_path(public_work[:id], {q: 'blacklight'})
+      expect(page).to have_http_status(200)
+    end
+  
+    xit 'does allow iiif_suggest for yale-only works' do
+      visit solr_document_iiif_suggest_path(yale_work[:id], {q: 'blacklight'})
+      expect(page).to have_http_status(200)
+    end
+  
+    xit 'does NOT allow iiif_suggest for private works' do
+      visit solr_document_iiif_suggest_path(private_work[:id], {q: 'blacklight'})
       expect(page).to have_http_status(:unauthorized)
     end
   end
@@ -175,6 +205,21 @@ RSpec.describe "access restrictions", type: :system, clean: true do
   
     it 'does NOT allow iiif_search for private works' do
       visit solr_document_iiif_search_path(private_work[:id], {q: 'blacklight'})
+      expect(page).to have_http_status(:unauthorized)
+    end
+
+    xit 'does allow iiif_suggest for public works' do
+      visit solr_document_iiif_suggest_path(public_work[:id], {q: 'blacklight'})
+      expect(page).to have_http_status(200)
+    end
+  
+    xit 'does allow iiif_suggest for yale-only works' do
+      visit solr_document_iiif_suggest_path(yale_work[:id], {q: 'blacklight'})
+      expect(page).to have_http_status(200)
+    end
+  
+    xit 'does NOT allow iiif_suggest for private works' do
+      visit solr_document_iiif_suggest_path(private_work[:id], {q: 'blacklight'})
       expect(page).to have_http_status(:unauthorized)
     end
   end

--- a/spec/system/access_restrictions_spec.rb
+++ b/spec/system/access_restrictions_spec.rb
@@ -64,32 +64,32 @@ RSpec.describe "access restrictions", type: :system, clean: true do
     end
 
     it 'does allow iiif_search for public works' do
-      visit solr_document_iiif_search_path(public_work[:id], {q: 'blacklight'})
-      expect(page).to have_http_status(200)
+      visit solr_document_iiif_search_path(public_work[:id], { q: 'blacklight' })
+      expect(page).to have_http_status(:ok)
     end
-  
+
     it 'does NOT allow iiif_search for yale-only works' do
-      visit solr_document_iiif_search_path(yale_work[:id], {q: 'blacklight'})
+      visit solr_document_iiif_search_path(yale_work[:id], { q: 'blacklight' })
       expect(page).to have_http_status(:unauthorized)
     end
-  
+
     it 'does NOT allow iiif_search for private works' do
-      visit solr_document_iiif_search_path(private_work[:id], {q: 'blacklight'})
+      visit solr_document_iiif_search_path(private_work[:id], { q: 'blacklight' })
       expect(page).to have_http_status(:unauthorized)
     end
-  
+
     xit 'does allow iiif_suggest for public works' do
-      visit solr_document_iiif_suggest_path(public_work[:id], {q: 'blacklight'})
-      expect(page).to have_http_status(200)
+      visit solr_document_iiif_suggest_path(public_work[:id], { q: 'blacklight' })
+      expect(page).to have_http_status(:ok)
     end
-  
+
     xit 'does NOT allow iiif_suggest for yale-only works' do
-      visit solr_document_iiif_suggest_path(yale_work[:id], {q: 'blacklight'})
+      visit solr_document_iiif_suggest_path(yale_work[:id], { q: 'blacklight' })
       expect(page).to have_http_status(:unauthorized)
     end
-  
+
     xit 'does NOT allow iiif_suggest for private works' do
-      visit solr_document_iiif_suggest_path(private_work[:id], {q: 'blacklight'})
+      visit solr_document_iiif_suggest_path(private_work[:id], { q: 'blacklight' })
       expect(page).to have_http_status(:unauthorized)
     end
   end
@@ -125,32 +125,32 @@ RSpec.describe "access restrictions", type: :system, clean: true do
     end
 
     it 'does allow iiif_search for public works' do
-      visit solr_document_iiif_search_path(public_work[:id], {q: 'blacklight'})
-      expect(page).to have_http_status(200)
+      visit solr_document_iiif_search_path(public_work[:id], { q: 'blacklight' })
+      expect(page).to have_http_status(:ok)
     end
-  
+
     it 'does allow iiif_search for yale-only works' do
-      visit solr_document_iiif_search_path(yale_work[:id], {q: 'blacklight'})
-      expect(page).to have_http_status(200)
+      visit solr_document_iiif_search_path(yale_work[:id], { q: 'blacklight' })
+      expect(page).to have_http_status(:ok)
     end
-  
+
     it 'does NOT allow iiif_search for private works' do
-      visit solr_document_iiif_search_path(private_work[:id], {q: 'blacklight'})
+      visit solr_document_iiif_search_path(private_work[:id], { q: 'blacklight' })
       expect(page).to have_http_status(:unauthorized)
     end
 
     xit 'does allow iiif_suggest for public works' do
-      visit solr_document_iiif_suggest_path(public_work[:id], {q: 'blacklight'})
-      expect(page).to have_http_status(200)
+      visit solr_document_iiif_suggest_path(public_work[:id], { q: 'blacklight' })
+      expect(page).to have_http_status(:ok)
     end
-  
+
     xit 'does allow iiif_suggest for yale-only works' do
-      visit solr_document_iiif_suggest_path(yale_work[:id], {q: 'blacklight'})
-      expect(page).to have_http_status(200)
+      visit solr_document_iiif_suggest_path(yale_work[:id], { q: 'blacklight' })
+      expect(page).to have_http_status(:ok)
     end
-  
+
     xit 'does NOT allow iiif_suggest for private works' do
-      visit solr_document_iiif_suggest_path(private_work[:id], {q: 'blacklight'})
+      visit solr_document_iiif_suggest_path(private_work[:id], { q: 'blacklight' })
       expect(page).to have_http_status(:unauthorized)
     end
   end
@@ -194,32 +194,32 @@ RSpec.describe "access restrictions", type: :system, clean: true do
     end
 
     it 'does allow iiif_search for public works' do
-      visit solr_document_iiif_search_path(public_work[:id], {q: 'blacklight'})
-      expect(page).to have_http_status(200)
+      visit solr_document_iiif_search_path(public_work[:id], { q: 'blacklight' })
+      expect(page).to have_http_status(:ok)
     end
-  
+
     it 'does allow iiif_search for yale-only works' do
-      visit solr_document_iiif_search_path(yale_work[:id], {q: 'blacklight'})
-      expect(page).to have_http_status(200)
+      visit solr_document_iiif_search_path(yale_work[:id], { q: 'blacklight' })
+      expect(page).to have_http_status(:ok)
     end
-  
+
     it 'does NOT allow iiif_search for private works' do
-      visit solr_document_iiif_search_path(private_work[:id], {q: 'blacklight'})
+      visit solr_document_iiif_search_path(private_work[:id], { q: 'blacklight' })
       expect(page).to have_http_status(:unauthorized)
     end
 
     xit 'does allow iiif_suggest for public works' do
-      visit solr_document_iiif_suggest_path(public_work[:id], {q: 'blacklight'})
-      expect(page).to have_http_status(200)
+      visit solr_document_iiif_suggest_path(public_work[:id], { q: 'blacklight' })
+      expect(page).to have_http_status(:ok)
     end
-  
+
     xit 'does allow iiif_suggest for yale-only works' do
-      visit solr_document_iiif_suggest_path(yale_work[:id], {q: 'blacklight'})
-      expect(page).to have_http_status(200)
+      visit solr_document_iiif_suggest_path(yale_work[:id], { q: 'blacklight' })
+      expect(page).to have_http_status(:ok)
     end
-  
+
     xit 'does NOT allow iiif_suggest for private works' do
-      visit solr_document_iiif_suggest_path(private_work[:id], {q: 'blacklight'})
+      visit solr_document_iiif_suggest_path(private_work[:id], { q: 'blacklight' })
       expect(page).to have_http_status(:unauthorized)
     end
   end


### PR DESCRIPTION
Ticket: https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1303

This PR implements access control for iiif searches.