### PR TITLE
Adds multiple finding aid fallbacks for collection title

### DIFF
--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -224,7 +224,7 @@ module BlacklightHelper
     findingAidUri.each do |link|
       popup_window = image_tag("YULPopUpWindow.png", { id: 'popup_window', alt: 'pop up window' })
       links << link_to(safe_join(['View full finding aid for ',
-                                  arg[:document]['sourceTitle_tesim'].presence || 'this collection']) + popup_window,
+                                  arg[:document]['collection_title_ssi'].presence || arg[:document]['sourceTitle_tesim'].presence || 'this collection']) + popup_window,
                                   link,
                                   target: '_blank',
                                   rel: 'noopener')

--- a/spec/system/view_fields_in_display_spec.rb
+++ b/spec/system/view_fields_in_display_spec.rb
@@ -361,7 +361,7 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       finding_aid_link = page.find("a[href = 'this is the finding aid']")
 
       expect(finding_aid_link).to be_truthy
-      expect(finding_aid_link).to have_content "View full finding aid for this is the source title"
+      expect(finding_aid_link).to have_content "View full finding aid for this is the collection title"
       expect(finding_aid_link).to have_css("img[src ^= '/assets/YULPopUpWindow']")
     end
   end


### PR DESCRIPTION
# Summary
Adds fallbacks for Collection Title - first `collection_title_ssi`, then `sourceTitle_tesim`, and if neither of those then 'this collection'

# Related Ticket
[#1598](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1598)
