### PR TITLE
Changed the wording on the landing page

### DIFF
--- a/app/views/application/landing.html.erb
+++ b/app/views/application/landing.html.erb
@@ -101,7 +101,8 @@
       </ul>
       <div id="content-statement">
        <h2>Statement on Potentially Harmful Content</h2>
-        <p>Yale University Library’s collections contain historical and contemporary materials documenting human expression and lived experience. Content may include images or language that library users may find harmful, offensive, or inappropriate. Some of these words or images are now recognized as offensive and unacceptable; some may have been viewed as unacceptable when they were created. Yale University Library staff are engaged in addressing or contextualizing this content and language; for more information, see the <a href="https://guides.library.yale.edu/statementharmfulcontent">Statement on Potentially Harmful Content</a>.</p>      </div>
+        <p>Yale Library's digital collections provide access to millions of digitized works and images. This site is a living database, and new materials are added regularly. Search or click an image below to begin your exploration.
+          There are Yale Library digital collections not available on this site. More information on these additional collections can be found <a href=" https://web.library.yale.edu/digital-collections"> here</a>. </p> </div>
     </div>
   </main>
 


### PR DESCRIPTION
JP <jp@notch8.com>

**Story**

Stakeholders would like the homepage text updated to better describe the collections.

**Acceptance**
- [ ] Homepage text reads:

Yale Library's digital collections provide access to millions of digitized works and images. This site is a living database, and new materials are added regularly. Search or click the image below to begin your exploration.
There are Yale Library digital collections not available on this site. More information on these additional collections can be found here.

- [ ] The word "here" should link to https://web.library.yale.edu/digital-collections


![Screen Shot 2021-09-10 at 2 42 21 PM](https://user-images.githubusercontent.com/41123693/132902417-4d829214-2a50-467d-8893-0e6898e93d00.png)
