### PR TITLE
1494 remove fulltext option to hide in safari

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -70,28 +70,16 @@ function onChangeSearchFields() {
 
 $(document).on('turbolinks:load', function() {
     // Receiving the data:
-    let useDefault = localStorage.getItem("useDefault");
-    if(useDefault === null){
-        useDefault = "true";
-        localStorage.setItem("useDefault", "true")
-    }
-    if(localStorage.getItem("searchFieldValue") === null){
-        localStorage.setItem("searchFieldValue", "all_fields")
-    }
-    useDefault = (useDefault === "true");
-
-    // hide fulltext option in search fields
-    hideFulltextOptions();
-    changePlaceholderText();
+    let fullTextSearchSelected = localStorage.getItem("fullTextSearchSelected");
+    fullTextSearchSelected = (fullTextSearchSelected === "true")
 
     let descriptionButton = document.getElementById("fulltext_search_1");
     let fullTextButton = document.getElementById("fulltext_search_2");
 
-    if(useDefault){
-        descriptionButton.click();
-    }
-    else{
+    if (fullTextSearchSelected) {
         fullTextButton.click();
+    } else {
+        descriptionButton.click();
     }
 });
 
@@ -115,41 +103,27 @@ function changePlaceholderText(){
 
 // Toggle the fulltext
 function onSelectDescription() {
-    localStorage.setItem("useDefault", "true");
-    const search_field = document.getElementById("search_field");
-    search_field.style.visibility = 'visible';
-
-    let options = search_field.options;
-    let value = localStorage.getItem("searchFieldValue");
-    for (let i = 0, optionsLength = options.length; i < optionsLength; i++) {
-        if (options[i].value === value) {
-            search_field.selectedIndex = i;
-        }
-    }
+    localStorage.removeItem("fullTextSearchSelected");
+    const search_field = $("#search_field");
+    search_field.find("option[value='fulltext_tesim']").remove();
+    search_field.css({visibility: 'visible'});
+    search_field.val('all_fields');
     changePlaceholderText();
     return true;
 };
 
 function onSelectFulltext(){
-    localStorage.setItem("useDefault", "false");
-    const search_field = document.getElementById("search_field");
-    search_field.style.visibility = 'hidden';
-
-    let options = search_field.options;
-    let value = "fulltext_tesim";
-
-    for (let i = 0, optionsLength = options.length; i < optionsLength; i++) {
-        if (options[i].value === value) {
-            search_field.selectedIndex = i;
-        }
+    localStorage.setItem("fullTextSearchSelected", "true");
+    const search_field = $("#search_field");
+    if (search_field.find("option[value='fulltext_tesim']").length === 0) {
+        search_field.append("<option value=\"fulltext_tesim\">Full Text</option>")
     }
+    search_field.css({visibility: 'hidden'});
+    search_field.val("fulltext_tesim")
     changePlaceholderText();
     return false;
 };
 
-function hideFulltextOptions(){
-    $('#search_field').children('option[value="fulltext_tesim"]').css('display','none');
-}
 // Toggle the fulltext button
 $(document).on('turbolinks:load', function() {
     const fulltextTranscription = $('.item-page-fulltext-wrapper .row')

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -66,8 +66,8 @@ function onChangeSearchFields() {
 
 $(document).on('turbolinks:load', function() {
     // Receiving the data:
-    let fullTextSearchSelected = localStorage.getItem("fullTextSearchSelected");
-    fullTextSearchSelected = (fullTextSearchSelected === "true")
+    let fullTextSearchSelected = new RegExp('[\?&]search_field=([^&#]*)').exec(window.location.href);
+    fullTextSearchSelected = fullTextSearchSelected && fullTextSearchSelected[1] === 'fulltext_tesim'
 
     let descriptionButton = document.getElementById("fulltext_search_1");
     let fullTextButton = document.getElementById("fulltext_search_2");
@@ -99,7 +99,6 @@ function changePlaceholderText(){
 
 // Toggle the fulltext
 function onSelectDescription() {
-    localStorage.removeItem("fullTextSearchSelected");
     const search_field = $("#search_field");
     search_field.find("option[value='fulltext_tesim']").remove();
     search_field.css({visibility: 'visible'});
@@ -111,7 +110,6 @@ function onSelectDescription() {
 };
 
 function onSelectFulltext(){
-    localStorage.setItem("fullTextSearchSelected", "true");
     const search_field = $("#search_field");
     if (search_field.find("option[value='fulltext_tesim']").length === 0) {
         search_field.append("<option value=\"fulltext_tesim\">Full Text</option>")

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -60,10 +60,6 @@ $(document).on('turbolinks:load', function() {
 });
 
 function onChangeSearchFields() {
-    const search_field = document.getElementById("search_field");
-    let options = search_field.options;
-
-    // change placeholder
     changePlaceholderText();
 }
 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -103,7 +103,9 @@ function onSelectDescription() {
     const search_field = $("#search_field");
     search_field.find("option[value='fulltext_tesim']").remove();
     search_field.css({visibility: 'visible'});
-    search_field.val('all_fields');
+    if ( search_field.val() === "fulltext_tesim") {
+        search_field.val('all_fields');
+    }
     changePlaceholderText();
     return true;
 };

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -25,14 +25,14 @@
               onclick:("onSelectDescription();")
           )
       %>
-      <%= label_tag(:fulltext_search, "Description") %>
+      <%= label_tag(:fulltext_search_1, "Description") %>
       <%= radio_button_tag(:fulltext_search,
                            2,
                            false,
                            onclick:("onSelectFulltext();")
                            )
       %>
-      <%= label_tag(:fulltext_search, "Full text") %>
+      <%= label_tag(:fulltext_search_2, "Full text") %>
     </span>
 
 


### PR DESCRIPTION
Remove fulltext option when "description" radio is selected.
Replace and select full text option when "full text' radio is selected.
Use jquery for some dom manipulation.
Determine if fulltext is selected using the parameters rather than localstorage.