### PR TITLE
Checks for full text before request

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -144,6 +144,7 @@ $(document).ready(() => {
 
 // Get the full text and render it on screen
 const fulltext = () => {
+    // check if fulltext is present
     const fulltextTranscription = $('.item-page-fulltext-wrapper .row')
     fulltextTranscription.empty() // Delete the old full text
     const child_oids_array = $('#uv-pages').html().split(' ')
@@ -157,16 +158,41 @@ const fulltext = () => {
 }
 
 const getFulltext = async (child_oid) => {
-    const result = await $.ajax({
+    shouldGet = await $.ajax({
         type:'GET',
         url:`/annotation/oid/${$('#parent-oid').text()}/canvas/${child_oid}/fulltext`,
-        data: {
-            oid: $('#parent-oid').text(),
-            child_oid: $('#uv-pages').text()
-        },
+        error: function (x) {
+            if (x.status == 500) {
+                console.log('500')
+                return false
+            } else {
+                console.log('else')
+                return true
+            }
+        }
     })
-
-    return result.body.value
+    if(shouldGet == true) {
+        const result = await $.ajax({
+            type:'GET',
+            url:`/annotation/oid/${$('#parent-oid').text()}/canvas/${child_oid}/fulltext`,
+            data: {
+                oid: $('#parent-oid').text(),
+                child_oid: $('#uv-pages').text()
+            },
+        })
+        return result.body.value
+    } else {
+        console.log('billow')
+    }
+    // const result = await $.ajax({
+    //     type:'GET',
+    //     url:`/annotation/oid/${$('#parent-oid').text()}/canvas/${child_oid}/fulltext`,
+    //     data: {
+    //         oid: $('#parent-oid').text(),
+    //         child_oid: $('#uv-pages').text()
+    //     },
+    // })
+    // return result.body.value
 }
 
 $(document).on('turbolinks:load', function() {

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -144,55 +144,34 @@ $(document).ready(() => {
 
 // Get the full text and render it on screen
 const fulltext = () => {
-    // check if fulltext is present
+    // check if fulltext is present on page
     const fulltextTranscription = $('.item-page-fulltext-wrapper .row')
     fulltextTranscription.empty() // Delete the old full text
-    const child_oids_array = $('#uv-pages').html().split(' ')
-    const pageWidth = child_oids_array.length === 1 ? 'col-md-12' : 'col-md-6'
-
-    child_oids_array.forEach(async child_oid => {
-        const transcription = await getFulltext(child_oid)
-
-        return fulltextTranscription.append(`<span class='${pageWidth}'>${transcription}</span>`)
-    })
+    // check if fulltext is present on child object - button will only display if fulltext is available
+    if($('.fulltext-button').length) {
+        const child_oids_array = $('#uv-pages').html().split(' ')
+        const pageWidth = child_oids_array.length === 1 ? 'col-md-12' : 'col-md-6'
+    
+        child_oids_array.forEach(async child_oid => {
+            const transcription = await getFulltext(child_oid)
+    
+            return fulltextTranscription.append(`<span class='${pageWidth}'>${transcription}</span>`)
+        })
+    } else {
+        return
+    }
 }
 
 const getFulltext = async (child_oid) => {
-    shouldGet = await $.ajax({
+    const result = await $.ajax({
         type:'GET',
         url:`/annotation/oid/${$('#parent-oid').text()}/canvas/${child_oid}/fulltext`,
-        error: function (x) {
-            if (x.status == 500) {
-                console.log('500')
-                return false
-            } else {
-                console.log('else')
-                return true
-            }
-        }
+        data: {
+            oid: $('#parent-oid').text(),
+            child_oid: $('#uv-pages').text()
+        },
     })
-    if(shouldGet == true) {
-        const result = await $.ajax({
-            type:'GET',
-            url:`/annotation/oid/${$('#parent-oid').text()}/canvas/${child_oid}/fulltext`,
-            data: {
-                oid: $('#parent-oid').text(),
-                child_oid: $('#uv-pages').text()
-            },
-        })
-        return result.body.value
-    } else {
-        console.log('billow')
-    }
-    // const result = await $.ajax({
-    //     type:'GET',
-    //     url:`/annotation/oid/${$('#parent-oid').text()}/canvas/${child_oid}/fulltext`,
-    //     data: {
-    //         oid: $('#parent-oid').text(),
-    //         child_oid: $('#uv-pages').text()
-    //     },
-    // })
-    // return result.body.value
+    return result.body.value
 }
 
 $(document).on('turbolinks:load', function() {

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -147,7 +147,7 @@ const fulltext = () => {
     // check if fulltext is present on page
     const fulltextTranscription = $('.item-page-fulltext-wrapper .row')
     fulltextTranscription.empty() // Delete the old full text
-    // check if fulltext is present on child object - button will only display if fulltext is available
+    // check if fulltext is present on child object - button will only display if 'has_fulltext_ssi' is Yes
     if($('.fulltext-button').length) {
         const child_oids_array = $('#uv-pages').html().split(' ')
         const pageWidth = child_oids_array.length === 1 ? 'col-md-12' : 'col-md-6'


### PR DESCRIPTION
# Summary 
Calling the resource when full text was not present was returning a 500 Internal server error.  These changes check for the presence of the Full Text button before calling the resource.  Full Text button only displayed when full text is present so this should reduce the number of 500 errors on HoneyBadger.

# Related Ticket
[#1615](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1615)

# Screenshots / Video

![Image 2021-09-24 at 9 49 19 AM](https://user-images.githubusercontent.com/36549923/134714278-8d08dd5f-e7d2-490d-ad93-1c1e05f2b426.jpg)

https://user-images.githubusercontent.com/36549923/134714312-53c3673c-0494-430c-87d0-aa4881d4633b.mp4

https://user-images.githubusercontent.com/36549923/134714394-0e972ba8-7c19-4092-8e3c-97ae8bed0fb7.mp4



