### PR TITLE
1451 display finding aidlink

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -217,8 +217,9 @@ class CatalogController < ApplicationController
     config.add_show_field 'sourceNote_tesim', label: 'Collection Note', metadata: 'collection_information'
     config.add_show_field 'sourceEdition_tesim', label: 'Collection Edition', metadata: 'collection_information'
     config.add_show_field 'containerGrouping_tesim', label: 'Container / Volume Information', metadata: 'collection_information'
-    config.add_show_field 'findingAid_ssim', label: 'Finding Aid', metadata: 'collection_information', helper_method: :link_to_url
+    # config.add_show_field 'findingAid_ssim', label: 'Finding Aid', metadata: 'collection_information', helper_method: :link_to_url
     config.add_show_field 'archiveSpaceUri_ssi', label: ' ', no_label: true, metadata: 'collection_information', helper_method: :aspace_link
+    config.add_show_field 'findingAid_ssim', label: ' ', no_label: true, metadata: 'collection_information', helper_method: :finding_aid_link
 
     # Subjects, Formats, and Genres Group
     config.add_show_field 'format', label: 'Format', metadata: 'subjects,_formats,_and_genres', link_to_facet: true

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -217,7 +217,6 @@ class CatalogController < ApplicationController
     config.add_show_field 'sourceNote_tesim', label: 'Collection Note', metadata: 'collection_information'
     config.add_show_field 'sourceEdition_tesim', label: 'Collection Edition', metadata: 'collection_information'
     config.add_show_field 'containerGrouping_tesim', label: 'Container / Volume Information', metadata: 'collection_information'
-    # config.add_show_field 'findingAid_ssim', label: 'Finding Aid', metadata: 'collection_information', helper_method: :link_to_url
     config.add_show_field 'archiveSpaceUri_ssi', label: ' ', no_label: true, metadata: 'collection_information', helper_method: :aspace_link
     config.add_show_field 'findingAid_ssim', label: ' ', no_label: true, metadata: 'collection_information', helper_method: :finding_aid_link
 

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -170,9 +170,8 @@ module BlacklightHelper
     links = []
     findingAidUri.each do |link|
       popup_window = image_tag("YULPopUpWindow.png", { id: 'popup_window', alt: 'pop up window' })
-      links << link_to("View full finding aid for #{arg[:document]['collection_title_ssi']}".html_safe + popup_window, link, target: '_blank')
+      links << link_to(safe_join(['View full finding aid for ', arg[:document]['collection_title_ssi']]) + popup_window, link, target: '_blank', rel: 'noopener')
     end
-    # safe_join(links, '<br/>'.html_safe)
     links.first
   end
 

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -164,6 +164,18 @@ module BlacklightHelper
     "/catalog?f" + ERB::Util.url_encode("[#{field}][]") + "=#{value}"
   end
 
+  def finding_aid_link(arg)
+    # rubocop:disable Naming/VariableName
+    findingAidUri = arg[:document][arg[:field]]
+    links = []
+    findingAidUri.each do |link|
+      popup_window = image_tag("YULPopUpWindow.png", { id: 'popup_window', alt: 'pop up window' })
+      links << link_to("View full finding aid for #{arg[:document]['collection_title_ssi']}".html_safe + popup_window, link, target: '_blank')
+    end
+    # safe_join(links, '<br/>'.html_safe)
+    links.first
+  end
+
   def link_to_url(arg)
     link_to(arg[:value][0], arg[:value][0])
   end

--- a/spec/system/view_fields_in_display_spec.rb
+++ b/spec/system/view_fields_in_display_spec.rb
@@ -63,6 +63,7 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       containerGrouping_tesim: 'this is the container information',
       orbisBibId_ssi: '1234567',
       findingAid_ssim: 'this is the finding aid',
+      collection_title_ssi: 'this is the collection title',
       edition_ssim: 'this is the edition',
       material_tesim: "this is the material, using ssim",
       scale_tesim: "this is the scale, using ssim",
@@ -198,9 +199,6 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
     it 'displays the Orbis Bib ID in results' do
       expect(document).to have_content("1234567")
     end
-    it 'displays the Finding Aid in results' do
-      expect(document).to have_content("this is the finding aid")
-    end
     it 'displays the Edition in results' do
       expect(document).to have_content("this is the edition")
     end
@@ -231,9 +229,6 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
     end
     it 'contains a link for the Creator field to the facet' do
       expect(page).to have_link('Frederick, Eric & Maggie', href: '/catalog?f%5Bcreator_ssim%5D%5B%5D=Frederick%2C++Eric+%26+Maggie')
-    end
-    it 'contains a link on the Finding Aid to the Finding Aid catalog record' do
-      expect(page).to have_link('this is the finding aid', href: 'this is the finding aid')
     end
     it 'contains a link on the more info to the more info record' do
       expect(page).to have_link('http://0.0.0.0:3000/catalog/111', href: 'http://0.0.0.0:3000/catalog/111')
@@ -272,6 +267,13 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
         expect(page).to have_content "second"
         expect(page).to have_content "third"
       end
+    end
+    it 'contains a link to Finding Aid' do
+      finding_aid_link = page.find("a[href = 'this is the finding aid']")
+
+      expect(finding_aid_link).to be_truthy
+      expect(finding_aid_link).to have_content "View full finding aid for this is the collection title"
+      expect(finding_aid_link).to have_css("img[src ^= '/assets/YULPopUpWindow']")
     end
   end
 


### PR DESCRIPTION
Co-authored-by: Eric DeJesus <eric.dejesus@yale.com>

**Story**

If a Finding Aid exists, we'd like to link to it.  Wireframe:

![Screen Shot 2021-07-09 at 1.34.13 PM.png](https://images.zenhubusercontent.com/5e5d472f410278efd81466ab/7c6d0731-4f6d-488a-96c6-05c4a6dd89a9)

**Acceptance**
- [x] Use the first URL in `findingAid_ssim` for the link
- [x] Use text, icon, and position as in the wireframe; note that the link includes the collection title.
- [x] Open the Finding Aid in a new window

TODO: How to handle multiple?

Note/Decision:  We are going to check for collection_title_ssi