### PR TITLE
Added related solr fields to search builder for finding aid

### DIFF
--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -101,6 +101,8 @@ class SearchBuilder < Blacklight::SearchBuilder
       publisher_tesim
       publisher_ssim
       recordType_ssi
+      relatedResourceOnline_ssim
+      resourceVersionOnline_ssim
       repository_ssim
       resourceType_ssim
       resourceType_tesim


### PR DESCRIPTION
Co-authored-by: Eric DeJesus <eric.dejesus@yale.com>

As a developer, I want the search builder to have the latest Solr fields. 

Acceptance: 
 - [ ] add resource version online
 - [ ] add related resource online