### PR TITLE
I1415 archival context

### DIFF
--- a/app/assets/stylesheets/customOverrides/show_page.scss
+++ b/app/assets/stylesheets/customOverrides/show_page.scss
@@ -1,6 +1,16 @@
 /********************************************************
 DEFAULT MOBILE STYLING
 ********************************************************/
+
+//Archival Context
+.blacklight-ancestortitles_tesim {
+  padding-right: 4px;
+}
+
+.archival-context {
+  display: flex;
+}
+
 .show-buttons > .btn-show {
   text-transform: uppercase;
 }

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -184,6 +184,7 @@ class CatalogController < ApplicationController
     # ]
 
     # Description Group
+    config.add_show_field 'ancestorTitles_tesim', label: 'Found In', metadata: 'ancestorTitles', helper_method: :archival_display
     config.add_show_field 'title_tesim', label: 'Title', metadata: 'description', helper_method: :join_with_br
     config.add_show_field 'alternativeTitle_tesim', label: 'Alternative Title', metadata: 'description', helper_method: :join_with_br
     config.add_show_field 'creator_ssim', label: 'Creator', metadata: 'description', link_to_facet: true

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -76,6 +76,11 @@ module BlacklightHelper
     safe_join(values, '<br/>'.html_safe)
   end
 
+  def archival_display(arg)
+    values = arg[:document][arg[:field]]
+    safe_join(values.reverse(), ' > ')
+  end
+
   def faceted_join_with_br(arg)
     values = arg[:document][arg[:field]]
     links = []

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -78,7 +78,7 @@ module BlacklightHelper
 
   def archival_display(arg)
     values = arg[:document][arg[:field]]
-    safe_join(values.reverse(), ' > ')
+    safe_join(values.reverse, ' > ')
   end
 
   def faceted_join_with_br(arg)

--- a/app/views/catalog/_archival_context.html.erb
+++ b/app/views/catalog/_archival_context.html.erb
@@ -1,0 +1,29 @@
+<% metadata = [
+  'ancestorTitles'
+] %>
+
+<div class='item-page__metadata-wrapper'>
+  <% metadata.each do | m | %>
+    <% doc_presenter = show_presenter(document) %>
+
+    <%# <div class='metadata-block single-item-show'> %>
+      <%# <dl class='metadata-block__group'> %>
+
+        <% doc_presenter.metadata_fields_to_render(metadata).each do |field_name, field, field_presenter| %>
+          <% if field_name == "ancestorTitles_tesim" %>
+            <div class="archival-context">
+              <!-- KEY -->
+              <p class='blacklight-<%= field_name.parameterize %> metadata-block__label-key'>
+                <%= (render_document_show_field_label document, field: field_name) %>
+              </p>
+              <!-- VALUE -->
+              <p class='blacklight-<%= field_name.parameterize %> metadata-block__label-value metadata-block__label-value--yul'>
+                <%= field_presenter.render %>
+              </p>
+            </div>
+          <% end %>
+        <% end %>
+      <%# </dl> %>
+    <%# </div> %>
+  <% end %>
+</div>

--- a/app/views/catalog/_archival_context.html.erb
+++ b/app/views/catalog/_archival_context.html.erb
@@ -6,24 +6,19 @@
   <% metadata.each do | m | %>
     <% doc_presenter = show_presenter(document) %>
 
-    <%# <div class='metadata-block single-item-show'> %>
-      <%# <dl class='metadata-block__group'> %>
-
-        <% doc_presenter.metadata_fields_to_render(metadata).each do |field_name, field, field_presenter| %>
-          <% if field_name == "ancestorTitles_tesim" %>
-            <div class="archival-context">
-              <!-- KEY -->
-              <p class='blacklight-<%= field_name.parameterize %> metadata-block__label-key'>
-                <%= (render_document_show_field_label document, field: field_name) %>
-              </p>
-              <!-- VALUE -->
-              <p class='blacklight-<%= field_name.parameterize %> metadata-block__label-value metadata-block__label-value--yul'>
-                <%= field_presenter.render %>
-              </p>
-            </div>
-          <% end %>
-        <% end %>
-      <%# </dl> %>
-    <%# </div> %>
+    <% doc_presenter.metadata_fields_to_render(metadata).each do |field_name, field, field_presenter| %>
+      <% if field_name == "ancestorTitles_tesim" %>
+        <div class="archival-context">
+          <!-- KEY -->
+          <p class='blacklight-<%= field_name.parameterize %> metadata-block__label-key'>
+            <%= (render_document_show_field_label document, field: field_name) %>
+          </p>
+          <!-- VALUE -->
+          <p class='blacklight-<%= field_name.parameterize %> metadata-block__label-value metadata-block__label-value--yul'>
+            <%= field_presenter.render %>
+          </p>
+        </div>
+      <% end %>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/catalog/_show_main_content.html.erb
+++ b/app/views/catalog/_show_main_content.html.erb
@@ -9,7 +9,9 @@
   <div id="doc_<%= @document.id.to_s.parameterize %>">
     <!-- Only render universal viewer if the work is public OR if the user is authenticated -->
     <% if client_can_view_digital?(@document) %>
-      <%= render_document_partials @document, [:show_header, :uv] %>
+      <%= render_document_partials @document, [:show_header] %>
+      <%= render_document_partials @document, [:archival_context] %>
+      <%= render_document_partials @document, [:uv] %>
       <%= render "grouped_metadata" %>
     <% else %>
       <%= render_document_partials @document, [:show_header] %>

--- a/spec/system/show_page_spec.rb
+++ b/spec/system/show_page_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe 'Show Page', type: :system, js: true, clean: true do
       language_ssim: 'la',
       visibility_ssi: 'Public',
       genre_ssim: 'Maps',
+      ancestorTitles_tesim: ['Oversize', 'Abraham Lincoln collection (GEN MSS 257)', 'Beinecke Rare Book and Manuscript Library (BRBL)'],
       resourceType_ssim: 'Maps, Atlases & Globes',
       creator_ssim: ['Anna Elizabeth Dewdney'],
       creator_tesim: ['Anna Elizabeth Dewdney'],
@@ -131,6 +132,14 @@ RSpec.describe 'Show Page', type: :system, js: true, clean: true do
       expect(page).to have_xpath("//button[@href='/catalog?page=1&per_page=10&search_field=all_fields']")
     end
   end
+
+  context 'Archival Context breadcrumbs' do
+    it 'renders the Archival Context' do
+      expect(page).to have_content 'Found In:'
+      expect(page).to have_content 'Beinecke Rare Book and Manuscript Library (BRBL) > Abraham Lincoln collection (GEN MSS 257) > Oversize'
+    end
+  end
+  
 
   context '"New Search" button' do
     it 'returns user to homepage' do

--- a/spec/system/show_page_spec.rb
+++ b/spec/system/show_page_spec.rb
@@ -139,7 +139,6 @@ RSpec.describe 'Show Page', type: :system, js: true, clean: true do
       expect(page).to have_content 'Beinecke Rare Book and Manuscript Library (BRBL) > Abraham Lincoln collection (GEN MSS 257) > Oversize'
     end
   end
-  
 
   context '"New Search" button' do
     it 'returns user to homepage' do


### PR DESCRIPTION
Show pages will now render the archival context breadcrumbs above the UV:  
![Image 2021-07-06 at 4 52 58 PM](https://user-images.githubusercontent.com/24666568/124680167-ad4fda00-de7a-11eb-9faa-42795437a5fd.jpg)
