### PR TITLE
1317 fulltext snippet separation

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -174,7 +174,7 @@ class CatalogController < ApplicationController
     config.add_index_field 'sourceTitle_tesim', label: 'Collection Title', highlight: true
     config.add_index_field 'imageCount_isi', label: 'Image Count'
     config.add_index_field 'resourceType_tesim', label: 'Resource Type', highlight: true
-    config.add_index_field 'fulltext_tsim', label: 'Full Text', highlight: true, solr_params: disp_highlight_on_search_params.merge({ 'hl.snippets': 4 })
+    config.add_index_field 'fulltext_tsim', label: 'Full Text', highlight: true, solr_params: disp_highlight_on_search_params.merge({ 'hl.snippets': 4 }), helper_method: :fulltext_snippet_separation
     config.add_index_field 'abstract_tesim', label: 'Abstract', highlight: true, solr_params: disp_highlight_on_search_params
     config.add_index_field 'alternativeTitle_tesim', label: 'Alternative Title', highlight: true, solr_params: disp_highlight_on_search_params
     config.add_index_field 'description_tesim', label: 'Description', highlight: true, solr_params: disp_highlight_on_search_params

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -138,7 +138,8 @@ module BlacklightHelper
   def fulltext_snippet_separation(options = {})
     # Some snippets come back with new lines embedded without them. We don't want that.
     # We do however want new lines after a snippet, to show separation
-    snippets_without_new_lines = options[:value].map { |snippet| snippet.gsub(/\n/, ' ') }
+    # the "tr" below has to use double quotes, otherwise it will remove the character 'n', instead of new line notations
+    snippets_without_new_lines = options[:value].map { |snippet| snippet.tr("\n", ' ') }
     snippets_separated_by_line_break = snippets_without_new_lines.join('<br><br>')
 
     simple_format(snippets_separated_by_line_break)

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -140,7 +140,7 @@ module BlacklightHelper
     # We do however want new lines after a snippet, to show separation
     # the "tr" below has to use double quotes, otherwise it will remove the character 'n', instead of new line notations
     snippets_without_new_lines = options[:value].map { |snippet| snippet.tr("\n", ' ') }
-    snippets_separated_by_line_break = snippets_without_new_lines.join('<br><br>')
+    snippets_separated_by_line_break = snippets_without_new_lines.join('<br>')
 
     simple_format(snippets_separated_by_line_break)
   end

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -135,6 +135,13 @@ module BlacklightHelper
     { lang: I18n.locale, prefix: "og: https://ogp.me/ns#" }
   end
 
+  def fulltext_snippet_separation(options = {})
+    snippets_without_new_lines = options[:value].map { |snippet| snippet.gsub(/\n/, ' ') }
+    snippets_separated_by_line_break = snippets_without_new_lines.join('<br><br>')
+
+    simple_format(snippets_separated_by_line_break)
+  end
+
   private
 
   def language_code_to_english(language_code)

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -136,6 +136,8 @@ module BlacklightHelper
   end
 
   def fulltext_snippet_separation(options = {})
+    # Some snippets come back with new lines embedded without them. We don't want that.
+    # We do however want new lines after a snippet, to show separation
     snippets_without_new_lines = options[:value].map { |snippet| snippet.gsub(/\n/, ' ') }
     snippets_separated_by_line_break = snippets_without_new_lines.join('<br><br>')
 

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -8,6 +8,16 @@ RSpec.describe BlacklightHelper, helper: true, style: true do
     user.present?
   end
 
+  describe '#fulltext_snippet_separation' do
+    it 'separates the snippets by line breaks' do
+      options = { value: ["This is a test.\n\nThis is the OCR <span class='search-highlight'>text</span>", " for 1030368.\n\nSearch for some <span class='search-highlight'>text</span> to see"] }
+
+      expect(helper.fulltext_snippet_separation(options)).to eq(
+        "<p>This is a test.  This is the OCR <span class=\"search-highlight\">text</span><br><br> for 1030368.  Search for some <span class=\"search-highlight\">text</span> to see</p>"
+      )
+    end
+  end
+
   describe '#language_code' do
     context 'with a valid language code' do
       it 'returns the English name of the language' do

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe BlacklightHelper, helper: true, style: true do
       options = { value: ["This is a test.\n\nThis is the OCR <span class='search-highlight'>text</span>", " for 1030368.\n\nSearch for some <span class='search-highlight'>text</span> to see"] }
 
       expect(helper.fulltext_snippet_separation(options)).to eq(
-        "<p>This is a test.  This is the OCR <span class=\"search-highlight\">text</span><br><br> for 1030368.  Search for some <span class=\"search-highlight\">text</span> to see</p>"
+        "<p>This is a test.  This is the OCR <span class=\"search-highlight\">text</span><br> for 1030368.  Search for some <span class=\"search-highlight\">text</span> to see</p>"
       )
     end
   end

--- a/spec/system/highlight_in_search_spec.rb
+++ b/spec/system/highlight_in_search_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Search results displays field', type: :system, clean: true do
       alternativeTitle_tesim: 'The Yale Bulldogs',
       description_tesim: 'in black ink on thin white paper',
       format: 'three dimensional object',
-      fulltext_tsim: ['fulltext text one'],
+      fulltext_tsim: ["fulltext text one.\n\nThis is for dog\n"],
       callNumber_tesim: 'Osborn Music MS 4',
       published_ssim: "1997",
       language_ssim: ['en', 'eng', 'zz'],
@@ -91,7 +91,12 @@ RSpec.describe 'Search results displays field', type: :system, clean: true do
 
     it 'highlights the full text when a term is queried' do
       visit '/catalog?search_field=fulltext_tsim&q=text'
-      expect(page.html).to include "fulltext <span class='search-highlight'>text</span> one"
+      expect(page.html).to include 'fulltext <span class="search-highlight">text</span> one'
+    end
+
+    it 'highlights the full text when multiple terms are queried' do
+      visit '/catalog?search_field=fulltext_tsim&q=text+dog'
+      expect(page.html).to include 'fulltext <span class="search-highlight">text</span> one.  This is for <span class="search-highlight">dog</span>'
     end
   end
 end


### PR DESCRIPTION
co-author: alisha evans <alisha@notch8.com>
co-author: dylan salay <dylan@notch8.com>

# Ticket
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1317

# Expected behavior
- line breaks will be removed from _within_ snippets that have one
- each snippet will have a line break _after_ it

# Demo
| | |
| --- | --- |
| <img width="1440" alt="image" src="https://user-images.githubusercontent.com/29032869/119726752-4f18eb80-be26-11eb-92ec-c8858cb65856.png"> | <img width="1440" alt="image" src="https://user-images.githubusercontent.com/29032869/119727283-f4cc5a80-be26-11eb-906a-4f9383f0b7cf.png"> |

# Resources
- lea ann from notch8
- https://apidock.com/rails/ActionView/Helpers/TextHelper/simple_format
- https://stackoverflow.com/a/4190812/8079848
- https://www.freecodecamp.org/news/common-array-methods-in-ruby/
- http://localhost:8983/solr/#/blacklight-core/query