### PR TITLE
1171 Return multiple finding aid and associated links

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -210,6 +210,8 @@ class CatalogController < ApplicationController
     config.add_show_field 'sourceNote_tesim', label: 'Collection Note', metadata: 'collection_information'
     config.add_show_field 'sourceEdition_tesim', label: 'Collection Edition', metadata: 'collection_information'
     config.add_show_field 'containerGrouping_tesim', label: 'Container / Volume Information', metadata: 'collection_information'
+    config.add_show_field 'relatedResourceOnline_ssim', label: 'Related Resource Online', metadata: 'collection_information', helper_method: :link_to_url_with_label
+    config.add_show_field 'resourceVersionOnline_ssim', label: 'Resource Version Online', metadata: 'collection_information', helper_method: :link_to_url_with_label
     config.add_show_field 'findingAid_ssim', label: 'Finding Aid', metadata: 'collection_information', helper_method: :link_to_url
 
     # Subjects, Formats, and Genres Group

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -89,6 +89,20 @@ module BlacklightHelper
     "/catalog?f" + ERB::Util.url_encode("[#{field}][]") + "=#{value}"
   end
 
+  def link_to_url_with_label(arg)
+    links = arg[:value].map do |value|
+      link_part = value.split('|')
+      next unless link_part.count <= 2
+      urls = link_part.select { |s| s.start_with? 'http' }
+      labels = link_part.select { |s| !s.start_with? 'http' }
+      if urls.count == 1
+        label = labels[0] || urls[0]
+        link_to(label, urls[0])
+      end
+    end.compact
+    safe_join(links, '<br/>'.html_safe)
+  end
+
   def link_to_url(arg)
     link_to(arg[:value][0], arg[:value][0])
   end

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -49,3 +49,5 @@ class SearchBuilder < Blacklight::SearchBuilder
     solr_parameters["hl.simple.post"] = "</span>"
   end
 end
+
+# TODO: add RelatedResourceOnline and ResourceVersionOnline to the list in def self.solr_record_fields

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -39,6 +39,25 @@ RSpec.describe BlacklightHelper, helper: true, style: true do
     end
   end
 
+  describe 'link to url with label' do
+    context 'with a list of links with labels' do
+      let(:document) { SolrDocument.new(id: 'xyz') }
+      let(:args) do
+        {
+          document: document,
+          field: 'relatedResourceOnline_ssim',
+          value: ['View Related Resource|http://library.somewhere.com/special_page', 'http://library.somewhereelse.com/special_page', 'View Related Resource| not']
+        }
+      end
+
+      it 'returns a list of links with labels' do
+        # rubocop:disable Layout/LineLength
+        expect(helper.link_to_url_with_label(args)).to eq "<a href=\"http://library.somewhere.com/special_page\">View Related Resource</a><br/><a href=\"http://library.somewhereelse.com/special_page\">http://library.somewhereelse.com/special_page</a>"
+        # rubocop:enable Layout/LineLength
+      end
+    end
+  end
+
   describe '#render_thumbnail' do
     context 'with public record and oid with images' do
       let(:valid_document) { SolrDocument.new(id: 'test', visibility_ssi: 'Public', oid_ssi: ['2055095'], thumbnail_path_ss: "http://localhost:8182/iiif/2/1234822/full/!200,200/0/default.jpg") }


### PR DESCRIPTION
Co-authored-by: Martin Lovell <martin.lovell@yale.edu>

Co-authored-by: Martin Lovell <martin.lovell@yale.edu>

**Story**

Updates to Metadata Cloud will potentially return multiple Finding Aid links from Voyager records.

**Blocked by MC ticket 260**

**Acceptance**
- [x] All Finding Aid links are rendered when there's more than one.

See [ticket 1171](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1171)  for more details