### PR TITLE
1362 fulltext suggest retain case

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
             POSTGRES_PASSWORD: password
             SOLR_CORE: blacklight-test
             SOLR_TEST_URL: http://localhost:8983/solr/blacklight-test
-      - image: yalelibraryit/dc-solr:fulltext_retain_case
+      - image: yalelibraryit/dc-solr:79a71ec
         command: bash -c 'precreate-core blacklight-test /opt/config; exec solr -f'
       - image: circleci/postgres:9.5-alpine-ram
         environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
             POSTGRES_PASSWORD: password
             SOLR_CORE: blacklight-test
             SOLR_TEST_URL: http://localhost:8983/solr/blacklight-test
-      - image: yalelibraryit/dc-solr:79a71ec
+      - image: yalelibraryit/dc-solr:v1.0.1
         command: bash -c 'precreate-core blacklight-test /opt/config; exec solr -f'
       - image: circleci/postgres:9.5-alpine-ram
         environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
             POSTGRES_PASSWORD: password
             SOLR_CORE: blacklight-test
             SOLR_TEST_URL: http://localhost:8983/solr/blacklight-test
-      - image: yalelibraryit/dc-solr:79a71ec
+      - image: yalelibraryit/dc-solr:fulltext_retain_case
         command: bash -c 'precreate-core blacklight-test /opt/config; exec solr -f'
       - image: circleci/postgres:9.5-alpine-ram
         environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,8 +38,8 @@ jobs:
             POSTGRES_PASSWORD: password
             SOLR_CORE: blacklight-test
             SOLR_TEST_URL: http://localhost:8983/solr/blacklight-test
-      - image: yalelibraryit/dc-solr:v1.0.3
-        command: bash -c 'precreate-core blacklight-test /opt/config; exec solr -f'
+      - image: yalelibraryit/dc-solr:1362_fulltext_suggest_retain_case
+        command: bash -c 'precreate-core blacklight-test /opt/config; chown -R solr:solr /var/solr/data/ ; /boot.sh'
       - image: circleci/postgres:9.5-alpine-ram
         environment:
             POSTGRES_DB: blacklight_yul_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
             POSTGRES_PASSWORD: password
             SOLR_CORE: blacklight-test
             SOLR_TEST_URL: http://localhost:8983/solr/blacklight-test
-      - image: yalelibraryit/dc-solr:v1.0.1
+      - image: yalelibraryit/dc-solr:v1.0.3
         command: bash -c 'precreate-core blacklight-test /opt/config; exec solr -f'
       - image: circleci/postgres:9.5-alpine-ram
         environment:

--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -10,10 +10,10 @@ class AnnotationsController < ApplicationController
   def full_text
     @oid = params[:oid]
     @child_oid = params[:child_oid]
-    @response, @child_document = search_service.fetch(@child_oid, { fl: ['child_fulltext_tsim', 'parent_ssi'] })
+    @response, @child_document = search_service.fetch(@child_oid, { fl: ['child_fulltext_wstsim', 'parent_ssi'] })
     child_doc = @child_document.response['response']['docs'].first
     if child_doc["parent_ssi"] == @oid
-      render json: fulltext_response(child_doc["child_fulltext_tsim"].join('\n'))
+      render json: fulltext_response(child_doc["child_fulltext_wstsim"].join('\n'))
     else
       render json: { error: 'unauthorized' }.to_json, status: 401
     end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -23,7 +23,7 @@ class CatalogController < ApplicationController
   configure_blacklight do |config|
     # configuration for Blacklight IIIF Content Search
     config.iiif_search = {
-      full_text_field: 'child_fulltext_tsim',
+      full_text_field: 'child_fulltext_wstsim',
       full_text_q_field: 'child_fulltext_tesim',
       object_relation_field: 'parent_ssi',
       supported_params: %w[q page],
@@ -560,12 +560,13 @@ class CatalogController < ApplicationController
     #  search children to get the count
     params = {
       "rows": 0,
-      "facet.field": "child_fulltext_tsim",
+      "facet.field": "child_fulltext_wstsim",
       "facet": "on",
       "q": "parent_ssi:#{@document_id}",
-      "facet.prefix": @query.downcase
+      "facet.contains": @query.downcase,
+      "facet.contains.ignoreCase": "true"
     }
-    results = search_service.repository.search(params)['facet_counts']['facet_fields']['child_fulltext_tsim']
+    results = search_service.repository.search(params)['facet_counts']['facet_fields']['child_fulltext_wstsim']
     terms_for_list = []
     results.each_slice(2) do |term, freq|
       term_hash = { match: term, url: solr_document_iiif_search_url(@document_id, q: term), count: freq }

--- a/spec/requests/annotation_request_spec.rb
+++ b/spec/requests/annotation_request_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'AnnotationsController', type: :request do
     {
       "id": "998833",
       "parent_ssi": "2034600",
-      "child_fulltext_tsim": ["This is the full text public"]
+      "child_fulltext_wstsim": ["This is the full text public"]
     }
   end
   let(:yale_work) do
@@ -30,7 +30,7 @@ RSpec.describe 'AnnotationsController', type: :request do
     {
       "id": "998834",
       "parent_ssi": "1618909",
-      "child_fulltext_tsim": ["This is the full text Yale only"]
+      "child_fulltext_wstsim": ["This is the full text Yale only"]
     }
   end
   let(:unknown_visibility_work) do
@@ -44,7 +44,7 @@ RSpec.describe 'AnnotationsController', type: :request do
     {
       "id": "998835",
       "parent_ssi": "1618904",
-      "child_fulltext_tsim": ["This is the full text Unknown"]
+      "child_fulltext_wstsim": ["This is the full text Unknown"]
     }
   end
 

--- a/spec/requests/iiif_search_request_spec.rb
+++ b/spec/requests/iiif_search_request_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Iiif Search", type: :request do
   let(:child_work1) do
     {
       "id": "3456",
-      "child_fulltext_tsim": ["This is the ocr text for this document. Paris basketball can you search for it."],
+      "child_fulltext_wstsim": ["This is the ocr text for this document. Paris basketball can you search for it."],
       "child_fulltext_tesim": ["This is the ocr text for this document. Paris basketball can you search for it."],
       "parent_ssi": "1234567"
     }
@@ -23,7 +23,7 @@ RSpec.describe "Iiif Search", type: :request do
   let(:child_work2) do
     {
       "id": "3457",
-      "child_fulltext_tsim": ["This is the ocr text for this document. Pakistan baseball can you search for it."],
+      "child_fulltext_wstsim": ["This is the ocr text for this document. Pakistan baseball can you search for it."],
       "child_fulltext_tesim": ["This is the ocr text for this document. Pakistan baseball can you search for it."],
       "parent_ssi": "1234567"
     }


### PR DESCRIPTION
Switch child_fulltext_tsim to child_fulltext_wstsim so that case is maintained.
Change iiif suggest query to use facet.contains so that case insensitive search is possible.  (facet.prefix does not have case insensitive option.)