### PR TITLE
Update archival links to clear current search

### DIFF
--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -88,10 +88,7 @@ module BlacklightHelper
 
     if hierarchy.present?
       (0..values.size - 1).each do |i|
-        values[i] = link_to values[i], request.params.merge('f' =>
-            request&.params&.[]("f")&.except("ancestor_titles_hierarchy_ssim"))&.merge(
-            "f[ancestor_titles_hierarchy_ssim][]" => hierarchy[i]
-          )&.except("page")
+        values[i] = link_to values[i], search_catalog_path("f[ancestor_titles_hierarchy_ssim][]" => hierarchy[i])
       end
     end
     if values.count > 5
@@ -109,7 +106,7 @@ module BlacklightHelper
 
     if hierarchy.present?
       (0..values.size - 1).each do |i|
-        values[i] = link_to values[i], url_for(hierarchy_params.pop&.merge(action: 'index')) if hierarchy_params.present?
+        values[i] = link_to values[i], search_catalog_path(hierarchy_params.pop) if hierarchy_params.present?
       end
     end
     if values.count > 5
@@ -126,10 +123,7 @@ module BlacklightHelper
 
     if hierarchy.present? && @search_params
       (0..hierarchy.size - 1).each do |i|
-        hierarchy_params << @search_params.merge('f' =>
-        @search_params&.[]("f")&.except("ancestor_titles_hierarchy_ssim"))&.merge(
-          "f[ancestor_titles_hierarchy_ssim][]" => hierarchy[i]
-        )&.except("page")
+        hierarchy_params << { "f[ancestor_titles_hierarchy_ssim][]" => hierarchy[i] }
       end
     end
     hierarchy_params
@@ -160,7 +154,7 @@ module BlacklightHelper
     # rubocop:disable Metrics/BlockLength
     (1..last).each do
       current = ancestor_display_strings.shift
-      current = link_to current, url_for(hierarchy_params.pop&.merge(action: 'index')) if hierarchy_params.present?
+      current = link_to current, search_catalog_path(hierarchy_params.pop) if hierarchy_params.present?
 
       case ancestor_display_strings.size
       when 0

--- a/spec/system/view_fields_in_display_spec.rb
+++ b/spec/system/view_fields_in_display_spec.rb
@@ -301,7 +301,7 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
         end
         expect(page).to have_content "Diversity Bull Dogs"
       end
-      it 'preserves search constraints', style: true do
+      it 'does not preserve search constraints', style: true do
         visit '/catalog?q='
         click_on 'Creator'
         click_on 'Frederick'
@@ -330,7 +330,7 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
         end
         expect(page).to have_content "Diversity Bull Dogs"
       end
-      it 'preserves search constraints', style: true do
+      it 'does not preserves search constraints', style: true do
         visit '/catalog?q='
         click_on 'Creator'
         click_on 'Frederick'

--- a/spec/system/view_fields_in_display_spec.rb
+++ b/spec/system/view_fields_in_display_spec.rb
@@ -313,7 +313,7 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
           click_on 'fourth'
         end
         expect(page).to have_css ".filter-name", text: "Found In", count: 1
-        expect(page).to have_css ".filter-name", text: "Creator", count: 1
+        expect(page).to have_css ".filter-name", text: "Creator", count: 0
       end
     end
     context 'ASpace hierarchy breadcrumb' do
@@ -340,7 +340,7 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
           click_on 'second'
         end
         expect(page).to have_css ".filter-name", text: "Found In", count: 1
-        expect(page).to have_css ".filter-name", text: "Creator", count: 1
+        expect(page).to have_css ".filter-name", text: "Creator", count: 0
       end
     end
 

--- a/spec/system/view_fields_in_search_spec.rb
+++ b/spec/system/view_fields_in_search_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe 'Search results displays field', type: :system, clean: true do
         click_on "Level0"
 
         expect(page).to have_css ".filter-name", text: "Found In", count: 1
-        expect(page).to have_css ".filter-name", text: "Creator", count: 1
+        expect(page).to have_css ".filter-name", text: "Creator", count: 0
       end
     end
   end

--- a/spec/system/view_fields_in_search_spec.rb
+++ b/spec/system/view_fields_in_search_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe 'Search results displays field', type: :system, clean: true do
         # makes sure "found in" does not stack
         expect(page).to have_css ".filter-name", text: "Found In", count: 1
       end
-      it 'keeps other constraints when facet links are clicked' do
+      it 'does not keep other constraints when facet links are clicked' do
         click_on "Creator"
         click_on "Me and You"
         expect(page).to have_css ".filter-name", text: "Creator", count: 1


### PR DESCRIPTION
Clicking on archival links (found in, breadcrumb, and hierarchy) no longer retains the current search
![ClearArchival](https://user-images.githubusercontent.com/32851993/133805525-58cc1b78-3a24-4aa0-a947-f7d74958f398.gif)
.