### PR TITLE
add facet repository

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -169,7 +169,6 @@ class CatalogController < ApplicationController
     config.add_index_field 'subjectName_tesim', label: 'Subject (Name)', highlight: true, solr_params: disp_highlight_on_search_params
     config.add_index_field 'subjectTopic_tesim', label: 'Subject (Topic)', highlight: true, solr_params: disp_highlight_on_search_params
     config.add_index_field 'sourceCreated_tesim', label: 'Collection Created', highlight: true, solr_params: disp_highlight_on_search_params
-    config.add_index_field 'repository_ssi', label: 'Repository', highlight: true, solr_params: disp_highlight_on_search_params
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
     #

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -106,6 +106,7 @@ class CatalogController < ApplicationController
 
     config.add_facet_field 'extentOfDigitization_ssim', label: 'Extent of Digitization', limit: true
     config.add_facet_field 'visibility_ssi', label: 'Access', limit: true
+    config.add_facet_field 'repository_ssi', label: 'Repository', limit: true
     config.add_facet_field 'format', label: 'Format', limit: true
     config.add_facet_field 'genre_ssim', label: 'Genre', limit: true
     config.add_facet_field 'resourceType_ssim', label: 'Resource Type', limit: true
@@ -168,7 +169,7 @@ class CatalogController < ApplicationController
     config.add_index_field 'subjectName_tesim', label: 'Subject (Name)', highlight: true, solr_params: disp_highlight_on_search_params
     config.add_index_field 'subjectTopic_tesim', label: 'Subject (Topic)', highlight: true, solr_params: disp_highlight_on_search_params
     config.add_index_field 'sourceCreated_tesim', label: 'Collection Created', highlight: true, solr_params: disp_highlight_on_search_params
-
+    config.add_index_field 'repository_ssi', label: 'Repository', highlight: true, solr_params: disp_highlight_on_search_params
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
     #
@@ -305,6 +306,7 @@ class CatalogController < ApplicationController
       'publisher_tesim',
       'preferredCitation_tesim',
       'repository_ssim',
+      "repository_ssi",
       'resourceType_tesim',
       'rights_tesim',
       'scale_tesim',

--- a/spec/system/view_facet_spec.rb
+++ b/spec/system/view_facet_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe 'Facets should display', type: :system, js: :true, clean: true do
     {
       id: '111',
       title_tesim: ['Amor Llama'],
+      repository_ssi: 'Yale University Arts Library',
       format: 'text',
       language_ssim: 'la',
       visibility_ssi: 'Yale Community Only',
@@ -29,6 +30,7 @@ RSpec.describe 'Facets should display', type: :system, js: :true, clean: true do
     {
       id: '222',
       title_tesim: ['HandsomeDan Bulldog'],
+      repository_ssi: 'Yale University Arts Library',
       format: 'three dimensional object',
       language_ssim: 'en',
       visibility_ssi: 'Public',
@@ -78,6 +80,14 @@ RSpec.describe 'Facets should display', type: :system, js: :true, clean: true do
     expect(page).to have_content('Amor Llama')
     expect(page).not_to have_content('Aquila Eccellenza')
     expect(page).not_to have_content('HandsomeDan Bulldog')
+  end
+
+  it 'can filter results with repository facets' do
+    click_on 'Repository'
+    click_on 'Yale University Arts Library'
+    expect(page).to have_content('Amor Llama')
+    expect(page).to have_content('HandsomeDan Bulldog')
+    expect(page).not_to have_content('Aquila Eccellenza')
   end
 
   it 'can filter results with genre facets' do


### PR DESCRIPTION
Story:

We'd like users to be able to facet by repository.

Acceptance

 

- [x] Add a "Repository" facet, based on the value indexed in #1413. It should appear immediately after the "Access" facet. Mockup:

![image](https://user-images.githubusercontent.com/46331329/124024837-bd207780-d9bd-11eb-8ed3-ca37c55be76c.png)

Repository in the facet:
<img width="1508" alt="Screen Shot 2021-07-02 at 11 34 24 AM" src="https://user-images.githubusercontent.com/46331329/124300018-15758780-db2c-11eb-8ba3-199947a7be39.png">

