### PR TITLE
ancestor title display in search result

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -170,6 +170,7 @@ class CatalogController < ApplicationController
     config.add_index_field 'subjectName_tesim', label: 'Subject (Name)', highlight: true, solr_params: disp_highlight_on_search_params
     config.add_index_field 'subjectTopic_tesim', label: 'Subject (Topic)', highlight: true, solr_params: disp_highlight_on_search_params
     config.add_index_field 'sourceCreated_tesim', label: 'Collection Created', highlight: true, solr_params: disp_highlight_on_search_params
+    config.add_index_field 'ancestorTitles_tesim', label: 'Found in', helper_method: :archival_display
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
     #

--- a/spec/system/highlight_in_search_spec.rb
+++ b/spec/system/highlight_in_search_spec.rb
@@ -26,7 +26,11 @@ RSpec.describe 'Search results displays field', type: :system, clean: true do
       subjectGeographic_tesim: 'United States--Maps, Manuscript',
       subjectTopic_tesim: 'Phrenology--United States',
       subjectName_tesim: 'Price, Leo',
-      visibility_ssi: 'Public'
+      visibility_ssi: 'Public',
+      ancestorTitles_tesim: ['Beinecke Rare Book and Manuscript Library (BRBL)',
+                             'Osborn Manuscript Files (OSB MSS FILE)',
+                             'Numerical Sequence: 17975-19123',
+                             'BURNEY, SARAH HARRIET, 1772-1844']
     }
   end
 
@@ -36,6 +40,8 @@ RSpec.describe 'Search results displays field', type: :system, clean: true do
     it 'highlights title when a term is queried' do
       visit '/catalog?search_field=all_fields&q=Dan'
       expect(page.html).to include "Jack or <span class='search-highlight'>Dan</span> the Bulldog"
+      expect(page.html).to include "Beinecke Rare Book and Manuscript Library (BRBL) >"
+      expect(page.html).to include "> BURNEY, SARAH HARRIET, 1772-1844"
     end
 
     it 'highlights abstract when a term is queried' do

--- a/spec/system/highlight_in_search_spec.rb
+++ b/spec/system/highlight_in_search_spec.rb
@@ -26,11 +26,7 @@ RSpec.describe 'Search results displays field', type: :system, clean: true do
       subjectGeographic_tesim: 'United States--Maps, Manuscript',
       subjectTopic_tesim: 'Phrenology--United States',
       subjectName_tesim: 'Price, Leo',
-      visibility_ssi: 'Public',
-      ancestorTitles_tesim: ['Beinecke Rare Book and Manuscript Library (BRBL)',
-                             'Osborn Manuscript Files (OSB MSS FILE)',
-                             'Numerical Sequence: 17975-19123',
-                             'BURNEY, SARAH HARRIET, 1772-1844']
+      visibility_ssi: 'Public'
     }
   end
 
@@ -40,8 +36,6 @@ RSpec.describe 'Search results displays field', type: :system, clean: true do
     it 'highlights title when a term is queried' do
       visit '/catalog?search_field=all_fields&q=Dan'
       expect(page.html).to include "Jack or <span class='search-highlight'>Dan</span> the Bulldog"
-      expect(page.html).to include "Beinecke Rare Book and Manuscript Library (BRBL) >"
-      expect(page.html).to include "> BURNEY, SARAH HARRIET, 1772-1844"
     end
 
     it 'highlights abstract when a term is queried' do

--- a/spec/system/view_fields_in_search_spec.rb
+++ b/spec/system/view_fields_in_search_spec.rb
@@ -17,7 +17,11 @@ RSpec.describe 'Search results displays field', type: :system, clean: true do
       resourceType_ssim: 'Archives or Manuscripts',
       callNumber_tesim: 'Beinecke MS 801',
       imageCount_isi: '23',
-      visibility_ssi: 'Public'
+      visibility_ssi: 'Public',
+      ancestorTitles_tesim: ['Beinecke Rare Book and Manuscript Library (BRBL)',
+                             'Osborn Manuscript Files (OSB MSS FILE)',
+                             'Numerical Sequence: 17975-19123',
+                             'BURNEY, SARAH HARRIET, 1772-1844']
     }
   end
 
@@ -38,6 +42,9 @@ RSpec.describe 'Search results displays field', type: :system, clean: true do
     end
     it 'displays Image Count in results' do
       expect(content).to have_content('23')
+    end
+    it 'displays Ancestor Title (Found in) in results' do
+      expect(content).to have_content('Osborn Manuscript Files (OSB MSS FILE)')
     end
   end
 end


### PR DESCRIPTION
Acceptance

 
- [x] Display the information in the search results list.

- [x] For objects with ASpace source data, format each value from ancestorTitles, delimited by > See #1413 for field names in Solr.

- [x]  Use the same horizontal spacing/alignment as the other fields (there's no space in the mock below)

- [x] Display does not include links.

<img width="865" alt="Screen Shot 2021-07-08 at 10 04 45 AM" src="https://user-images.githubusercontent.com/46331329/124940409-f49fad00-dfd7-11eb-8078-5956fbc5f734.png">
