### PR TITLE
1532 archival graphical display expands modification

### DIFF
--- a/app/assets/stylesheets/customOverrides/show_page.scss
+++ b/app/assets/stylesheets/customOverrides/show_page.scss
@@ -230,7 +230,7 @@ h2.yale-restricted-work-text {
 
 .aSpace_tree li {
   right: 1%;
-  top: -20%;
+  top: -4%;
   padding-bottom: 0%;
   list-style: none;
   position: relative;
@@ -238,6 +238,7 @@ h2.yale-restricted-work-text {
 }
 .yaleASpaceHome li{
   width: 620px;
+  //height: 620px;
 }
 
 .yaleASpaceHomeNested li {

--- a/app/assets/stylesheets/customOverrides/show_page.scss
+++ b/app/assets/stylesheets/customOverrides/show_page.scss
@@ -236,9 +236,9 @@ h2.yale-restricted-work-text {
   position: relative;
   margin: 0;
 }
+
 .yaleASpaceHome li{
   width: 620px;
-  //height: 620px;
 }
 
 .yaleASpaceHomeNested li {


### PR DESCRIPTION
**Story**

The archival context hierarchy can expand to overlap the section header.  See https://collections-demo.library.yale.edu/catalog/2042376

**Current System Image**
![Screen Shot 2021-08-16 at 2.11.11 PM.png](https://images.zenhubusercontent.com/5e5d472f410278efd81466ab/d0fed6a3-bb46-4d42-85a6-b78ff83666e9)

**Modification**
![Ticket_1532](https://user-images.githubusercontent.com/41123693/130273968-47c592d2-d37f-4143-aaf1-969b88f67ac8.gif)


**Acceptance**
- [ ] Space below title expands to fit the hierarchy.