### PR TITLE
1502 Changed result page 'Found In' links color

### DIFF
--- a/app/assets/stylesheets/customOverrides/show_page.scss
+++ b/app/assets/stylesheets/customOverrides/show_page.scss
@@ -174,6 +174,10 @@ DEFAULT MOBILE STYLING
   width: 70%;
 }
 
+.blacklight-ancestortitles_tesim a{
+  color: $light_blue;
+}
+
 .single-item-show {
   border-bottom: 1px solid $light_grey;
   margin-bottom: 45px;


### PR DESCRIPTION
**User Story**

As a user I want the links to be the same color on the whole site. 

- [x] change the color of the 'found in' links on the result page.

Current Design: 
![image.png](https://images.zenhubusercontent.com/5e6013c029e314c92afd4769/7c832ccc-0a6d-4126-8cb4-29195f15429e)

Proposed Design: 

![image.png](https://images.zenhubusercontent.com/5e6013c029e314c92afd4769/cd485fed-59eb-4548-b81f-0540e4777db8)

----
**Alternative Description**

The 'found in' links on the result page are not the correct color.   

