### PR TITLE
Use fulltext_tesim as search field name when passing params to UV.

### DIFF
--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -28,7 +28,7 @@ module CatalogHelper
   def uv_fulltext_search_param
     search_params = current_search_session.try(:query_params) || {}
     q = nil
-    if 'fulltext_tsim' == search_params['search_field'] && search_params['q']
+    if 'fulltext_tesim' == search_params['search_field'] && search_params['q']
       q = search_params['q']
     elsif search_params['fulltext_tsim_advanced']
       q = search_params['fulltext_tsim_advanced']


### PR DESCRIPTION
Updating field name when passing to UV.

(fulltext_tesim is used as the search field to correspond with the solr field
 being searched, as we do with other fields.)