### PR TITLE
fixed found in css overlap on small devices

### DIFF
--- a/app/assets/stylesheets/customOverrides/search_result.scss
+++ b/app/assets/stylesheets/customOverrides/search_result.scss
@@ -90,6 +90,7 @@ DEFAULT MOBILE STYLING
     flex-wrap: wrap;
     margin-top: -21px;
     margin-left: 74px;
+    max-width: 250px;
   }
 
   .document-metadata {
@@ -185,6 +186,7 @@ DEFAULT MOBILE STYLING
       flex-wrap: wrap;
       margin-top: -21px;
       margin-left: 74px;
+      max-width: 285px;
     }
 
     .document-metadata {
@@ -267,6 +269,7 @@ DEFAULT MOBILE STYLING
       flex-wrap: wrap;
       margin-top: -21px;
       margin-left: 74px;
+      max-width: 325px;
     }
 
     .document-metadata {


### PR DESCRIPTION
"Found In" ancestorTitles no longer run off the page on smaller devices.  
  
Before:  
![Screen Recording 2021-09-08 at 10 13 51 AM](https://user-images.githubusercontent.com/24666568/132554601-2add7950-e206-431e-9e0e-cbd438850434.gif)
  
  
After:  
![Screen Recording 2021-09-08 at 10 18 02 AM](https://user-images.githubusercontent.com/24666568/132555063-c354d9f1-e74d-483e-8e3c-2ffc4ac45843.gif)
  
  
![Image 2021-09-08 at 10 10 11 AM](https://user-images.githubusercontent.com/24666568/132555101-8d66842a-d4c7-49f9-ac79-ed65c95c8000.jpg)
  
![Image 2021-09-08 at 10 10 25 AM](https://user-images.githubusercontent.com/24666568/132555122-58f36461-07fc-4081-a86b-053a8eaa55bc.jpg)
