### PR TITLE
Adds found in constraint to repository culling logic

### DIFF
--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -49,6 +49,7 @@ module BlacklightHelper
     label = "Repository"
     remove_url = url_in.gsub(/f%5Bcollection_title_ssi%5D%5B%5D=[^&]*/, '')
     remove_url.gsub!(/f%5Brepository_ssi%5D%5B%5D=[^&]*/, '')
+    remove_url.gsub!(/f%5Bancestor_titles_hierarchy_ssim%5D%5B%5D=[^&]*/, '')
     remove_url.gsub!(/&&/, '')
     value = params["f"]["repository_ssi"].first
     options = {

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -126,6 +126,12 @@ RSpec.describe BlacklightHelper, helper: true, style: true do
           genre_ssim: 'Maps',
           repository_ssi: 'Yale University Arts Library',
           collection_title_ssi: ['AAA'],
+          ancestor_titles_hierarchy_ssim:  [
+            "Beinecke > ",
+            "Beinecke > David > ",
+            "Beinecke > David > Drawing > ",
+            "Beinecke > David > Drawing > June > "
+          ],
           thumbnail_path_ss: "http://localhost:8182/iiif/2/1234822/full/!200,200/0/default.jpg"
         )
       end
@@ -156,7 +162,7 @@ RSpec.describe BlacklightHelper, helper: true, style: true do
           params["f"]["repository_ssi"] = ["Yale University Arts Library"]
           params
         end
-        let(:request_url) { "/catalog?f%5Bcollection_title_ssi%5D%5B%5D=AAA&f%5Brepository_ssi%5D%5B%5D=Yale+University+Arts+Library&q=&search_field=all_fields" }
+        let(:request_url) { "/catalog?f%5Bancestor_titles_hierarchy_ssim%5D%5B%5D=Beinecke+%3E+David+%3E+Photo+%3E+June+%3E+%5Bcollection_title_ssi%5D%5B%5D=AAA&f%5Brepository_ssi%5D%5B%5D=Yale+University+Arts+Library&q=&search_field=all_fields" }
         let(:clean_url) { "/catalog?q=&search_field=all_fields" }
 
         it 'filters out collection when repository is clicked' do


### PR DESCRIPTION
# Summary
Adds 'found in' / ancestor_titles_hierarchy_ssim to constraints that will be cleared when repository constraint is removed.

# Related Ticket
[#1453] (https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1453)

# Video

https://user-images.githubusercontent.com/36549923/131383687-7aa005ae-f533-4b5e-bfcf-afff162dd551.mp4

