### PR TITLE
1485 Added Hierarchy graphical display links to single item page

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -524,8 +524,14 @@ class CatalogController < ApplicationController
     blacklight_config[:per_page] = grouping
   end
 
+  def index
+    session[:search_params] = request.params.dup
+    super
+  end
+
   def show
     super
+    @search_params = session[:search_params]
     render "catalog/show_unauthorized", status: :unauthorized unless client_can_view_metadata?(@document)
   end
 end

--- a/spec/system/view_fields_in_display_spec.rb
+++ b/spec/system/view_fields_in_display_spec.rb
@@ -72,7 +72,8 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       projection_tesim: "this is the projection, using ssim",
       extent_ssim: ["this is the extent, using ssim", "here is another extent"],
       archiveSpaceUri_ssi: "/repositories/11/archival_objects/214638",
-      ancestorDisplayStrings_tesim: %w[third second first]
+      ancestorDisplayStrings_tesim: %w[third second first],
+      ancestor_titles_hierarchy_ssim: ['first > ', 'first > second > ', 'first > second > third > ']
     }
   end
 
@@ -252,7 +253,7 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       expect(aspace_link).to have_content "View item information in Archives at Yale"
       expect(aspace_link).to have_css("img[src ^= '/assets/YULPopUpWindow']")
     end
-    context 'ASpace hierarchy display' do
+    context 'ASpace hierarchy graphical display' do
       it 'has an ellipsis instead of a full tree' do
         expect(page).to have_content "first"
         expect(page).not_to have_text(type: :visible, text: "second")
@@ -266,6 +267,37 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
         expect(page).not_to have_text(type: :visible, text: "...")
         expect(page).to have_content "second"
         expect(page).to have_content "third"
+      end
+      it 'has links for each item' do
+        within '.aSpace_tree' do
+          page.find('.show-full-tree-button').click
+
+          expect(page).to have_link "first"
+          expect(page).to have_link "second"
+          expect(page).to have_link "third"
+        end
+      end
+      it 'searches on link click' do
+        within '.aSpace_tree' do
+          page.find('.show-full-tree-button').click
+
+          click_on 'second'
+        end
+        expect(page).to have_content "Diversity Bull Dogs"
+      end
+      it 'preserves search constraints', style: true do
+        visit '/catalog?q='
+        click_on 'Creator'
+        click_on 'Frederick'
+
+        visit '/catalog/111'
+        within '.aSpace_tree' do
+          page.find('.show-full-tree-button').click
+
+          click_on 'second'
+        end
+        expect(page).to have_css ".filter-name", text: "Found In", count: 1
+        expect(page).to have_css ".filter-name", text: "Creator", count: 1
       end
     end
     it 'contains a link to Finding Aid' do


### PR DESCRIPTION
Co-authored-by: Eric DeJesus <eric.dejesus@yale.edu>

**Story**

Users should easily be able to restrict their search to a specific archive or component of an archive.  

![Screen Shot 2021-07-26 at 10.42.47 AM.png](https://images.zenhubusercontent.com/5e5d472f410278efd81466ab/dba1f5f9-4b21-4e1d-8b58-79f7bbd7b91d)

**Acceptance**
- [x] Each element of the hierarchy is a link
- [x] Clicking the link restricts the user's search to objects at that level of the collection or below. 
- [x] Other criteria of the user's search remain unchanged.
 