### PR TITLE
1367 Separated multiply titles on showpage

### DIFF
--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -73,7 +73,7 @@ module BlacklightHelper
 
   def join_with_br(arg)
     values = arg[:document][arg[:field]]
-    safe_join(values, '<br />'.html_safe)
+    safe_join(values, '<br/>'.html_safe)
   end
 
   def faceted_join_with_br(arg)

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -105,7 +105,7 @@ module BlacklightHelper
 
   def sep_title_show_page
     values = @document[:title_tesim]
-    safe_join(values, '<br/>'.html_safe)
+    safe_join(values, '<br/>'.html_safe) unless values.nil?
   end
 
   def language_code(args)

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -73,7 +73,7 @@ module BlacklightHelper
 
   def join_with_br(arg)
     values = arg[:document][arg[:field]]
-    safe_join(values, '<br/>'.html_safe)
+    safe_join(values, '<br />'.html_safe)
   end
 
   def faceted_join_with_br(arg)
@@ -103,7 +103,7 @@ module BlacklightHelper
     link_to(field_value.join, link_text)
   end
 
-  def sep_title_showpage
+  def sep_title_show_page
     values = @document[:title_tesim]
     safe_join(values, '<br/>'.html_safe)
   end

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -103,6 +103,11 @@ module BlacklightHelper
     link_to(field_value.join, link_text)
   end
 
+  def sep_title_showpage
+    values = @document[:title_tesim]
+    safe_join(values, '<br/>'.html_safe)
+  end
+
   def language_code(args)
     language_value = args
     language_code_to_english(language_value)

--- a/app/views/catalog/_show_header.html.erb
+++ b/app/views/catalog/_show_header.html.erb
@@ -1,1 +1,1 @@
-<h1 itemprop="name" class="show-header"><%= sep_title_showpage %></h1>
+<h1 itemprop="name" class="show-header"><%= document_heading || sep_title_show_page %></h1>

--- a/app/views/catalog/_show_header.html.erb
+++ b/app/views/catalog/_show_header.html.erb
@@ -1,4 +1,1 @@
-<!--<h1 itemprop="name" class="show-header"><%#= document_heading %></h1>-->
-<h1 itemprop="name" class="show-header">
-  <%= Deprecation.silence(Blacklight::BlacklightHelperBehavior) { render_document_heading(document, helper_method: :join_with_br) } %>
-</h1>
+<h1 itemprop="name" class="show-header"><%= sep_title_showpage %></h1>

--- a/app/views/catalog/_show_header.html.erb
+++ b/app/views/catalog/_show_header.html.erb
@@ -1,1 +1,1 @@
-<h1 itemprop="name" class="show-header"><%= document_heading || sep_title_show_page %></h1>
+<h1 itemprop="name" class="show-header"><%= sep_title_show_page %></h1>

--- a/app/views/catalog/_show_header.html.erb
+++ b/app/views/catalog/_show_header.html.erb
@@ -1,1 +1,4 @@
-<h1 itemprop="name" class="show-header"><%= document_heading %></h1>
+<!--<h1 itemprop="name" class="show-header"><%#= document_heading %></h1>-->
+<h1 itemprop="name" class="show-header">
+  <%= Deprecation.silence(Blacklight::BlacklightHelperBehavior) { render_document_heading(document, helper_method: :join_with_br) } %>
+</h1>


### PR DESCRIPTION
**Story**

We switched to breaks instead of "and" in the metadata display, but the page header should also do this:

![Screen Shot 2021-06-07 at 2.56.43 PM.png](https://images.zenhubusercontent.com/5e5d472f410278efd81466ab/03f61803-ec9d-4920-9c44-2ef74946c886)

Object is https://collections.library.yale.edu/catalog/31901015

**Acceptance**
- [x] Multiple titles in the page header should be on new lines

----

**Test Record:**
https://collections-test.library.yale.edu/catalog/800043384

**Current State**
![image.png](https://images.zenhubusercontent.com/5e6013c029e314c92afd4769/4574a88f-82ca-4d83-ac49-a027c1707be5)

**Proposed State**
![Screen Shot 2021-06-11 at 1.03.22 PM.png](https://images.zenhubusercontent.com/5e6013c029e314c92afd4769/4a09cfea-c9bc-4802-b8eb-99f1717d39f8)


----
**Feature Demo**
![Multiple titles in 1368object page header should have line breaks](https://user-images.githubusercontent.com/41123693/121724034-488ca400-cab5-11eb-8842-f187b0c5bf01.gif)


