### PR TITLE
Pass fulltext search query to UV when loading show page

### DIFF
--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -21,4 +21,18 @@ module CatalogHelper
 
     constraints.join(' / ')
   end
+
+  # Extract fulltext param from search
+  # Simple: ...search_field=fulltext_tsim&q=XXX
+  # Advanced: fulltext_tsim_advanced=XXX
+  def uv_fulltext_search_param
+    search_params = current_search_session.try(:query_params) || {}
+    q = nil
+    if 'fulltext_tsim' == search_params['search_field'] && search_params['q']
+      q = search_params['q']
+    elsif search_params['fulltext_tsim_advanced']
+      q = search_params['fulltext_tsim_advanced']
+    end
+    "&q=#{url_encode(q)}" if q
+  end
 end

--- a/app/views/catalog/_uv.html.erb
+++ b/app/views/catalog/_uv.html.erb
@@ -9,7 +9,7 @@
 <iframe
     class="universal-viewer-iframe"
     title="Universal Viewer"
-    src="<%= request&.base_url %>/uv/uv.html#?manifest=<%= manifest_url(oid) %><%= order_param %>"
+    src="<%= request&.base_url %>/uv/uv.html#?manifest=<%= manifest_url(oid) %><%= order_param %><%= uv_fulltext_search_param %>"
     width="924"
     height="668"
     allowfullscreen

--- a/config/uv/uv.html
+++ b/config/uv/uv.html
@@ -58,6 +58,7 @@
                 rotation: Number(urlDataProvider.get('r', 0)),
                 xywh: urlDataProvider.get('xywh', ''),
                 embedded: true,
+                highlight: urlDataProvider.get('q'),
                 locales: formattedLocales
             }, urlDataProvider);
 

--- a/public/uv/uv.html
+++ b/public/uv/uv.html
@@ -58,6 +58,7 @@
                 rotation: Number(urlDataProvider.get('r', 0)),
                 xywh: urlDataProvider.get('xywh', ''),
                 embedded: true,
+                highlight: urlDataProvider.get('q'),
                 locales: formattedLocales
             }, urlDataProvider);
 

--- a/spec/system/uv_full_text_search.rb
+++ b/spec/system/uv_full_text_search.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Searching for full text and navigate to the UV', type: :system, js: true, clean: true do
+  before do
+    stub_request(:get, 'https://yul-dc-development-samples.s3.amazonaws.com/manifests/01/1.json')
+      .to_return(status: 200, body: File.open(File.join('spec', 'fixtures', '2041002.json')).read)
+
+    solr = Blacklight.default_index.connection
+    solr.add([dog])
+    solr.commit
+  end
+
+  let(:dog) { ADVANCED_SEARCH_TESTING_1 }
+
+  it 'adds the fulltext search parameter to the iframe src URL in advanced search' do
+    visit search_catalog_path
+    click_on "Advanced Search"
+    fill_in 'fulltext_tsim_advanced', with: 'fulltext'
+    click_on 'SEARCH'
+    click_on 'Record 1'
+    uv_iframe = page.find('.universal-viewer-iframe')
+    expect(uv_iframe[:src]).to include('q=fulltext')
+  end
+
+  it 'adds the fulltext search parameter to the iframe src URL in simple search' do
+    visit search_catalog_path
+    select('Full Text', from: 'search_field')
+    fill_in 'q', with: 'fulltext'
+    within '.input-group-append' do
+      click_button("Search")
+    end
+    click_on 'Record 1'
+    uv_iframe = page.find('.universal-viewer-iframe')
+    expect(uv_iframe[:src]).to include('q=fulltext')
+  end
+end


### PR DESCRIPTION
* UV is configured to accept the search param in its iframe URL via the `q` parameter
* When loading single object show page, retrieves full text search query (if any) from user session and passes it to Universal Viewer iframe.

This initial commit uses the search params stored in the user session, which is not ideal - the state isn't captured in the URL and can't be shared. 