### PR TITLE
1602 display item in hierarchy search result

### DIFF
--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -83,9 +83,9 @@ module BlacklightHelper
 
   def archival_display(arg)
     values = arg[:document][arg[:field]].reverse
-
+    title = arg[:document]["title_tesim"].presence || []
     hierarchy = arg[:document][:ancestor_titles_hierarchy_ssim]
-
+    # byebug
     if hierarchy.present?
       (0..values.size - 1).each do |i|
         values[i] = link_to values[i], request.params.merge('f' =>
@@ -98,7 +98,7 @@ module BlacklightHelper
       values[3] = "<span><button class='show-more-button' aria-label='Show More' title='Show More'>...</button> &gt; </span><span class='show-more-hidden-text'>".html_safe + values[3]
       values[values.count - 2] = "</span></span>".html_safe + values[values.count - 2]
     end
-    safe_join(values, ' > ')
+    safe_join(values + title, ' > ')
   end
 
   def archival_display_show(arg)
@@ -120,6 +120,7 @@ module BlacklightHelper
   end
 
   def hierarchy_builder(document)
+    # byebug
     hierarchy = document[:ancestor_titles_hierarchy_ssim]
     hierarchy_params = []
     @search_params ||= Hash.new { |h, k| h[k] = h.dup.clear }
@@ -146,7 +147,7 @@ module BlacklightHelper
 
   def aspace_tree_display(arg)
     ancestor_display_strings = arg[:document][arg[:field]]
-    hierarchy_params = hierarchy_builder arg[:document]
+    hierarchy_params = hierarchy_builder arg[:document]    
     last = ancestor_display_strings.size
 
     img_home = image_tag("archival_icons/yaleASpaceHome.png", { class: 'ASpace_Home ASpace_Icon', alt: 'Main level' })

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -83,9 +83,9 @@ module BlacklightHelper
 
   def archival_display(arg)
     values = arg[:document][arg[:field]].reverse
-    title = arg[:document]["title_tesim"].presence || []
+    title = link_to arg[:document][:title_tesim] ? arg[:document][:title_tesim].join(", ") : arg[:document][:id], solr_document_path(arg[:document][:id])
     hierarchy = arg[:document][:ancestor_titles_hierarchy_ssim]
-    # byebug
+
     if hierarchy.present?
       (0..values.size - 1).each do |i|
         values[i] = link_to values[i], search_catalog_path("f[ancestor_titles_hierarchy_ssim][]" => hierarchy[i])
@@ -95,7 +95,8 @@ module BlacklightHelper
       values[3] = "<span><button class='show-more-button' aria-label='Show More' title='Show More'>...</button> &gt; </span><span class='show-more-hidden-text'>".html_safe + values[3]
       values[values.count - 2] = "</span></span>".html_safe + values[values.count - 2]
     end
-    safe_join(values + title, ' > ')
+    values << title
+    safe_join(values, ' > ')
   end
 
   def archival_display_show(arg)

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -119,7 +119,6 @@ module BlacklightHelper
   end
 
   def hierarchy_builder(document)
-    # byebug
     hierarchy = document[:ancestor_titles_hierarchy_ssim]
     hierarchy_params = []
     @search_params ||= Hash.new { |h, k| h[k] = h.dup.clear }

--- a/spec/system/show_page_spec.rb
+++ b/spec/system/show_page_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Show Page', type: :system, js: true, clean: true do
               void])
     solr.commit
     visit '/catalog?search_field=all_fields&q='
-    click_on 'Amor Llama'
+    click_on 'Amor Llama', :match => :first
   end
 
   let(:llama) do

--- a/spec/system/show_page_spec.rb
+++ b/spec/system/show_page_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Show Page', type: :system, js: true, clean: true do
               void])
     solr.commit
     visit '/catalog?search_field=all_fields&q='
-    click_on 'Amor Llama', :match => :first
+    click_on 'Amor Llama', match: :first
   end
 
   let(:llama) do

--- a/spec/system/view_fields_in_search_spec.rb
+++ b/spec/system/view_fields_in_search_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe 'Search results displays field', type: :system, clean: true do
     {
       id: '111',
       creator_ssim: 'Me and You',
+      title_tesim: ['Amor Perro'],
       date_ssim: '1999',
       resourceType_ssim: 'Archives or Manuscripts',
       callNumber_tesim: 'Beinecke MS 801',

--- a/spec/system/view_fields_in_search_spec.rb
+++ b/spec/system/view_fields_in_search_spec.rb
@@ -70,15 +70,16 @@ RSpec.describe 'Search results displays field', type: :system, clean: true do
     context 'Ancestor Title (Found in)' do
       it 'is displayed in results with links' do
         expect(content).to have_link("Level0")
+        expect(content).to have_link("Amor Perro")
         click_on "Level0"
-        expect(page).to have_content "111"
+        expect(page).to have_content "Amor Perro"
 
         click_on "Beinecke Rare Book and Manuscript Library (BRBL)"
-        expect(page).to have_content "111"
+        expect(page).to have_content "Amor Perro"
 
         click_on("...")
         click_on "Level3"
-        expect(page).to have_content "111"
+        expect(page).to have_content "Amor Perro"
 
         # makes sure "found in" does not stack
         expect(page).to have_css ".filter-name", text: "Found In", count: 1


### PR DESCRIPTION
# Summary  
The item title is now displayed in the "Found In" hierarchy tree in the search results. Clicking on the title will redirect to the item showpage.  
![Image 2021-09-20 at 1 29 11 PM](https://user-images.githubusercontent.com/24666568/134071081-a90bcef9-57b1-4080-a4bd-3dbe2962e599.jpg)

  

