### PR TITLE
Updated harm language statement on landingpage

### DIFF
--- a/app/assets/stylesheets/customOverrides/landing.scss
+++ b/app/assets/stylesheets/customOverrides/landing.scss
@@ -210,6 +210,10 @@ DEFAULT MOBILE STYLING
   margin-left: 0px !important;
 }
 
+#content-statement p {
+  width: 95%;
+}
+
 
 @media screen and (min-width: $small_device) {
   #hero {
@@ -393,7 +397,10 @@ DEFAULT MOBILE STYLING
     margin-top: -175px;
     margin-bottom: 50px;
   }
-
+  
+  #content-statement p{
+    width: 98%;
+  }
 }
 
 

--- a/app/views/application/landing.html.erb
+++ b/app/views/application/landing.html.erb
@@ -101,7 +101,7 @@
       </ul>
       <div id="content-statement">
        <h2>Statement on Potentially Harmful Content</h2>
-       <p>Yale University Library’s collections contain historical and contemporary materials documenting human expression and lived experience. Content may include images or language that library users may find harmful, offensive, or inappropriate. Some of these words or images are now recognized as offensive and unacceptable; some may have been viewed as unacceptable when they were created. Yale University Library staff are engaged in addressing or contextualizing this content and language; for more information, see the <a href="https://guides.library.yale.edu/specialcollections/statementondescription">Statement on Potentially Harmful Content</a>.</p>
+       <p>Yale University Library’s collections contain historical and contemporary materials documenting human expression and lived experience. Content may include images or language that library users may find harmful, offensive, or inappropriate. Some of these words or images are now recognized as offensive and unacceptable; some may have been viewed as unacceptable when they were created. Yale University Library staff are engaged in addressing or contextualizing this content and language; for more information, see the <a href="https://guides.library.yale.edu/about/statement-on-content">Statement on Potentially Harmful Content</a>.</p>
       </div>
     </div>
   </main>


### PR DESCRIPTION
**Story**

"I happened to notice yesterday that the link on the homepage of https://collections.library.yale.edu/ still points to the Statement on Harmful Language in Archival Description (https://guides.library.yale.edu/specialcollections/statementondescription), rather than the Statement on Potentially Harmful Content (https://guides.library.yale.edu/about/statement-on-content). I think that’s because I wasn’t clear when we were corresponding back in April that the text (which did change) and also the hyperlink itself should be updated."

**Acceptance**
- [x] Link on homepage in Blacklight is updated.

**Bonus**
- [x] Correct the paragraph word hung 


![Screen Shot 2021-06-10 at 10.23.00 AM.png](https://images.zenhubusercontent.com/5e6013c029e314c92afd4769/6176f90b-8218-487d-a8d8-b6b1b5aff9bb)

![Screen Shot 2021-06-10 at 10.23.00 AM.png](https://images.zenhubusercontent.com/5e6013c029e314c92afd4769/6f3d80e4-413a-4a58-a999-840c13dec075)

-----

**Feature Demo**

![1371_UpdateHarmLanguageStatement](https://user-images.githubusercontent.com/41123693/121544700-eb6ef080-c9d7-11eb-838d-d0c29554c4bb.gif)
