### PR TITLE
1498 Blacklight tar Dependency Patching WK32

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "postcss": "^8.3.2",
     "serialize-javascript": "^3.1.0",
     "ssri": "^8.0.1",
+    "tar": "^6.1.6",
     "trim-newlines": "^4.0.2",
     "turbolinks": "^5.2.0",
     "universalviewer": "3.0.16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7094,6 +7094,18 @@ tar@^6.0.2:
     mkdirp "^1.0.3"
     yallist "^4.0.0"
 
+tar@^6.1.6:
+  version "6.1.6"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.6.tgz#c23d797b0a1efe5d479b1490805c5443f3560c5d"
+  integrity sha512-oaWyu5dQbHaYcyZCTfyPpC+VmI62/OM2RTUYavTk1MDr1cwW5Boi3baeYQKiZbY2uSQJGr+iMOzb/JFxLrft+g==
+  dependencies:
+    chownr "^2.0.0"
+    fs-minipass "^2.0.0"
+    minipass "^3.0.0"
+    minizlib "^2.1.1"
+    mkdirp "^1.0.3"
+    yallist "^4.0.0"
+
 terser-webpack-plugin@^1.4.3:
   version "1.4.5"
   resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz#a217aefaea330e734ffacb6120ec1fa312d6040b"


### PR DESCRIPTION
Story
The application's dependencies should be up-to-date for week 32 of the year.

![Dependabot alerts.png](https://images.zenhubusercontent.com/5e6013c029e314c92afd4769/1e6f4a16-d4fb-499b-a008-b22051130212)

---

Acceptance
- [x] patch tar from 6.1.0 to 6.1.5
- [x] create a separate release 
- [x] deploy the patch release to test 
- [x] deploy the patch release to UAT
