### PR TITLE
Added exclusive highlighting to advanced fulltext search

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -156,6 +156,7 @@ class CatalogController < ApplicationController
     disp_highlight_on_search_params = {
       'hl': true,
       'hl.method': 'original',
+      'hl.requireFieldMatch': true,
       'hl.usePhraseHighlighter': true,
       'hl.preserveMulti': false,
       "hl.simple.pre": "<span class='search-highlight'>",


### PR DESCRIPTION
**Story**

When searching full text (e.g., "the") in Advanced Search the results highlight matches in other fields (e.g., in the title).

See #1362 for simple search equivalent.

**Acceptance**
- [x] Advanced searches for full text highlight matches in the full text display only.

----
**Demo of the Feature**

![1367_AdvancedFulltextExclusiveHighlighting](https://user-images.githubusercontent.com/41123693/121538640-f1ae9e00-c9d2-11eb-989f-4d9e1af40282.gif)






