### PR TITLE
Adds title as final item in graphical hierarchy

### DIFF
--- a/app/assets/stylesheets/customOverrides/show_page.scss
+++ b/app/assets/stylesheets/customOverrides/show_page.scss
@@ -273,6 +273,10 @@ p.yale-restricted-work-text{
   list-style: none;
 }
 
+.yaleASpaceItemTitle {
+  display: inline;
+}
+
 //Control the appearance of hierarchy icons and space
 .aSpaceBranch {
   position: absolute;

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -147,7 +147,7 @@ module BlacklightHelper
   def aspace_tree_display(arg)
     ancestor_display_strings = arg[:document][arg[:field]]
     hierarchy_params = hierarchy_builder arg[:document]
-    last = ancestor_display_strings.size
+    last = ancestor_display_strings.size + 1
 
     img_home = image_tag("archival_icons/yaleASpaceHome.png", { class: 'ASpace_Home ASpace_Icon', alt: 'Main level' })
     img_stack = image_tag("archival_icons/yaleASpaceStack.png", { class: 'ASpace_Stack ASpace_Icon', alt: 'Second level' })
@@ -157,10 +157,18 @@ module BlacklightHelper
     above_or_below = false
     collapsed = nil
     hierarchy_tree = nil
+    ancestor_display_strings.unshift(arg[:document][:title_tesim].first)
     # rubocop:disable Metrics/BlockLength
     (1..last).each do
       current = ancestor_display_strings.shift
-      current = link_to current, url_for(hierarchy_params.pop&.merge(action: 'index')) if hierarchy_params.present?
+
+      current = if current == arg[:document][:title_tesim].first
+                  tag.p(current, class: 'yaleASpaceItemTitle')
+                elsif hierarchy_params.present?
+                  link_to current, url_for(hierarchy_params.pop&.merge(action: 'index'))
+                else
+                  tag.p(current, class: 'yaleASpaceItem')
+                end
 
       case ancestor_display_strings.size
       when 0

--- a/spec/system/view_fields_in_display_spec.rb
+++ b/spec/system/view_fields_in_display_spec.rb
@@ -284,6 +284,14 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
           expect(page).to have_link "seventh"
         end
       end
+      it 'has title of display item as text' do
+        within '.aSpace_tree' do
+          page.find('.show-full-tree-button').click
+
+          expect(page).to have_content "Diversity Bull Dogs"
+          expect(page).not_to have_link "Diversity Bull Dogs"
+        end
+      end
       it 'searches on link click' do
         within '.aSpace_tree' do
           page.find('.show-full-tree-button').click


### PR DESCRIPTION
# Summary
Adds the parent object title as the last element (as text, not a link) of the graphical hierarchy tree on the object show page.

# Related Ticket
[1601](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1601)

# Screenshots
![image](https://user-images.githubusercontent.com/36549923/133703590-eaf2d334-e681-4fd9-b4fd-7f8f2be7defc.png)
![image](https://user-images.githubusercontent.com/36549923/133703616-cd8acb89-c72d-4bcd-bddb-9bb0f4fafecc.png)
