### PR TITLE
Adds archivalSort to all sort bys

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -507,13 +507,13 @@ class CatalogController < ApplicationController
     # label in pulldown is followed by the name of the SOLR field to sort by and
     # whether the sort is ascending or descending (it must be asc or desc
     # except in the relevancy case).
-    config.add_sort_field 'score desc, pub_date_si desc, title_si asc, archivalSort_ssi desc', label: 'relevance'
-    config.add_sort_field 'creator_ssim asc, title_ssim asc', label: 'Creator (A --> Z)'
-    config.add_sort_field 'creator_ssim desc, title_ssim asc', label: 'Creator (Z --> A)'
-    config.add_sort_field 'title_ssim asc, oid_ssi desc', label: 'Title (A --> Z)'
-    config.add_sort_field 'title_ssim desc, oid_ssi desc', label: 'Title (Z --> A)'
-    config.add_sort_field 'year_isim asc, id desc', label: 'Year (ascending)'
-    config.add_sort_field 'year_isim desc, id desc', label: 'Year (descending)'
+    config.add_sort_field 'score desc, pub_date_si desc, title_si asc, archivalSort_ssi asc', label: 'relevance'
+    config.add_sort_field 'creator_ssim asc, title_ssim asc, archivalSort_ssi asc', label: 'Creator (A --> Z)'
+    config.add_sort_field 'creator_ssim desc, title_ssim asc, archivalSort_ssi asc', label: 'Creator (Z --> A)'
+    config.add_sort_field 'title_ssim asc, oid_ssi desc, archivalSort_ssi asc', label: 'Title (A --> Z)'
+    config.add_sort_field 'title_ssim desc, oid_ssi desc, archivalSort_ssi asc', label: 'Title (Z --> A)'
+    config.add_sort_field 'year_isim asc, id desc, archivalSort_ssi asc', label: 'Year (ascending)'
+    config.add_sort_field 'year_isim desc, id desc, archivalSort_ssi asc', label: 'Year (descending)'
 
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.

--- a/spec/system/advanced_search_spec.rb
+++ b/spec/system/advanced_search_spec.rb
@@ -233,7 +233,7 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: tr
   context 'sorting' do
     it 'can sort by title' do
       within '#sort' do
-        find("option[value='title_ssim asc, oid_ssi desc']").click
+        find("option[value='title_ssim asc, oid_ssi desc, archivalSort_ssi asc']").click
       end
 
       click_on 'SEARCH'
@@ -245,7 +245,7 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: tr
 
     it 'can sort by creator' do
       within '#sort' do
-        find("option[value='creator_ssim asc, title_ssim asc']").click
+        find("option[value='creator_ssim asc, title_ssim asc, archivalSort_ssi asc']").click
       end
 
       click_on 'SEARCH'
@@ -257,7 +257,7 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: tr
 
     it 'can sort by date asc' do
       within '#sort' do
-        find("option[value='year_isim asc, id desc']").click
+        find("option[value='year_isim asc, id desc, archivalSort_ssi asc']").click
       end
       click_on 'SEARCH'
       within '#documents' do
@@ -268,7 +268,7 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: tr
 
     it 'can sort by date desc' do
       within '#sort' do
-        find("option[value='year_isim desc, id desc']").click
+        find("option[value='year_isim desc, id desc, archivalSort_ssi asc']").click
       end
       click_on 'SEARCH'
       # same order as asc because Record 1's dates strattle Record 2's

--- a/spec/system/archival_sort_spec.rb
+++ b/spec/system/archival_sort_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe 'archivalSort', type: :system, clean: true do
 
   context 'search results' do
     it 'sorts based on archivalSort conditions' do
-      expect(page).to have_content('Osborn Manuscript Files (OSB MSS FILE)')
+      expect(page).to have_content('Llama Files')
       expect(page).not_to have_content('Script Files')
     end
   end

--- a/spec/system/date_slider_spec.rb
+++ b/spec/system/date_slider_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe "Blacklight Range Limit", type: :system, clean: true, js: true do
       sliders = find_all('.slider-handle.round')
 
       beg_slider = sliders.first
-      beg_slider.drag_by(30, 0)
+      beg_slider.drag_by(25, 0)
 
       end_slider = sliders.last
       end_slider.drag_by(-105, 0)
@@ -123,11 +123,11 @@ RSpec.describe "Blacklight Range Limit", type: :system, clean: true, js: true do
     end
 
     within '.blacklight-year_isim' do
-      expect(page.text).to match(/12\d\d to 16\d\d/)
+      expect(page.text).to match(/11\d\d to 16\d\d/)
     end
 
     within '.constraints-container' do
-      expect(page.text).to match(/Date 12\d\d - 16\d\d/)
+      expect(page.text).to match(/Date 11\d\d - 16\d\d/)
     end
 
     # makes sure that it includes the turtle record with years: 1555-1800


### PR DESCRIPTION
# Summary
Rework from demo:
- change to ascending not descending order for archivalSort
- add archivalSort to all sort by options

# Related Tickets
[#1530](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1530)
[#1573](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1573)