### PR TITLE
Adds finding aid fallback

### DIFF
--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -222,7 +222,11 @@ module BlacklightHelper
     links = []
     findingAidUri.each do |link|
       popup_window = image_tag("YULPopUpWindow.png", { id: 'popup_window', alt: 'pop up window' })
-      links << link_to(safe_join(['View full finding aid for ', arg[:document]['collection_title_ssi']]) + popup_window, link, target: '_blank', rel: 'noopener')
+      links << link_to(safe_join(['View full finding aid for ',
+                                  arg[:document]['collection_title_ssi'].presence || 'this collection']) + popup_window,
+                                  link,
+                                  target: '_blank',
+                                  rel: 'noopener')
     end
     links.first
   end

--- a/spec/system/view_fields_in_display_spec.rb
+++ b/spec/system/view_fields_in_display_spec.rb
@@ -6,7 +6,8 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
     solr = Blacklight.default_index.connection
     solr.add([test_record,
               same_call_record,
-              diff_call_record])
+              diff_call_record,
+              no_collection_record])
     solr.commit
     visit '/catalog/111'
   end
@@ -24,6 +25,14 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       id: '333',
       visibility_ssi: 'Public',
       callNumber_ssim: 'this is the call number, but different'
+    }
+  end
+
+  let(:no_collection_record) do
+    {
+      id: '444',
+      visibility_ssi: 'Public',
+      findingAid_ssim: 'this is the finding aid'
     }
   end
 
@@ -353,5 +362,16 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
     expect(page).to have_css '.show-header'
     expect(page).to have_css '.universal-viewer-iframe'
     expect(page).to have_css '.showpage_no_label_tag'
+  end
+
+  context 'when record has no collection title' do
+    it 'the finding aid contains fallback text in the link' do
+      visit '/catalog/444'
+      finding_aid_link = page.find("a[href = 'this is the finding aid']")
+
+      expect(finding_aid_link).to be_truthy
+      expect(finding_aid_link).to have_content "View full finding aid for this collection"
+      expect(finding_aid_link).to have_css("img[src ^= '/assets/YULPopUpWindow']")
+    end
   end
 end


### PR DESCRIPTION
# Summary
Provides fallback text for when no Collection Title is present.

# Related Ticket
[#1598](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1598)

# Note
On show page it is the `sourceTitle_tesim` that is displayed as 'Collection Title' not the `collection_title_ssi` value that is used for the finding aid link.

# Screenshots
- When Collection Title is present

![image](https://user-images.githubusercontent.com/36549923/133514564-11f9e4c3-b85c-467d-aac2-0603802550dc.png)

- When Collection Title is not present

![image](https://user-images.githubusercontent.com/36549923/133514621-451238ff-e320-4d43-9842-594165024224.png)
