### PR TITLE
Modified advance search exclusive highlighting

### DIFF
--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -156,6 +156,7 @@ class SearchBuilder < Blacklight::SearchBuilder
 
     solr_parameters[:hl] = true
     # solr_parameters['hl.usePhraseHighlighter'] = false
+    solr_parameters['hl.requireFieldMatch'] = true
     solr_parameters['hl.preserveMulti'] = true
     solr_parameters['hl.fl'] << "*"
     solr_parameters["hl.simple.pre"] = "<span class='search-highlight'>"


### PR DESCRIPTION
Co-Authored-By: Martin Lovell <martin.lovell@yale.edu>

**Story**

When searching full text (e.g., "the") in Advanced Search the results highlight matches in other fields (e.g., in the title).

See #1362 for simple search equivalent.

**Acceptance**
- [x] Advanced searches for full text highlight matches in the full text display only.
