### PR TITLE
Modifies html sanitize helper

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -249,7 +249,7 @@ class CatalogController < ApplicationController
 
     # Access and Usage Rights Group
     config.add_show_field 'visibility_ssi', label: 'Access', metadata: 'access_and_usage_rights'
-    config.add_show_field 'rights_ssim', label: 'Rights', metadata: 'access_and_usage_rights', helper_method: :html_safe_converter
+    config.add_show_field 'rights_ssim', label: 'Rights', metadata: 'access_and_usage_rights', helper_method: :line_break_converter
     config.add_show_field 'preferredCitation_tesim', label: 'Citation', metadata: 'access_and_usage_rights', helper_method: :join_with_br
 
     # Identifiers Group

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -249,7 +249,7 @@ class CatalogController < ApplicationController
 
     # Access and Usage Rights Group
     config.add_show_field 'visibility_ssi', label: 'Access', metadata: 'access_and_usage_rights'
-    config.add_show_field 'rights_ssim', label: 'Rights', metadata: 'access_and_usage_rights', helper_method: :line_break_converter
+    config.add_show_field 'rights_ssim', label: 'Rights', metadata: 'access_and_usage_rights', helper_method: :html_safe_converter
     config.add_show_field 'preferredCitation_tesim', label: 'Citation', metadata: 'access_and_usage_rights', helper_method: :join_with_br
 
     # Identifiers Group

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -112,10 +112,15 @@ module BlacklightHelper
     link_to(arg[:value][0], arg[:value][0])
   end
 
-  def line_break_converter(arg)
+  def html_safe_converter(arg)
     value = arg[:value].first
     values = value.split("\n")
-    safe_join(values, '<br/>'.html_safe)
+    sanitized_values = []
+    values.each do |v|
+      sanitize v, tags: %w[a], attributes: %w[href]
+      sanitized_values << v
+    end
+    safe_join(sanitized_values, '<br/>'.html_safe)
   end
 
   def search_field_value_link(args)

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -112,8 +112,10 @@ module BlacklightHelper
     link_to(arg[:value][0], arg[:value][0])
   end
 
-  def html_safe_converter(arg)
-    sanitize arg[:value][0], tags: %w[a], attributes: %w[href]
+  def line_break_converter(arg)
+    value = arg[:value].first
+    values = value.split("\n")
+    safe_join(values, '<br/>'.html_safe)
   end
 
   def search_field_value_link(args)

--- a/spec/system/view_fields_in_display_spec.rb
+++ b/spec/system/view_fields_in_display_spec.rb
@@ -45,7 +45,7 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       subjectName_ssim: ['this is the subject name', 'these are the subject names'],
       subjectTopic_ssim: ['this is the subject topic', 'these are the subject topics'],
       extentOfDigitization_ssim: 'this is the extent of digitization',
-      rights_ssim: "these are the rights",
+      rights_ssim: "these are the rights.\nThese are additional rights.",
       creationPlace_ssim: "this is the publication place",
       sourceCreated_tesim: "this is the source created",
       publisher_ssim: "this is the publisher",
@@ -147,7 +147,7 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       expect(document).to have_content("Public")
     end
     it 'displays the Rights in results' do
-      expect(document).to have_content("these are the rights")
+      expect(document).to have_content("these are the rights.These are additional rights.")
     end
     it 'displays the Publication Place in results' do
       expect(document).to have_content("this is the publication place")


### PR DESCRIPTION
# Summary
Multiple rights statements should display on new lines.

# Related Ticket
[#1613](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1613)

# Screenshot
![image](https://user-images.githubusercontent.com/36549923/133827287-3830fabf-474f-410b-beb1-1ecc2927bdb2.png)
