### PR TITLE
Revert "Bump addressable from 2.7.0 to 2.8.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,7 +66,7 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2, >= 2.2.2)
-    addressable (2.8.0)
+    addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     amazing_print (1.2.2)
     apparition (0.6.0)


### PR DESCRIPTION
Reverts yalelibrary/yul-dc-blacklight#602