### PR TITLE
Hide empty metadata blocks from show page

### DIFF
--- a/app/presenters/yul/metadata_presenter.rb
+++ b/app/presenters/yul/metadata_presenter.rb
@@ -9,6 +9,15 @@ module Yul
       super
     end
 
+    def metadata_section_empty?(metadata_section = nil)
+      return true unless @metadata_sections.include? metadata_section
+      list_of_fields = to_enum(:fields_to_render).select do |_name, field_config|
+        field_config[:metadata].eql? metadata_section
+      end
+
+      list_of_fields.empty?
+    end
+
     def metadata_fields_to_render(metadata_section = nil)
       return fields_to_render unless @metadata_sections.include? metadata_section
       if block_given?

--- a/app/views/catalog/record/_item_metadata.html.erb
+++ b/app/views/catalog/record/_item_metadata.html.erb
@@ -1,5 +1,5 @@
 <% doc_presenter = show_presenter(document) %>
-
+<% unless doc_presenter.metadata_section_empty? metadata %>
   <div class='metadata-block single-item-show'>
     <h2 class='metadata-block__title'><%= metadata.titlecase %></h2>
     <dl class='metadata-block__group'>
@@ -16,3 +16,4 @@
       <% end %>
     </dl>
   </div>
+<% end %>

--- a/spec/system/show_page_spec.rb
+++ b/spec/system/show_page_spec.rb
@@ -204,7 +204,6 @@ RSpec.describe 'Show Page', type: :system, js: true, clean: true do
       expect(page).not_to have_content "Identifiers"
     end
     it 'is displayed when they have values' do
-
       expect(page).to have_content "Description"
       expect(page).to have_content "Collection Information"
       expect(page).to have_content "Subjects, Formats, And Genres"

--- a/spec/system/show_page_spec.rb
+++ b/spec/system/show_page_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe 'Show Page', type: :system, js: true, clean: true do
               llama_child_2,
               dog,
               eagle,
-              puppy])
+              puppy,
+              void])
     solr.commit
     visit '/catalog?search_field=all_fields&q='
     click_on 'Amor Llama'
@@ -35,7 +36,8 @@ RSpec.describe 'Show Page', type: :system, js: true, clean: true do
       creator_tesim: ['Anna Elizabeth Dewdney'],
       child_oids_ssim: [112, 113],
       oid_ssi: 111,
-      thumbnail_path_ss: 'https://this/is/an/image'
+      thumbnail_path_ss: 'https://this/is/an/image',
+      callNumber_ssim: "call number"
     }
   end
 
@@ -118,6 +120,13 @@ RSpec.describe 'Show Page', type: :system, js: true, clean: true do
     }
   end
 
+  let(:void) do
+    {
+      other_vis_bsi: true,
+      id: '666'
+    }
+  end
+
   it 'has expected css' do
     expect(page).to have_css '.btn-show'
     expect(page).to have_css '.constraints-container'
@@ -181,6 +190,26 @@ RSpec.describe 'Show Page', type: :system, js: true, clean: true do
     it 'does not have image of og tag' do
       expect(page).not_to have_css("meta[property='og:image'][content='https://this/is/an/image']", visible: false)
       expect(page).not_to have_css("meta[property='og:image:type'][content='image/jpeg']", visible: false)
+    end
+  end
+
+  context "Metadata block" do
+    it 'is not displayed when empty', :use_other_vis do
+      visit 'catalog/666'
+
+      expect(page).not_to have_content "Description"
+      expect(page).not_to have_content "Collection Information"
+      expect(page).not_to have_content "Subjects, Formats, And Genres"
+      expect(page).not_to have_content "Access And Usage Rights"
+      expect(page).not_to have_content "Identifiers"
+    end
+    it 'is displayed when they have values' do
+
+      expect(page).to have_content "Description"
+      expect(page).to have_content "Collection Information"
+      expect(page).to have_content "Subjects, Formats, And Genres"
+      expect(page).to have_content "Access And Usage Rights"
+      expect(page).to have_content "Identifiers"
     end
   end
 end


### PR DESCRIPTION
**Story**
The Subjects, Formats, And Genres category is sometimes empty.  Ex: https://collections-test.library.yale.edu/catalog/16847708


![Screen Shot 2021-07-22 at 2.52.36 PM.png](https://images.zenhubusercontent.com/5e6013c029e314c92afd4769/f08643de-7cb5-4d15-97f4-9e43022acf9c)

**Acceptance**
- [x] Don't display the header if all fields are empty.