### PR TITLE
added margin to date field

### DIFF
--- a/app/assets/stylesheets/customOverrides/search_result.scss
+++ b/app/assets/stylesheets/customOverrides/search_result.scss
@@ -89,7 +89,7 @@ DEFAULT MOBILE STYLING
     color: $medium_grey;
     flex-wrap: wrap;
     margin-top: -21px;
-    margin-left: 74px;
+    margin-left: 82px;
     max-width: 250px;
   }
 


### PR DESCRIPTION
Note: This is only a bug on small screens. Added a few more margin-left pixels on small devices.

Before:  
  
![Image 2021-09-08 at 4 26 32 PM](https://user-images.githubusercontent.com/24666568/132600011-fe99f473-b7c0-44ad-9b03-38f13b003746.jpg)  
  
After:  
  
![Image 2021-09-08 at 4 48 04 PM](https://user-images.githubusercontent.com/24666568/132600081-7c40dc3d-fea4-4918-b9af-f637e8b6889b.jpg)
