### PR TITLE
1464 Removed link from harmful content statement

### DIFF
--- a/app/views/application/landing.html.erb
+++ b/app/views/application/landing.html.erb
@@ -101,7 +101,7 @@
       </ul>
       <div id="content-statement">
        <h2>Statement on Potentially Harmful Content</h2>
-       <p>Yale University Library’s collections contain historical and contemporary materials documenting human expression and lived experience. Content may include images or language that library users may find harmful, offensive, or inappropriate. Some of these words or images are now recognized as offensive and unacceptable; some may have been viewed as unacceptable when they were created. Yale University Library staff are engaged in addressing or contextualizing this content and language</a>.</p>
+       <p>Yale University Library’s collections contain historical and contemporary materials documenting human expression and lived experience. Content may include images or language that library users may find harmful, offensive, or inappropriate. Some of these words or images are now recognized as offensive and unacceptable; some may have been viewed as unacceptable when they were created. Yale University Library staff are engaged in addressing or contextualizing this content and language.</p>
       </div>
     </div>
   </main>

--- a/app/views/application/landing.html.erb
+++ b/app/views/application/landing.html.erb
@@ -101,7 +101,7 @@
       </ul>
       <div id="content-statement">
        <h2>Statement on Potentially Harmful Content</h2>
-       <p>Yale University Library’s collections contain historical and contemporary materials documenting human expression and lived experience. Content may include images or language that library users may find harmful, offensive, or inappropriate. Some of these words or images are now recognized as offensive and unacceptable; some may have been viewed as unacceptable when they were created. Yale University Library staff are engaged in addressing or contextualizing this content and language; for more information, see the <a href="https://guides.library.yale.edu/about/statement-on-content">Statement on Potentially Harmful Content</a>.</p>
+       <p>Yale University Library’s collections contain historical and contemporary materials documenting human expression and lived experience. Content may include images or language that library users may find harmful, offensive, or inappropriate. Some of these words or images are now recognized as offensive and unacceptable; some may have been viewed as unacceptable when they were created. Yale University Library staff are engaged in addressing or contextualizing this content and language</a>.</p>
       </div>
     </div>
   </main>


### PR DESCRIPTION
**Story**

The link to the statement on harmful content is in flux.

**Acceptance**
- [x] Remove the link from the Blacklight home page, in red below:

Current Design with Link:
![MicrosoftTeams-image (3).png](https://images.zenhubusercontent.com/5e5d472f410278efd81466ab/2c78d395-88dd-4c0a-b889-d32e4351a89e)

Modified Design with Link: 
![Screen Shot 2021-07-19 at 2.11.09 PM.png](https://images.zenhubusercontent.com/5e6013c029e314c92afd4769/ee8bda7f-e70a-4695-8d2f-282969f81b52)