### PR TITLE
Fulltext simple search

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -64,6 +64,10 @@ $(document).on('turbolinks:load', function() {
     renderBanner();
 })
 
+$(document).on('turbolinks:load', function() {
+    document.getElementById("search_field").onchange = selectFulltext;
+})
+
 function renderBanner() {
     fetch("https://banner.library.yale.edu/banner.json")
         .then(response => response.json())

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -92,7 +92,6 @@ function selectFulltext() {
     var fulltext = document.getElementById("search_field").value;
     if (fulltext == "fulltext_tesim") {
         fulltext_info = document.getElementById("fulltext-info");
-        fulltext_info.style.backgroudColor ="";
         fulltext_info.innerHTML = "Search full text that occurs in a work. Not all works contain searchable full text."
         fulltext_info.style.display ="inline-block"
 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -88,3 +88,15 @@ function renderBanner() {
         });
 }
 
+function selectFulltext() {
+    var fulltext = document.getElementById("search_field").value;
+    if (fulltext == "fulltext_tesim") {
+        fulltext_info = document.getElementById("fulltext-info");
+        fulltext_info.style.backgroudColor ="";
+        fulltext_info.innerHTML = "Search full text that occurs in a work. Not all works contain searchable full text."
+        fulltext_info.style.display ="inline-block"
+
+    }
+}
+
+

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -105,10 +105,10 @@ function renderBanner() {
 
 function selectFulltext() {
     var fulltext = document.getElementById("search_field").value;
+    var fulltext_info = document.getElementById("fulltext-info");
     if (fulltext == "fulltext_tesim") {
-        fulltext_info = document.getElementById("fulltext-info");
-        fulltext_info.innerHTML = "Search full text that occurs in a work. Not all works contain searchable full text."
         fulltext_info.style.display ="inline-block"
-
+    } else {
+        fulltext_info.style.display = "none"
     }
 }

--- a/app/assets/stylesheets/customOverrides/search_bar.scss
+++ b/app/assets/stylesheets/customOverrides/search_bar.scss
@@ -123,7 +123,6 @@ DEFAULT MOBILE STYLING
     max-width: 96%;
   }
   .fulltext-info {
-    display: inline-block;
     right: 45%;
     width: 61%;
     left: 2%;
@@ -138,7 +137,6 @@ DEFAULT MOBILE STYLING
     margin-top: 0;
   }
   .fulltext-info {
-    display: inline-block;
     right: 45%;
     width: 38%;
     left: 29%;

--- a/app/assets/stylesheets/customOverrides/search_bar.scss
+++ b/app/assets/stylesheets/customOverrides/search_bar.scss
@@ -106,6 +106,7 @@ DEFAULT MOBILE STYLING
 }
 
 
+
 @media screen and (min-width: $medium_device) {
   .input-group {
     max-width: 96%;
@@ -174,6 +175,19 @@ DEFAULT MOBILE STYLING
 
   .navbar-search .search-query-form {
     flex: 0 0 100%;
+  }
+
+  .fulltext-info {
+    z-index:9999;
+    display:none;
+    font-size: 14px;
+    font-family: $mallory_book, $mallory_light, Arial, Helvetica, sans-serif;
+    margin-top:60px;
+    margin-right:120px;
+    width: 450px;
+    line-height:20px;
+    color:#303030;
+    position:absolute;
   }
 }
 }

--- a/app/assets/stylesheets/customOverrides/search_bar.scss
+++ b/app/assets/stylesheets/customOverrides/search_bar.scss
@@ -105,18 +105,43 @@ DEFAULT MOBILE STYLING
   font-family: $mallory_book, $mallory_light, Arial, Helvetica, sans-serif !important;
 }
 
+  .fulltext-info {
+    font-size: 14px;
+    font-family: $mallory_book, $mallory_light, Arial, Helvetica, sans-serif;
+    top: 103%;
+    right: 52%;
+    width: 46%;
+    color: $medium_grey;
+    position:absolute;
+    background-color: none;
+  }
+
 
 
 @media screen and (min-width: $medium_device) {
   .input-group {
     max-width: 96%;
   }
+  .fulltext-info {
+    display: inline-block;
+    right: 45%;
+    width: 61%;
+    left: 2%;
+  }
 }
+
+
 
 
 @media screen and (min-width: $large_device) {
   .advanced_search {
     margin-top: 0;
+  }
+  .fulltext-info {
+    display: inline-block;
+    right: 45%;
+    width: 38%;
+    left: 29%;
   }
 
   .form-control {
@@ -178,16 +203,10 @@ DEFAULT MOBILE STYLING
   }
 
   .fulltext-info {
-    z-index:9999;
-    display:none;
-    font-size: 14px;
-    font-family: $mallory_book, $mallory_light, Arial, Helvetica, sans-serif;
-    margin-top:60px;
-    margin-right:120px;
-    width: 450px;
-    line-height:20px;
-    color:#303030;
-    position:absolute;
+    top: 103%;
+    left: 24%;
+    width: 46%;
   }
+
 }
 }

--- a/app/assets/stylesheets/customOverrides/subheader_users.scss
+++ b/app/assets/stylesheets/customOverrides/subheader_users.scss
@@ -90,11 +90,12 @@ DEFAULT MOBILE STYLING
   .user-subheader-title {
     font-size: 30px;
     width: 300px;
+    padding-top: 2%;
   }
 
   .user-subheader-options {
     padding-left: 45%;
-    padding-top: 2%
+    padding-top: 2%;
   }
 }
 

--- a/app/assets/stylesheets/customOverrides/subheader_users.scss
+++ b/app/assets/stylesheets/customOverrides/subheader_users.scss
@@ -18,7 +18,7 @@ DEFAULT MOBILE STYLING
   overflow: visible;
   width: 250px;
   padding-bottom: 12px;
-  padding-top: 12px;
+  padding-top: 10%;
 }
 
 .user-subheader-options {

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -133,7 +133,6 @@ class CatalogController < ApplicationController
     config.add_facet_field 'subject_ssim', label: 'Topic', limit: 20, index_range: 'A'..'Z'
     config.add_facet_field 'creationPlace_ssim', label: 'Publication Place', limit: true
     config.add_facet_field 'pub_date_ssim', label: 'Publication Year', single: true
-    config.add_facet_field 'has_fulltext_ssi', label: "Full Text Available", limit: true
     config.add_facet_field 'year_isim', label: 'Date Created',
                                         range: {
                                           segments: true,
@@ -444,6 +443,16 @@ class CatalogController < ApplicationController
       }
     end
 
+    config.add_search_field('fulltext_tesim', label: 'Full Text') do |field|
+      field.qt = 'search'
+      field.include_in_advanced_search = false
+      field.solr_parameters = {
+          qf: 'fulltext_tesim',
+          pf: '',
+          'hl.requireFieldMatch': true
+      }
+    end
+
     config.add_search_field('fulltext_tsim_advanced', label: 'Full Text') do |field|
       field.qt = 'search'
       field.include_in_simple_select = false
@@ -462,15 +471,6 @@ class CatalogController < ApplicationController
       }
     end
 
-    config.add_search_field('fulltext_tesim', label: 'Full Text') do |field|
-      field.qt = 'search'
-      field.include_in_advanced_search = false
-      field.solr_parameters = {
-        qf: 'fulltext_tesim',
-        pf: '',
-        'hl.requireFieldMatch': true
-      }
-    end
 
     config.add_search_field('oid_ssi', label: 'OID [Parent/primary]') do |field|
       field.qt = 'search'

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -447,9 +447,9 @@ class CatalogController < ApplicationController
       field.qt = 'search'
       field.include_in_advanced_search = false
       field.solr_parameters = {
-          qf: 'fulltext_tesim',
-          pf: '',
-          'hl.requireFieldMatch': true
+        qf: 'fulltext_tesim',
+        pf: '',
+        'hl.requireFieldMatch': true
       }
     end
 
@@ -470,7 +470,6 @@ class CatalogController < ApplicationController
         pf: ''
       }
     end
-
 
     config.add_search_field('oid_ssi', label: 'OID [Parent/primary]') do |field|
       field.qt = 'search'

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -443,16 +443,6 @@ class CatalogController < ApplicationController
       }
     end
 
-    config.add_search_field('fulltext_tesim', label: 'Full Text') do |field|
-      field.qt = 'search'
-      field.include_in_advanced_search = false
-      field.solr_parameters = {
-        qf: 'fulltext_tesim',
-        pf: '',
-        'hl.requireFieldMatch': true
-      }
-    end
-
     config.add_search_field('fulltext_tsim_advanced', label: 'Full Text') do |field|
       field.qt = 'search'
       field.include_in_simple_select = false
@@ -468,6 +458,16 @@ class CatalogController < ApplicationController
       field.solr_parameters = {
         qf: 'orbisBibId_ssi',
         pf: ''
+      }
+    end
+
+    config.add_search_field('fulltext_tesim', label: 'Full Text') do |field|
+      field.qt = 'search'
+      field.include_in_advanced_search = false
+      field.solr_parameters = {
+        qf: 'fulltext_tesim',
+        pf: '',
+        'hl.requireFieldMatch': true
       }
     end
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -147,6 +147,7 @@ class CatalogController < ApplicationController
     # but we need to be able to provide a label when they are filtered upon from an individual show page
     config.add_facet_field 'callNumber_ssim', label: 'Call Number', show: false
     config.add_facet_field 'subjectGeographic_ssim', label: 'Subject (Geographic)', show: false
+    config.add_facet_field 'has_fulltext_ssi', label: "Full Text Available", limit: true
 
     # This was example code after running rails generate blacklight_range_limit:install
     # config.add_facet_field 'example_query_facet_field', label: 'Publish Date', query: {

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -4,15 +4,19 @@
     <label for="search_field" class="sr-only"><%= t('blacklight.search.form.search_field.label') %></label>
   <% end %>
   <div class="input-group">
+    <%= javascript_include_tag "application" %>
     <% if search_fields.length > 1 %>
         <%= select_tag(:search_field,
                        options_for_select(search_fields, h(params[:search_field])),
                        title: t('blacklight.search.form.search_field.title'),
                        id: "search_field",
+                       onchange: "selectFulltext()",
                        class: "custom-select search-field") %>
     <% elsif search_fields.length == 1 %>
       <%= hidden_field_tag :search_field, search_fields.first.last %>
     <% end %>
+
+    <span class="fulltext-info hidden" id="fulltext-info"></span>
 
     <label for="q" class="sr-only"><%= t('blacklight.search.form.search.label') %></label>
     <%#= text_field_tag :q, params[:q], placeholder: t('blacklight.search.form.search.placeholder'), class: "search-q q form-control rounded-#{search_fields.length > 1 ? '0' : 'left'}", id: "q", autocomplete: presenter.autocomplete_enabled? ? "off" : "", autofocus: presenter.autofocus?, data: { autocomplete_enabled: presenter.autocomplete_enabled?, autocomplete_path: search_action_path(action: :suggest) }  %>
@@ -24,6 +28,7 @@
         <%= blacklight_icon :search, aria_hidden: true %>
       </button>
     </span>
+
     <span>
       <button class="advanced_search btn btn-secondary href-button" href="<%=blacklight_advanced_search_engine.advanced_search_path %>">Advanced Search</button>
     </span>

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -14,7 +14,8 @@
       <%= hidden_field_tag :search_field, search_fields.first.last %>
     <% end %>
 
-    <span class="fulltext-info hidden" id="fulltext-info"></span>
+    <span class="fulltext-info hidden" id="fulltext-info"> Search full text that occurs in a work. Not all works contain searchable full text.
+    </span>
 
     <label for="q" class="sr-only"><%= t('blacklight.search.form.search.label') %></label>
     <%#= text_field_tag :q, params[:q], placeholder: t('blacklight.search.form.search.placeholder'), class: "search-q q form-control rounded-#{search_fields.length > 1 ? '0' : 'left'}", id: "q", autocomplete: presenter.autocomplete_enabled? ? "off" : "", autofocus: presenter.autofocus?, data: { autocomplete_enabled: presenter.autocomplete_enabled?, autocomplete_path: search_action_path(action: :suggest) }  %>

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -4,13 +4,11 @@
     <label for="search_field" class="sr-only"><%= t('blacklight.search.form.search_field.label') %></label>
   <% end %>
   <div class="input-group">
-    <%= javascript_include_tag "application" %>
     <% if search_fields.length > 1 %>
         <%= select_tag(:search_field,
                        options_for_select(search_fields, h(params[:search_field])),
                        title: t('blacklight.search.form.search_field.title'),
                        id: "search_field",
-                       onchange: "selectFulltext()",
                        class: "custom-select search-field") %>
     <% elsif search_fields.length == 1 %>
       <%= hidden_field_tag :search_field, search_fields.first.last %>

--- a/spec/requests/annotation_request_spec.rb
+++ b/spec/requests/annotation_request_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 # WebMock.allow_net_connect!
-RSpec.describe 'AnnotationsController', type: :request do
+RSpec.describe 'AnnotationsController', type: :request, clean: true, js: true do
   let(:user) { FactoryBot.create(:user) }
   let(:public_work) do
     {

--- a/spec/system/search_fields_spec.rb
+++ b/spec/system/search_fields_spec.rb
@@ -95,5 +95,11 @@ RSpec.describe 'Search results displays field', type: :system, clean: true, js: 
       expect(page).to have_content 'Handsome Dan is a bull dog.'
       expect(page).not_to have_content 'Handsome Dan is not a cat.'
     end
+
+    it 'adds the fulltext  simple search description' do
+      visit search_catalog_path
+      select('Full Text', from: 'search_field')
+      expect(page).to have_content 'Search full text that occurs in a work. Not all works contain searchable full text.'
+    end
   end
 end


### PR DESCRIPTION
**Story**

In FindIt there is descriptive text for the full text search option that displays in a popup when hovering over the "what's this?" text:
![Screen Shot 2021-06-06 at 5.40.22 PM.png](https://images.zenhubusercontent.com/5e5d472f410278efd81466ab/9ab3f210-caa1-4069-ad99-6dede96db93d)

In Blacklight we'd like to display a similar message:
```
Search full text that occurs in a work. Not all works contain searchable full text.
```

**Acceptance**
Display the message:
- [ ] In the simple search, when "full text" is selected in the drop down, display the message under the text input for the search. ![Screen Shot 2021-06-08 at 1.30.01 PM.png](https://images.zenhubusercontent.com/5e5d472f410278efd81466ab/12fd831d-33f6-4222-944c-741a71cef91a)

