### PR TITLE
Modified digital collection access statement

### DIFF
--- a/app/views/application/landing.html.erb
+++ b/app/views/application/landing.html.erb
@@ -55,7 +55,7 @@
           </div>
         <% end %>
         <p class="d-none d-xl-block" style="font-size: medium;">
-          Yale University Library’s digital collections provide access to millions of digitized works and images. As of January 2021, Beinecke Library digital collections have been moved to a new platform for improved viewing. Over time, material from other Yale Library digital collections will be added to the platform. Click on an image or use the search box to explore Beinecke digital collections. Begin your <a href="https://web.library.yale.edu/digital-collections" class="link-white">search for all other Yale Library digital collections here</a>.
+          Yale Library's digital collections provide access to millions of digitized works and images. This site is a living database, and new materials are added regularly. Search or click an image below to begin your exploration. There are Yale Library digital collections not available on this site. More information on these additional collections can be found <a href=" https://web.library.yale.edu/digital-collections" class="link-white"> here</a>.
         </p>
       </div>
     </div>
@@ -101,7 +101,7 @@
       </ul>
       <div id="content-statement">
         <h2>Statement on Potentially Harmful Content</h2>
-        <p>Yale Library's digital collections provide access to millions of digitized works and images. This site is a living database, and new materials are added regularly. Search or click an image below to begin your exploration. There are Yale Library digital collections not available on this site. More information on these additional collections can be found <a href=" https://web.library.yale.edu/digital-collections"> here</a>. </p> </div>
+        <p>Yale University Library’s collections contain historical and contemporary materials documenting human expression and lived experience. Content may include images or language that library users may find harmful, offensive, or inappropriate. Some of these words or images are now recognized as offensive and unacceptable; some may have been viewed as unacceptable when they were created. Yale University Library staff are engaged in addressing or contextualizing this content and language; for more information, see the <a href="https://guides.library.yale.edu/statementharmfulcontent">Statement on Potentially Harmful Content</a>.</p>
     </div>
   </main>
 


### PR DESCRIPTION
**Story**

As a stakeholder, I want the homepage text under the search bar updated to better describe the collections.

The statement ought to read: 
Yale Library's digital collections provide access to millions of digitized works and images. This site is a living database, and new materials are added regularly. Search or click an image below to begin your exploration.
There are Yale Library digital collections not available on this site. More information on these additional collections can be found here.

**Acceptance**
- [x] Change the digital collection access statement 
- [x] Add the hyperlink (https://web.library.yale.edu/digital-collections) to the word here at the end of the statement.  
- [x] Revert the potential harmful statement

-----
![Capture.JPG](https://images.zenhubusercontent.com/60786c408c8643227aa47d8f/d903a271-37c5-436d-9381-4bb502439dd3)

----

![image.png](https://images.zenhubusercontent.com/5e6013c029e314c92afd4769/17d8181c-6139-4047-a3e4-e77e75abd7a5)

![Screen Shot 2021-09-13 at 3.15.11 PM.png](https://images.zenhubusercontent.com/5e6013c029e314c92afd4769/8f16f054-30e8-4646-9735-cef5b24dc1c9)

