### PR TITLE
1419 collection title

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -170,7 +170,6 @@ class CatalogController < ApplicationController
     config.add_index_field 'subjectName_tesim', label: 'Subject (Name)', highlight: true, solr_params: disp_highlight_on_search_params
     config.add_index_field 'subjectTopic_tesim', label: 'Subject (Topic)', highlight: true, solr_params: disp_highlight_on_search_params
     config.add_index_field 'sourceCreated_tesim', label: 'Collection Created', highlight: true, solr_params: disp_highlight_on_search_params
-    config.add_index_field 'ancestorTitles_tesim', label: 'Found in', highlight: true, solr_params: disp_highlight_on_search_params
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
@@ -267,7 +266,6 @@ class CatalogController < ApplicationController
       'accessionNumber_ssi',
       'alternativeTitle_tesim',
       'alternativeTitleDisplay_tesim',
-      'ancestorTitles_tesim',
       'archiveSpaceUri_ssi',
       'callNumber_tesim',
       'containerGrouping_tesim',

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -106,6 +106,7 @@ class CatalogController < ApplicationController
 
     config.add_facet_field 'extentOfDigitization_ssim', label: 'Extent of Digitization', limit: true
     config.add_facet_field 'visibility_ssi', label: 'Access', limit: true
+    config.add_facet_field 'repository_ssi', label: 'Repository', limit: true
     config.add_facet_field 'format', label: 'Format', limit: true
     config.add_facet_field 'genre_ssim', label: 'Genre', limit: true
     config.add_facet_field 'resourceType_ssim', label: 'Resource Type', limit: true
@@ -168,7 +169,7 @@ class CatalogController < ApplicationController
     config.add_index_field 'subjectName_tesim', label: 'Subject (Name)', highlight: true, solr_params: disp_highlight_on_search_params
     config.add_index_field 'subjectTopic_tesim', label: 'Subject (Topic)', highlight: true, solr_params: disp_highlight_on_search_params
     config.add_index_field 'sourceCreated_tesim', label: 'Collection Created', highlight: true, solr_params: disp_highlight_on_search_params
-
+    config.add_index_field 'repository_ssi', label: 'Repository', highlight: true, solr_params: disp_highlight_on_search_params
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
     #
@@ -305,6 +306,7 @@ class CatalogController < ApplicationController
       'publisher_tesim',
       'preferredCitation_tesim',
       'repository_ssim',
+      "repository_ssi",
       'resourceType_tesim',
       'rights_tesim',
       'scale_tesim',

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -107,6 +107,7 @@ class CatalogController < ApplicationController
     config.add_facet_field 'extentOfDigitization_ssim', label: 'Extent of Digitization', limit: true
     config.add_facet_field 'visibility_ssi', label: 'Access', limit: true
     config.add_facet_field 'repository_ssi', label: 'Repository', limit: true
+    config.add_facet_field 'collection_title_ssi', label: 'Collection Title', limit: true
     config.add_facet_field 'format', label: 'Format', limit: true
     config.add_facet_field 'genre_ssim', label: 'Genre', limit: true
     config.add_facet_field 'resourceType_ssim', label: 'Resource Type', limit: true
@@ -170,6 +171,7 @@ class CatalogController < ApplicationController
     config.add_index_field 'subjectTopic_tesim', label: 'Subject (Topic)', highlight: true, solr_params: disp_highlight_on_search_params
     config.add_index_field 'sourceCreated_tesim', label: 'Collection Created', highlight: true, solr_params: disp_highlight_on_search_params
     config.add_index_field 'repository_ssi', label: 'Repository', highlight: true, solr_params: disp_highlight_on_search_params
+    config.add_index_field 'collection_title_ssi', label: 'Collection Title', highlight: true, solr_params: disp_highlight_on_search_params
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
     #
@@ -269,6 +271,7 @@ class CatalogController < ApplicationController
       'callNumber_tesim',
       'containerGrouping_tesim',
       'collectionId_tesim',
+      'collection_title_ssi',
       'contents_tesim',
       'contributor_tsim',
       'contributorDisplay_tsim',

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -170,8 +170,8 @@ class CatalogController < ApplicationController
     config.add_index_field 'subjectName_tesim', label: 'Subject (Name)', highlight: true, solr_params: disp_highlight_on_search_params
     config.add_index_field 'subjectTopic_tesim', label: 'Subject (Topic)', highlight: true, solr_params: disp_highlight_on_search_params
     config.add_index_field 'sourceCreated_tesim', label: 'Collection Created', highlight: true, solr_params: disp_highlight_on_search_params
-    config.add_index_field 'repository_ssi', label: 'Repository', highlight: true, solr_params: disp_highlight_on_search_params
-    config.add_index_field 'collection_title_ssi', label: 'Collection Title', highlight: true, solr_params: disp_highlight_on_search_params
+    config.add_index_field 'ancestorTitles_tesim', label: 'Found in', highlight: true, solr_params: disp_highlight_on_search_params
+
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
     #
@@ -267,6 +267,7 @@ class CatalogController < ApplicationController
       'accessionNumber_ssi',
       'alternativeTitle_tesim',
       'alternativeTitleDisplay_tesim',
+      'ancestorTitles_tesim',
       'archiveSpaceUri_ssi',
       'callNumber_tesim',
       'containerGrouping_tesim',

--- a/spec/system/view_facet_spec.rb
+++ b/spec/system/view_facet_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe 'Facets should display', type: :system, js: :true, clean: true do
     {
       id: '111',
       title_tesim: ['Amor Llama'],
+      repository_ssi: 'Yale University Arts Library',
       format: 'text',
       language_ssim: 'la',
       visibility_ssi: 'Yale Community Only',
@@ -29,6 +30,7 @@ RSpec.describe 'Facets should display', type: :system, js: :true, clean: true do
     {
       id: '222',
       title_tesim: ['HandsomeDan Bulldog'],
+      repository_ssi: 'Yale University Arts Library',
       format: 'three dimensional object',
       language_ssim: 'en',
       visibility_ssi: 'Public',
@@ -78,6 +80,14 @@ RSpec.describe 'Facets should display', type: :system, js: :true, clean: true do
     expect(page).to have_content('Amor Llama')
     expect(page).not_to have_content('Aquila Eccellenza')
     expect(page).not_to have_content('HandsomeDan Bulldog')
+  end
+
+  it 'can filter results with repository facets' do
+    click_on 'Repository'
+    click_on 'Yale University Arts Library'
+    expect(page).to have_content('Amor Llama')
+    expect(page).to have_content('HandsomeDan Bulldog')
+    expect(page).not_to have_content('Aquila Eccellenza')
   end
 
   it 'can filter results with genre facets' do

--- a/spec/system/view_facet_spec.rb
+++ b/spec/system/view_facet_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe 'Facets should display', type: :system, js: :true, clean: true do
       id: '111',
       title_tesim: ['Amor Llama'],
       repository_ssi: 'Yale University Arts Library',
+      collection_title_ssi: ['AAA'],
       format: 'text',
       language_ssim: 'la',
       visibility_ssi: 'Yale Community Only',
@@ -87,6 +88,14 @@ RSpec.describe 'Facets should display', type: :system, js: :true, clean: true do
     click_on 'Yale University Arts Library'
     expect(page).to have_content('Amor Llama')
     expect(page).to have_content('HandsomeDan Bulldog')
+    expect(page).not_to have_content('Aquila Eccellenza')
+  end
+
+  it 'can filter results with collection title facets' do
+    click_on 'Collection Title'
+    click_on 'AAA'
+    expect(page).to have_content('Amor Llama')
+    expect(page).not_to have_content('HandsomeDan Bulldog')
     expect(page).not_to have_content('Aquila Eccellenza')
   end
 


### PR DESCRIPTION


Story:

We'd like to be able to facet on Collection Title.

Acceptance

- [x]  Add a facet "Collection Title" immediately below the new "Repository" facet (see #1417). See #1413 for the Solr field name.

![image](https://user-images.githubusercontent.com/46331329/124024861-c4e01c00-d9bd-11eb-918f-65e7569b47bc.png)
Collection Title in the facet:

<img width="1508" alt="Screen Shot 2021-07-02 at 11 34 24 AM" src="https://user-images.githubusercontent.com/46331329/124300093-2d4d0b80-db2c-11eb-9b4d-73d304228f39.png">
