### PR TITLE
Modified the graphical archival tree alighnment

### DIFF
--- a/app/assets/stylesheets/customOverrides/show_page.scss
+++ b/app/assets/stylesheets/customOverrides/show_page.scss
@@ -229,7 +229,7 @@ h2.yale-restricted-work-text {
 }
 
 .aSpace_tree li {
-  right: 3%;
+  right: 1%;
   top: -20%;
   padding-bottom: 0%;
   list-style: none;
@@ -256,15 +256,22 @@ h2.yale-restricted-work-text {
 .yaleASpaceHomeNested ul, .yaleASpaceStackNested ul, .yaleASpaceFolderNested ul{
   list-style: none;
 }
+
 .aSpaceBranch {
   position: absolute;
   height: 15px;
   width: 15px;
   border-left: 2px solid #dddddd;
   border-bottom: 2px solid #dddddd;
-  padding: 22px 20px 0px 1px;
+  padding: 20px 20px 0 1px;
   top: -12px;
   left: -25px;
+}
+
+.aSpaceBranch img {
+  position: absolute;
+  height: 15px;
+  width: 15px;
 }
 
 @media screen and (min-width: $medium_device) {


### PR DESCRIPTION
**User Story**
As a product designer, I want the alignment of the icons and lines pointing to the next icon in the graphical archival tree centered with one another especially when the tree branches are collapsed.  This is under Collection Information on the single object show page.

**Current Design:**
![image.png](https://images.zenhubusercontent.com/5e6013c029e314c92afd4769/ce824dbe-57d3-4470-87fd-121569f7dc9f)

**Proposed Design:**
![Screen Shot 2021-08-09 at 3.10.27 PM.png](https://images.zenhubusercontent.com/5e6013c029e314c92afd4769/819d4d74-c75e-4de7-bb78-956f20e569ae)

**Acceptance:**
- [ ] Lines between connecting icons are now center-aligned with icons when branches are collapsed.