### PR TITLE
Add title to the end of the archival hierarchy (found in) on show page

### DIFF
--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -112,9 +112,10 @@ module BlacklightHelper
         values[i] = link_to values[i], url_for(hierarchy_params.pop&.merge(action: 'index')) if hierarchy_params.present?
       end
     end
-    if values.count > 5
+    values << arg[:document][:title_tesim].join(", ") if arg[:document][:title_tesim]
+    if values.count > 6
       values[3] = "<span><button class='show-more-button' aria-label='Show More' title='Show More'>...</button> &gt; </span><span class='show-more-hidden-text'>".html_safe + values[3]
-      values[values.count - 2] = "</span></span>".html_safe + values[values.count - 2]
+      values[values.count - 3] = "</span></span>".html_safe + values[values.count - 3]
     end
     safe_join(values, ' > ')
   end

--- a/spec/system/view_fields_in_display_spec.rb
+++ b/spec/system/view_fields_in_display_spec.rb
@@ -330,6 +330,11 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
         end
         expect(page).to have_content "Diversity Bull Dogs"
       end
+      it 'displays title of current document' do
+        within '.archival-context' do
+          expect(page).to have_content("Diversity Bull Dogs, this is the second title")
+        end
+      end
       it 'preserves search constraints', style: true do
         visit '/catalog?q='
         click_on 'Creator'


### PR DESCRIPTION
Add title to the end of the list, not as a link.
Still show the same number of links.

![AddTitleToFoundInShow.gif](https://images.zenhubusercontent.com/5e5e9bbd38fda217bdabbde0/de4ff728-e629-446d-b93c-324def083fa5)