### PR TITLE
Aligned the visiblity messages on single item page

### DIFF
--- a/app/assets/stylesheets/customOverrides/show_page.scss
+++ b/app/assets/stylesheets/customOverrides/show_page.scss
@@ -191,6 +191,16 @@ h2.yale-restricted-work-text {
   margin-left: -3%;
 }
 
+h2.yale-restricted-work-text{
+  margin-left: 8%;
+  width: 90%;
+}
+
+p.yale-restricted-work-text{
+  margin-left: 8%;
+  width: 90%;
+}
+
 @media screen and (min-width: $medium_device) {
   .constraints-container {
     margin-left: -.5%;
@@ -291,6 +301,16 @@ h2.yale-restricted-work-text {
 
   .show-document #appliedParams {
     width: 130%;
+  }
+
+  h2.yale-restricted-work-text{
+    margin-left: 19%;
+    width: 120%;
+  }
+
+  p.yale-restricted-work-text{
+    margin-left: 19%;
+    width: 120%;
   }
 }
 


### PR DESCRIPTION
**Issue**

The advisory about restricted access is not aligned with the rest of the text on the page:

![Screen Shot 2021-07-28 at 10.33.58 AM.png](https://images.zenhubusercontent.com/5e5d472f410278efd81466ab/1546226c-ae0d-44d5-ae68-6acfa0b9d109)

**Acceptance**

- [x] The message is left-aligned with the title and "Description" text, etc.
   - [x] Desktop responsive design alignment 
   - [x] Mobile responsive design alignment 