### PR TITLE
1468 Break abstract up into paragraphs

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -190,7 +190,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'copyrightDate_ssim', label: 'Copyright Date', metadata: 'description'
     config.add_show_field 'creationPlace_ssim', label: 'Publication Place', metadata: 'description'
     config.add_show_field 'publisher_ssim', label: 'Publisher', metadata: 'description'
-    config.add_show_field 'abstract_tesim', label: 'Abstract', metadata: 'description'
+    config.add_show_field 'abstract_tesim', label: 'Abstract', metadata: 'description', helper_method: :join_as_paragraphs
     config.add_show_field 'description_tesim', label: 'Description', metadata: 'description', helper_method: :join_with_br
     config.add_show_field 'extent_ssim', label: 'Extent', metadata: 'description', helper_method: :join_with_br
     config.add_show_field 'extentOfDigitization_ssim', label: 'Extent of Digitization', metadata: 'description'

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -76,6 +76,11 @@ module BlacklightHelper
     safe_join(values, '<br/>'.html_safe)
   end
 
+  def join_as_paragraphs(arg)
+    values = arg[:value]
+    '<p>'.html_safe + safe_join(values, '</p><p>'.html_safe) + '</p>'.html_safe if values
+  end
+
   def faceted_join_with_br(arg)
     values = arg[:document][arg[:field]]
     links = []

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -39,6 +39,20 @@ RSpec.describe BlacklightHelper, helper: true, style: true do
     end
   end
 
+  describe '#join_as_paragraphs' do
+    it 'returns multiple items in paragraphs' do
+      expect(helper.join_as_paragraphs({ value: %w[Test1 Test2 Test3] })).to eq '<p>Test1</p><p>Test2</p><p>Test3</p>'
+    end
+
+    it 'returns one item in paragraph' do
+      expect(helper.join_as_paragraphs({ value: %w[Test1] })).to eq '<p>Test1</p>'
+    end
+
+    it 'returns nil with nil value' do
+      expect(helper.join_as_paragraphs({ value: nil })).to be_nil
+    end
+  end
+
   describe '#render_thumbnail' do
     context 'with public record and oid with images' do
       let(:valid_document) { SolrDocument.new(id: 'test', visibility_ssi: 'Public', oid_ssi: ['2055095'], thumbnail_path_ss: "http://localhost:8182/iiif/2/1234822/full/!200,200/0/default.jpg") }

--- a/spec/system/view_fields_in_display_spec.rb
+++ b/spec/system/view_fields_in_display_spec.rb
@@ -37,7 +37,7 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       language_ssim: ['en', 'eng', 'zz'],
       description_tesim: ["Handsome Dan is a bulldog who serves as Yale Univeristy's mascot.", "here is something else about it"],
       visibility_ssi: 'Public',
-      abstract_tesim: "this is an abstract",
+      abstract_tesim: ["this is an abstract", "abstract2"],
       alternativeTitle_tesim: ["this is an alternative title", "this is the second alternative title"],
       genre_ssim: ["this is the genre", "this is the second genre"],
       subjectGeographic_ssim: ['this is the geo subject', 'these are the geo subjects'],
@@ -116,7 +116,7 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       expect(page).to have_text("Handsome Dan is a bulldog who serves as Yale Univeristy's mascot.here is something else about it")
     end
     it 'displays the Abstract in results' do
-      expect(document).to have_content("this is an abstract")
+      expect(page.html).to match("<p>this is an abstract</p><p>abstract2</p>")
     end
     it 'displays the Alternative Title in results' do
       expect(page.html).to match("this is an alternative title<br/>")


### PR DESCRIPTION
Adds join_as_paragraphs helper for joining an array of strings into &lt;p> tags.
Uses join_as_paragraphs for abstract on show page.