### PR TITLE
Created new archival hierarchy design

### DIFF
--- a/app/assets/stylesheets/customOverrides/show_page.scss
+++ b/app/assets/stylesheets/customOverrides/show_page.scss
@@ -211,15 +211,12 @@ DEFAULT MOBILE STYLING
 
 h2.yale-restricted-work-text {
   font-size: 1.5em;
+  margin-left: 8%;
+  width: 90%;
 }
 
 .tools-text-format{
   margin-left: -3%;
-}
-
-h2.yale-restricted-work-text{
-  margin-left: 8%;
-  width: 90%;
 }
 
 p.yale-restricted-work-text{
@@ -234,23 +231,26 @@ p.yale-restricted-work-text{
   margin-right: 6px;
 }
 
+.aSpace_tree {
+  margin-top: 14%;
+  margin-inline-start: -46%;
+  height: fit-content;
+  width: 500px;
+}
+
 .aSpace_tree ul{
   list-style: none;
   margin-top: 10px;
 }
 
 .aSpace_tree li {
-  right: 1%;
+  right: 9%;
   top: -4%;
-  padding-bottom: 0%;
+  padding-bottom: 0;
   list-style: none;
   position: relative;
   margin: 0;
-}
-
-.yaleASpaceHome li{
-  width: 620px;
-  //height: 620px;
+  left: -3%;
 }
 
 .yaleASpaceHomeNested li {
@@ -270,6 +270,7 @@ p.yale-restricted-work-text{
   list-style: none;
 }
 
+//Control the appearance of hierarchy icons and space
 .aSpaceBranch {
   position: absolute;
   height: 15px;
@@ -285,6 +286,31 @@ p.yale-restricted-work-text{
   position: absolute;
   height: 15px;
   width: 15px;
+}
+.showpage_no_label_tag,
+.blacklight-archivespaceuri_ssi {
+  font-family: Mallory-Bold;
+  background-color: $lighter_grey;
+  margin: 0;
+  padding-left: 2%;
+  width: 100%;
+  padding-top: 2%!important;
+  #popup_window{
+    padding-left: 1.5%;
+    padding-bottom: 0.75%
+  }
+}
+
+.showpage_no_label_tag,
+.blacklight-findingaid_ssim {
+  padding-bottom: 3%;
+  padding-left: 2%;
+  width: 100%;
+  padding-top: 0;
+  #popup_window{
+    padding-left: 1.5%;
+    padding-bottom: 0.75%
+  }
 }
 
 @media screen and (min-width: $medium_device) {
@@ -353,6 +379,13 @@ p.yale-restricted-work-text{
     margin-left: 8%;
   }
 
+  .aSpace_tree {
+    width: fit-content;
+  }
+
+  .aSpace_tree li {
+    left: 0;
+  }
 }
 
 
@@ -431,16 +464,31 @@ p.yale-restricted-work-text{
     width: 120%;
   }
 
+  .aSpace_tree {
+    margin-top: 11%;
+    margin-inline-start: -46%;
+  }
+
+  .aSpace_Data_Block{
+    width: 95%;
+  }
+
+  .showpage_no_label_tag, .blacklight-archivespaceuri_ssi{
+    margin: 0;
+    padding-left: 2%;
+  }
+
+  .showpage_no_label_tag,.blacklight-findingaid_ssim{
+    padding-bottom: 2%;
+    padding-left: 2%;
+  }
+
   .showpage_no_label_tag{
-    font-family: Mallory-Bold;
-    width: 100%;
-    padding-top: 2%;
-    position: -webkit-sticky;
     #popup_window{
-      padding-left: 0.5%;
-      padding-bottom: 0.5%;
+      padding-left: 1.5%;
+      padding-bottom: 0.75%;
     }
- }
+  }
 }
 
 
@@ -495,5 +543,9 @@ p.yale-restricted-work-text{
   }
   .show-tools.list-group{
     margin-left: -0.5%;
+  }
+
+  .aSpace_tree {
+    margin-top: 6%;
   }
 }

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -136,13 +136,13 @@ class CatalogController < ApplicationController
     config.add_facet_field 'creationPlace_ssim', label: 'Publication Place', limit: true
     config.add_facet_field 'pub_date_ssim', label: 'Publication Year', single: true
     config.add_facet_field 'year_isim', label: 'Date Created',
-                           range: {
-                             segments: true,
-                             maxlength: 4
-                           },
-                           if: lambda { |_context, _field_config, facet|
-                             facet.items.length > 1
-                           }
+                                        range: {
+                                          segments: true,
+                                          maxlength: 4
+                                        },
+                                        if: lambda { |_context, _field_config, facet|
+                                              facet.items.length > 1
+                                            }
 
     # the facets below are set to false because we aren't filtering on them from the main search page
     # but we need to be able to provide a label when they are filtered upon from an individual show page
@@ -622,4 +622,3 @@ class CatalogController < ApplicationController
     term_list.to_ordered_hash(force: true, include_context: false)
   end
 end
-

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -136,13 +136,13 @@ class CatalogController < ApplicationController
     config.add_facet_field 'creationPlace_ssim', label: 'Publication Place', limit: true
     config.add_facet_field 'pub_date_ssim', label: 'Publication Year', single: true
     config.add_facet_field 'year_isim', label: 'Date Created',
-                                        range: {
-                                          segments: true,
-                                          maxlength: 4
-                                        },
-                                        if: lambda { |_context, _field_config, facet|
-                                              facet.items.length > 1
-                                            }
+                           range: {
+                             segments: true,
+                             maxlength: 4
+                           },
+                           if: lambda { |_context, _field_config, facet|
+                             facet.items.length > 1
+                           }
 
     # the facets below are set to false because we aren't filtering on them from the main search page
     # but we need to be able to provide a label when they are filtered upon from an individual show page
@@ -233,7 +233,6 @@ class CatalogController < ApplicationController
     # ancestorDisplayStrings must be first
     # archiveSpaceUri must be last
     #
-    config.add_show_field 'ancestorDisplayStrings_tesim', label: ' ', no_label: true, metadata: 'collection_information', helper_method: :aspace_tree_display
     config.add_show_field 'callNumber_ssim', label: 'Call Number', metadata: 'collection_information', link_to_facet: true
     config.add_show_field 'sourceTitle_tesim', label: 'Collection Title', metadata: 'collection_information'
     config.add_show_field 'sourceCreator_tesim', label: 'Collection/Other Creator', metadata: 'collection_information'
@@ -242,10 +241,11 @@ class CatalogController < ApplicationController
     config.add_show_field 'sourceNote_tesim', label: 'Collection Note', metadata: 'collection_information'
     config.add_show_field 'sourceEdition_tesim', label: 'Collection Edition', metadata: 'collection_information'
     config.add_show_field 'containerGrouping_tesim', label: 'Container / Volume Information', metadata: 'collection_information'
-    config.add_show_field 'archiveSpaceUri_ssi', label: ' ', no_label: true, metadata: 'collection_information', helper_method: :aspace_link
-    config.add_show_field 'findingAid_ssim', label: ' ', no_label: true, metadata: 'collection_information', helper_method: :finding_aid_link
     config.add_show_field 'relatedResourceOnline_ssim', label: 'Related Resource Online', metadata: 'collection_information', helper_method: :link_to_url_with_label
     config.add_show_field 'resourceVersionOnline_ssim', label: 'Resource Version Online', metadata: 'collection_information', helper_method: :link_to_url_with_label
+    config.add_show_field 'ancestorDisplayStrings_tesim', label: 'Item Within Collection Hierarchy', metadata: 'collection_information', helper_method: :aspace_tree_display
+    config.add_show_field 'archiveSpaceUri_ssi', label: ' ', no_label: true, metadata: 'collection_information', helper_method: :aspace_link
+    config.add_show_field 'findingAid_ssim', label: ' ', no_label: true, metadata: 'collection_information', helper_method: :finding_aid_link
 
     # Subjects, Formats, and Genres Group
     config.add_show_field 'format', label: 'Format', metadata: 'subjects,_formats,_and_genres', link_to_facet: true
@@ -622,3 +622,4 @@ class CatalogController < ApplicationController
     term_list.to_ordered_hash(force: true, include_context: false)
   end
 end
+


### PR DESCRIPTION
This design mockup is based on feedback from the Archival Context group, DSU and others. It is meant to address confusion re: the label "Collection Information", and also meant to highlight where the current item is found within the hierarchy. External links are also given more visual separation from the collection info itself. 


**Acceptance:** 
- [x] Move the hierarchy tree to the antepenultimate position of the data block
- [x] Subtitle for hierarchy tree - Item Within Collection Hierarchy: 
- [x] Create a $light_grey box around the two links 
- [x] Format hierarchy tree for all mobile screens

**Don't Include:** 
deactivating the last link in the tree.

**Uploaded here for review before development:**
![collection-info-mockup-new-label.png](https://images.zenhubusercontent.com/604a2edec7bb2836333e6ec0/19478380-ef0e-43fe-b781-e3ccd5d0a780)


DEMO: 

![1561_New Archival_HierarchyDesign](https://user-images.githubusercontent.com/41123693/131910312-6d5151db-9146-4d8b-a558-a7c86da42b86.gif)