### PR TITLE
Changed graphical archival tree expand and collapse breakpoint

### DIFF
--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -173,7 +173,7 @@ module BlacklightHelper
         ul_class = 'yaleASpaceFolderNested'
       end
       hierarchy_tree = tag.li(class: li_class) do
-        tag.div(class: (!(ancestor_display_strings.size<3 || ancestor_display_strings.size>last-4)? 'show-full-tree-hidden-text' : '')) do
+        tag.div(class: (!(ancestor_display_strings.size < 3 || ancestor_display_strings.size > last - 4) ? 'show-full-tree-hidden-text' : '')) do
           concat tag.span(nil, class: 'aSpaceBranch') if branch_connection
           concat img
           concat current
@@ -182,18 +182,17 @@ module BlacklightHelper
         end
       end
 
-      above_or_below = last>6 && [3, last-3].include?(ancestor_display_strings.size)
-      if above_or_below && collapsed.nil?
+      above_or_below = last > 6 && [3, last - 3].include?(ancestor_display_strings.size)
+      next unless above_or_below && collapsed.nil?
 
-        collapsed ||= tag.ul do
-          tag.li do
-            concat tag.span(nil, class: 'aSpaceBranch')
-            concat button_tag '...', class: 'show-full-tree-button'
-            concat tag.ul(hierarchy_tree)
-          end
+      collapsed ||= tag.ul do
+        tag.li do
+          concat tag.span(nil, class: 'aSpaceBranch')
+          concat button_tag '...', class: 'show-full-tree-button'
+          concat tag.ul(hierarchy_tree)
         end
-        above_or_below = false
       end
+      above_or_below = false
     end
     # rubocop:enable Metrics/BlockLength
     tag.ul(hierarchy_tree, class: 'aSpace_tree') if hierarchy_tree

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -149,7 +149,7 @@ module BlacklightHelper
     img_folder = image_tag("archival_icons/yaleASpaceFolder.png", { class: 'ASpace_Folder ASpace_Icon', alt: 'Document or last level' })
 
     branch_connection = true
-    last_or_first = true
+    above_or_below = false
     collapsed = nil
     hierarchy_tree = nil
     # rubocop:disable Metrics/BlockLength
@@ -163,7 +163,6 @@ module BlacklightHelper
         li_class = 'yaleASpaceHome'
         ul_class = 'yaleASpaceHomeNested'
         branch_connection = false
-        last_or_first = true
       when 1
         img = img_stack
         li_class = 'yaleASpaceStack'
@@ -174,24 +173,27 @@ module BlacklightHelper
         ul_class = 'yaleASpaceFolderNested'
       end
       hierarchy_tree = tag.li(class: li_class) do
-        tag.div(class: (!last_or_first ? 'show-full-tree-hidden-text' : '')) do
+        tag.div(class: (!(ancestor_display_strings.size<3 || ancestor_display_strings.size>last-4)? 'show-full-tree-hidden-text' : '')) do
           concat tag.span(nil, class: 'aSpaceBranch') if branch_connection
           concat img
           concat current
-          concat collapsed if collapsed && last_or_first
+          concat collapsed if collapsed && above_or_below
           concat tag.ul(hierarchy_tree, class: ul_class) if hierarchy_tree
         end
       end
-      if last_or_first
-        collapsed = tag.ul do
+
+      above_or_below = last>6 && [3, last-3].include?(ancestor_display_strings.size)
+      if above_or_below && collapsed.nil?
+
+        collapsed ||= tag.ul do
           tag.li do
             concat tag.span(nil, class: 'aSpaceBranch')
             concat button_tag '...', class: 'show-full-tree-button'
             concat tag.ul(hierarchy_tree)
           end
         end
+        above_or_below = false
       end
-      last_or_first = false
     end
     # rubocop:enable Metrics/BlockLength
     tag.ul(hierarchy_tree, class: 'aSpace_tree') if hierarchy_tree

--- a/spec/system/view_fields_in_display_spec.rb
+++ b/spec/system/view_fields_in_display_spec.rb
@@ -72,9 +72,9 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       projection_tesim: "this is the projection, using ssim",
       extent_ssim: ["this is the extent, using ssim", "here is another extent"],
       archiveSpaceUri_ssi: "/repositories/11/archival_objects/214638",
-      ancestorTitles_tesim: %w[third second first],
-      ancestorDisplayStrings_tesim: %w[third second first],
-      ancestor_titles_hierarchy_ssim: ['first > ', 'first > second > ', 'first > second > third > ']
+      ancestorTitles_tesim: %w[seventh sixth fifth fourth third second first],
+      ancestorDisplayStrings_tesim: %w[seventh sixth fifth fourth third second first],
+      ancestor_titles_hierarchy_ssim: ['first > ', 'first > second > ', 'first > second > third > ', 'first > second > third > fourth > ', 'first > second > third > fourth > fifth > ', 'first > second > third > fourth > fifth > sixth > ', 'first > second > third > fourth > fifth > sixth > seventh > ']
     }
   end
 
@@ -257,17 +257,17 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
     context 'ASpace hierarchy graphical display' do
       it 'has an ellipsis instead of a full tree' do
         expect(page).to have_content "first"
-        expect(page).not_to have_text(type: :visible, text: "second")
+        expect(page).not_to have_text(type: :visible, text: "fourth")
         expect(page).to have_content "..."
-        expect(page).to have_content "third"
+        expect(page).to have_content "seventh"
       end
       it 'shows full tree on button click' do
         page.find('.show-full-tree-button').click
 
         expect(page).to have_content "first"
         expect(page).not_to have_text(type: :visible, text: "...")
-        expect(page).to have_content "second"
-        expect(page).to have_content "third"
+        expect(page).to have_content "fourth"
+        expect(page).to have_content "seventh"
       end
       it 'has links for each item' do
         within '.aSpace_tree' do
@@ -276,13 +276,17 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
           expect(page).to have_link "first"
           expect(page).to have_link "second"
           expect(page).to have_link "third"
+          expect(page).to have_link "fourth"
+          expect(page).to have_link "fifth"
+          expect(page).to have_link "sixth"
+          expect(page).to have_link "seventh"
         end
       end
       it 'searches on link click' do
         within '.aSpace_tree' do
           page.find('.show-full-tree-button').click
 
-          click_on 'second'
+          click_on 'fourth'
         end
         expect(page).to have_content "Diversity Bull Dogs"
       end
@@ -295,7 +299,7 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
         within '.aSpace_tree' do
           page.find('.show-full-tree-button').click
 
-          click_on 'second'
+          click_on 'fourth'
         end
         expect(page).to have_css ".filter-name", text: "Found In", count: 1
         expect(page).to have_css ".filter-name", text: "Creator", count: 1

--- a/spec/system/view_fields_in_display_spec.rb
+++ b/spec/system/view_fields_in_display_spec.rb
@@ -74,7 +74,9 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       archiveSpaceUri_ssi: "/repositories/11/archival_objects/214638",
       ancestorTitles_tesim: %w[seventh sixth fifth fourth third second first],
       ancestorDisplayStrings_tesim: %w[seventh sixth fifth fourth third second first],
-      ancestor_titles_hierarchy_ssim: ['first > ', 'first > second > ', 'first > second > third > ', 'first > second > third > fourth > ', 'first > second > third > fourth > fifth > ', 'first > second > third > fourth > fifth > sixth > ', 'first > second > third > fourth > fifth > sixth > seventh > ']
+      ancestor_titles_hierarchy_ssim: ['first > ', 'first > second > ', 'first > second > third > ',
+                                       'first > second > third > fourth > ', 'first > second > third > fourth > fifth > ',
+                                       'first > second > third > fourth > fifth > sixth > ', 'first > second > third > fourth > fifth > sixth > seventh > ']
     }
   end
 


### PR DESCRIPTION
Co-authored-by: Eric DeJesus <eric.dejesus@yale.edu>

**Story**
Currently the hierarchical link tree for archival context under Collection Information on the single object show page shows collapsed with an ellipsis with apparently any more than 2 levels.  This should be updated to go as far as 6 levels before collapsing with ellipsis.  With 7 or more levels, default view should be collapsed to show only the broadest 3 and narrowest 3 with an ellipsis in between; clicking on ellipsis expands to show all levels in the middle.

**Current Design:**
![Screen Shot 2021-08-09 at 1.23.20 PM.png](https://images.zenhubusercontent.com/5e5d4b9fe308104eddc52c88/d4222f39-60d4-4851-af04-7422e0429e61)

**Proposed Design:**
6 or less:
![Screen Shot 2021-08-09 at 1.43.44 PM.png](https://images.zenhubusercontent.com/5e5d4b9fe308104eddc52c88/b23203a1-e482-42ab-9b21-4572a04f2062)
7 or more:
![Screen Shot 2021-08-09 at 1.44.16 PM.png](https://images.zenhubusercontent.com/5e5d4b9fe308104eddc52c88/c17eeb7b-5922-4517-95b9-a791ddc00315)

**Acceptance:**
- [ ] Hierarchical links tree on single object show page limits to six display items and collapses with an ellipsis with 7+.