### PR TITLE
1611 Added volume number to search results page

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -179,7 +179,7 @@ class CatalogController < ApplicationController
     config.add_index_field 'date_ssim', label: 'Published / Created', highlight: true, solr_params: disp_req_fieldmatch_on_search_params
     config.add_index_field 'callNumber_tesim', label: 'Call Number', highlight: true, solr_params: disp_req_fieldmatch_on_search_params
     config.add_index_field 'sourceTitle_tesim', label: 'Collection Title', highlight: true, solr_params: disp_req_fieldmatch_on_search_params
-    config.add_index_field 'containerGrouping_tesim', label: 'Container/ Volume Information'
+    config.add_index_field 'containerGrouping_tesim', label: 'Container / Volume'
     config.add_index_field 'imageCount_isi', label: 'Image Count'
     config.add_index_field 'resourceType_tesim', label: 'Resource Type', highlight: true, solr_params: disp_req_fieldmatch_on_search_params
     config.add_index_field 'fulltext_tesim', label: 'Full Text', highlight: true, solr_params: disp_highlight_on_search_params.merge({ 'hl.snippets': 4 }), helper_method: :fulltext_snippet_separation

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -179,6 +179,7 @@ class CatalogController < ApplicationController
     config.add_index_field 'date_ssim', label: 'Published / Created', highlight: true, solr_params: disp_req_fieldmatch_on_search_params
     config.add_index_field 'callNumber_tesim', label: 'Call Number', highlight: true, solr_params: disp_req_fieldmatch_on_search_params
     config.add_index_field 'sourceTitle_tesim', label: 'Collection Title', highlight: true, solr_params: disp_req_fieldmatch_on_search_params
+    config.add_index_field 'containerGrouping_tesim', label: 'Container/ Volume Information'
     config.add_index_field 'imageCount_isi', label: 'Image Count'
     config.add_index_field 'resourceType_tesim', label: 'Resource Type', highlight: true, solr_params: disp_req_fieldmatch_on_search_params
     config.add_index_field 'fulltext_tesim', label: 'Full Text', highlight: true, solr_params: disp_highlight_on_search_params.merge({ 'hl.snippets': 4 }), helper_method: :fulltext_snippet_separation

--- a/spec/system/view_fields_in_search_spec.rb
+++ b/spec/system/view_fields_in_search_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe 'Search results displays field', type: :system, clean: true do
       date_ssim: '1999',
       resourceType_ssim: 'Archives or Manuscripts',
       callNumber_tesim: 'Beinecke MS 801',
+      containerGrouping_tesim: 'BRBL_091081',
       imageCount_isi: '23',
       visibility_ssi: 'Public'
     }
@@ -35,6 +36,9 @@ RSpec.describe 'Search results displays field', type: :system, clean: true do
     end
     it 'displays Call Number in results' do
       expect(content).to have_content('Beinecke MS 801')
+    end
+    it 'displays Container / Volume in results' do
+      expect(content).to have_content('BRBL_091081')
     end
     it 'displays Image Count in results' do
       expect(content).to have_content('23')


### PR DESCRIPTION
**Story**

The Voyager volumeEnumeration field ought to display in the search results page list under the object the items with the data. 

**Acceptance**
- [x] "Container/ Volume Information" (Solr field `containerGrouping_tesim`) displays in search results
- [x] The field should appear next after the Collection Title / `sourceTitle_tesim` field
- [ ] Properly space the field title with the field data for the Container/ Volume Information and the rest of the section
OR 
- [x] Implement a phrase with 20 or fewer characters

Current System View: 
![image](https://user-images.githubusercontent.com/41123693/134359238-0af5f3fc-afdf-4d63-9499-dd56aa5d381f.png)

Proposed System View: 
![image](https://user-images.githubusercontent.com/41123693/134514078-b7a3e186-68bf-472f-bfb9-335f0e5b8f19.png)

