### PR TITLE
1483 Add breadcrumbs to hierarchy elements on single object page

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -186,7 +186,7 @@ class CatalogController < ApplicationController
     # ]
 
     # Description Group
-    config.add_show_field 'ancestorTitles_tesim', label: 'Found In', metadata: 'ancestorTitles', helper_method: :archival_display
+    config.add_show_field 'ancestorTitles_tesim', label: 'Found In', metadata: 'ancestorTitles', helper_method: :archival_display_show
     config.add_show_field 'title_tesim', label: 'Title', metadata: 'description', helper_method: :join_with_br
     config.add_show_field 'alternativeTitle_tesim', label: 'Alternative Title', metadata: 'description', helper_method: :join_with_br
     config.add_show_field 'creator_ssim', label: 'Creator', metadata: 'description', link_to_facet: true

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -96,6 +96,24 @@ module BlacklightHelper
     safe_join(values, ' > ')
   end
 
+  def archival_display_show(arg)
+  values = arg[:document][arg[:field]].reverse
+
+  hierarchy = arg[:document][:ancestor_titles_hierarchy_ssim]
+  hierarchy_params = (hierarchy_builder arg[:document]).reverse
+
+  if hierarchy.present?
+    (0..values.size - 1).each do |i|
+      values[i] = link_to values[i], url_for(hierarchy_params.pop&.merge(action: 'index')) if hierarchy_params.present?
+    end
+  end
+  if values.count > 5
+    values[3] = "<span><button class='show-more-button' aria-label='Show More' title='Show More'>...</button> &gt; </span><span class='show-more-hidden-text'>".html_safe + values[3]
+    values[values.count - 2] = "</span></span>".html_safe + values[values.count - 2]
+  end
+  safe_join(values, ' > ')
+end
+
   def hierarchy_builder(document)
     hierarchy = document[:ancestor_titles_hierarchy_ssim]
     hierarchy_params = []

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -97,22 +97,22 @@ module BlacklightHelper
   end
 
   def archival_display_show(arg)
-  values = arg[:document][arg[:field]].reverse
+    values = arg[:document][arg[:field]].reverse
 
-  hierarchy = arg[:document][:ancestor_titles_hierarchy_ssim]
-  hierarchy_params = (hierarchy_builder arg[:document]).reverse
+    hierarchy = arg[:document][:ancestor_titles_hierarchy_ssim]
+    hierarchy_params = (hierarchy_builder arg[:document]).reverse
 
-  if hierarchy.present?
-    (0..values.size - 1).each do |i|
-      values[i] = link_to values[i], url_for(hierarchy_params.pop&.merge(action: 'index')) if hierarchy_params.present?
+    if hierarchy.present?
+      (0..values.size - 1).each do |i|
+        values[i] = link_to values[i], url_for(hierarchy_params.pop&.merge(action: 'index')) if hierarchy_params.present?
+      end
     end
+    if values.count > 5
+      values[3] = "<span><button class='show-more-button' aria-label='Show More' title='Show More'>...</button> &gt; </span><span class='show-more-hidden-text'>".html_safe + values[3]
+      values[values.count - 2] = "</span></span>".html_safe + values[values.count - 2]
+    end
+    safe_join(values, ' > ')
   end
-  if values.count > 5
-    values[3] = "<span><button class='show-more-button' aria-label='Show More' title='Show More'>...</button> &gt; </span><span class='show-more-hidden-text'>".html_safe + values[3]
-    values[values.count - 2] = "</span></span>".html_safe + values[values.count - 2]
-  end
-  safe_join(values, ' > ')
-end
 
   def hierarchy_builder(document)
     hierarchy = document[:ancestor_titles_hierarchy_ssim]

--- a/spec/system/view_fields_in_display_spec.rb
+++ b/spec/system/view_fields_in_display_spec.rb
@@ -304,7 +304,6 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
     context 'ASpace hierarchy breadcrumb' do
       it 'has links for each item' do
         within '.archival-context' do
-
           expect(page).to have_link "first"
           expect(page).to have_link "second"
           expect(page).to have_link "third"
@@ -312,7 +311,6 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       end
       it 'searches on link click' do
         within '.archival-context' do
-
           click_on 'second'
         end
         expect(page).to have_content "Diversity Bull Dogs"
@@ -324,7 +322,6 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
 
         visit '/catalog/111'
         within '.archival-context' do
-
           click_on 'second'
         end
         expect(page).to have_css ".filter-name", text: "Found In", count: 1

--- a/spec/system/view_fields_in_display_spec.rb
+++ b/spec/system/view_fields_in_display_spec.rb
@@ -72,6 +72,7 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       projection_tesim: "this is the projection, using ssim",
       extent_ssim: ["this is the extent, using ssim", "here is another extent"],
       archiveSpaceUri_ssi: "/repositories/11/archival_objects/214638",
+      ancestorTitles_tesim: %w[third second first],
       ancestorDisplayStrings_tesim: %w[third second first],
       ancestor_titles_hierarchy_ssim: ['first > ', 'first > second > ', 'first > second > third > ']
     }
@@ -300,6 +301,37 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
         expect(page).to have_css ".filter-name", text: "Creator", count: 1
       end
     end
+    context 'ASpace hierarchy breadcrumb' do
+      it 'has links for each item' do
+        within '.archival-context' do
+
+          expect(page).to have_link "first"
+          expect(page).to have_link "second"
+          expect(page).to have_link "third"
+        end
+      end
+      it 'searches on link click' do
+        within '.archival-context' do
+
+          click_on 'second'
+        end
+        expect(page).to have_content "Diversity Bull Dogs"
+      end
+      it 'preserves search constraints', style: true do
+        visit '/catalog?q='
+        click_on 'Creator'
+        click_on 'Frederick'
+
+        visit '/catalog/111'
+        within '.archival-context' do
+
+          click_on 'second'
+        end
+        expect(page).to have_css ".filter-name", text: "Found In", count: 1
+        expect(page).to have_css ".filter-name", text: "Creator", count: 1
+      end
+    end
+
     it 'contains a link to Finding Aid' do
       finding_aid_link = page.find("a[href = 'this is the finding aid']")
 
@@ -308,7 +340,6 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       expect(finding_aid_link).to have_css("img[src ^= '/assets/YULPopUpWindow']")
     end
   end
-
   it 'has expected css' do
     expect(page).to have_css '.card'
     expect(page).to have_css '.iiif-logo'


### PR DESCRIPTION
**Story**

Users should easily be able to restrict their search to a specific archive or component of an archive.  

This ticket is the parallel of #1482 but for the top of the individual object page.

**Acceptance**
- [x] Each element of the hierarchy is a link
- [x] Clicking the link restricts the user's search to objects at that level of the collection or below. 
- [x] Other criteria of the user's search remain unchanged.
 