### PR TITLE
1415 css found in text no longer breaks with larger breadcrumbs

### DIFF
--- a/app/assets/stylesheets/customOverrides/show_page.scss
+++ b/app/assets/stylesheets/customOverrides/show_page.scss
@@ -5,10 +5,16 @@ DEFAULT MOBILE STYLING
 //Archival Context
 .blacklight-ancestortitles_tesim {
   padding-right: 4px;
+  width: 1080px;
 }
 
 .archival-context {
   display: flex;
+}
+
+.archival-context-key {
+  width: 75px;
+  height: 20px;
 }
 
 .show-buttons > .btn-show {

--- a/app/assets/stylesheets/customOverrides/show_page.scss
+++ b/app/assets/stylesheets/customOverrides/show_page.scss
@@ -3,6 +3,7 @@ DEFAULT MOBILE STYLING
 ********************************************************/
 
 //Archival Context
+
 .blacklight-ancestortitles_tesim {
   padding-right: 4px;
   width: 1080px;
@@ -10,6 +11,9 @@ DEFAULT MOBILE STYLING
 
 .archival-context {
   display: flex;
+  width: 83%;
+  left: 8%;
+  position: relative;
 }
 
 .archival-context-key {
@@ -229,6 +233,11 @@ h2.yale-restricted-work-text {
     width: 92%;
   }
 
+  .archival-context {
+    left: 8%;
+    width: 92%;
+  }
+
   .single-item-show {
     width: 625px;
   }
@@ -282,6 +291,11 @@ h2.yale-restricted-work-text {
   .yale-restricted-work-text {
     width: 97%;
     left: 19%;
+  }
+
+  .archival-context {
+    left: 19%;
+    width: 96%;
   }
 
   .single-item-show {

--- a/app/views/catalog/_archival_context.html.erb
+++ b/app/views/catalog/_archival_context.html.erb
@@ -10,9 +10,11 @@
       <% if field_name == "ancestorTitles_tesim" %>
         <div class="archival-context">
           <!-- KEY -->
-          <p class='blacklight-<%= field_name.parameterize %> metadata-block__label-key'>
-            <%= (render_document_show_field_label document, field: field_name) %>
-          </p>
+          <div class="archival-context-key">
+            <p class='blacklight-<%= field_name.parameterize %> metadata-block__label-key'>
+              <%= (render_document_show_field_label document, field: field_name) %>
+            </p>
+          </div>
           <!-- VALUE -->
           <p class='blacklight-<%= field_name.parameterize %> metadata-block__label-value metadata-block__label-value--yul'>
             <%= field_presenter.render %>

--- a/app/views/catalog/_archival_context.html.erb
+++ b/app/views/catalog/_archival_context.html.erb
@@ -2,25 +2,23 @@
   'ancestorTitles'
 ] %>
 
-<div class='item-page__metadata-wrapper'>
-  <% metadata.each do | m | %>
-    <% doc_presenter = show_presenter(document) %>
+<% metadata.each do | m | %>
+  <% doc_presenter = show_presenter(document) %>
 
-    <% doc_presenter.metadata_fields_to_render(metadata).each do |field_name, field, field_presenter| %>
-      <% if field_name == "ancestorTitles_tesim" %>
-        <div class="archival-context">
-          <!-- KEY -->
-          <div class="archival-context-key">
-            <p class='blacklight-<%= field_name.parameterize %> metadata-block__label-key'>
-              <%= (render_document_show_field_label document, field: field_name) %>
-            </p>
-          </div>
-          <!-- VALUE -->
-          <p class='blacklight-<%= field_name.parameterize %> metadata-block__label-value metadata-block__label-value--yul'>
-            <%= field_presenter.render %>
+  <% doc_presenter.metadata_fields_to_render(metadata).each do |field_name, field, field_presenter| %>
+    <% if field_name == "ancestorTitles_tesim" %>
+      <div class="archival-context">
+        <!-- KEY -->
+        <div class="archival-context-key">
+          <p class='blacklight-<%= field_name.parameterize %> metadata-block__label-key'>
+            <%= (render_document_show_field_label document, field: field_name) %>
           </p>
         </div>
-      <% end %>
+        <!-- VALUE -->
+        <p class='blacklight-<%= field_name.parameterize %> metadata-block__label-value metadata-block__label-value--yul'>
+          <%= field_presenter.render %>
+        </p>
+      </div>
     <% end %>
   <% end %>
-</div>
+<% end %>


### PR DESCRIPTION
CSS no longer breaks when the breadcrumbs are more than one line:  
![Screen Recording 2021-07-12 at 02 45 55 PM](https://user-images.githubusercontent.com/24666568/125360026-11154f80-e320-11eb-8d45-b6372bcfc453.gif)


