### PR TITLE
Remove page param from archival hierachy links

### DIFF
--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -105,7 +105,7 @@ module BlacklightHelper
         values[i] = link_to values[i], request.params.merge('f' =>
             request&.params&.[]("f")&.except("ancestor_titles_hierarchy_ssim"))&.merge(
             "f[ancestor_titles_hierarchy_ssim][]" => hierarchy[i]
-          )
+          )&.except("page")
       end
     end
     if values.count > 5
@@ -143,7 +143,7 @@ module BlacklightHelper
         hierarchy_params << @search_params.merge('f' =>
         @search_params&.[]("f")&.except("ancestor_titles_hierarchy_ssim"))&.merge(
           "f[ancestor_titles_hierarchy_ssim][]" => hierarchy[i]
-        )
+        )&.except("page")
       end
     end
     hierarchy_params

--- a/app/views/catalog/_constraints.html.erb
+++ b/app/views/catalog/_constraints.html.erb
@@ -5,10 +5,10 @@
       <% value, label, options = get_date_constraint_params(params, request.url)%>
       <%= render partial: "constraints_element", locals: { value: value, label: label, options: options } %>
     <% end %>
-      <% if params["f"] && params["f"]["repository_ssi"].present? %>
-        <% value, label, options = get_repository_constraint_params(params, request.url)%>
-        <%= render partial: "constraints_element", locals: { value: value, label: label, options: options } %>
-      <% end %>
+    <% if params["f"] && params["f"]["repository_ssi"].present? %>
+      <% value, label, options = get_repository_constraint_params(params, request.url)%>
+      <%= render partial: "constraints_element", locals: { value: value, label: label, options: options } %>
+    <% end %>
 
     <%= render_constraints(controller.params != params ? params : search_state) %>
     <%= render 'start_over', show_icon: true%>


### PR DESCRIPTION
**Story**

On page 2 of search results, if I click the breadcrumb to refine my search, I end up on a blank page.   This is because the `page=2` parameter is in the breadcrumb link, but the added restriction returns only one page of results.

![Screen Shot 2021-08-12 at 4.34.11 PM.png](https://images.zenhubusercontent.com/5e5d472f410278efd81466ab/3b111e08-5ac1-4266-a1f7-06edfba72905)

The demo cluster has enough objects to test this now.

**Acceptance**
Always send the user to page 1 of the result list when narrowing the search.
- [x] from the search results breadcrumb
- [x] from the single object page breadcrumb
- [x] from the single object page graphical breadcrumb