### PR TITLE
1464 link modification for harmful content statement

### DIFF
--- a/app/views/application/landing.html.erb
+++ b/app/views/application/landing.html.erb
@@ -101,8 +101,7 @@
       </ul>
       <div id="content-statement">
        <h2>Statement on Potentially Harmful Content</h2>
-       <p>Yale University Library’s collections contain historical and contemporary materials documenting human expression and lived experience. Content may include images or language that library users may find harmful, offensive, or inappropriate. Some of these words or images are now recognized as offensive and unacceptable; some may have been viewed as unacceptable when they were created. Yale University Library staff are engaged in addressing or contextualizing this content and language.</p>
-      </div>
+        <p>Yale University Library’s collections contain historical and contemporary materials documenting human expression and lived experience. Content may include images or language that library users may find harmful, offensive, or inappropriate. Some of these words or images are now recognized as offensive and unacceptable; some may have been viewed as unacceptable when they were created. Yale University Library staff are engaged in addressing or contextualizing this content and language; for more information, see the <a href="https://guides.library.yale.edu/statementharmfulcontent">Statement on Potentially Harmful Content</a>.</p>      </div>
     </div>
   </main>
 


### PR DESCRIPTION
**Story**

The link to the statement on harmful content is in flux.

**Acceptance**
- [x] Modified the link on the Blacklight home page to https://guides.library.yale.edu/statementharmfulcontent:

Current Link: 
![MicrosoftTeams-image (3).png](https://images.zenhubusercontent.com/5e5d472f410278efd81466ab/2c78d395-88dd-4c0a-b889-d32e4351a89e)

Modified Link: 
![Harm Content Link Modification](https://user-images.githubusercontent.com/41123693/126230217-00afc8fa-e100-47b8-9edd-6615df28db9d.gif)



