### PR TITLE
Shortens Container Volume label on show page

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -234,7 +234,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'sourceDate_tesim', label: 'Collection Date', metadata: 'collection_information'
     config.add_show_field 'sourceNote_tesim', label: 'Collection Note', metadata: 'collection_information'
     config.add_show_field 'sourceEdition_tesim', label: 'Collection Edition', metadata: 'collection_information'
-    config.add_show_field 'containerGrouping_tesim', label: 'Container / Volume Information', metadata: 'collection_information'
+    config.add_show_field 'containerGrouping_tesim', label: 'Container / Volume', metadata: 'collection_information'
     config.add_show_field 'relatedResourceOnline_ssim', label: 'Related Resource Online', metadata: 'collection_information', helper_method: :link_to_url_with_label
     config.add_show_field 'resourceVersionOnline_ssim', label: 'Resource Version Online', metadata: 'collection_information', helper_method: :link_to_url_with_label
     config.add_show_field 'findingAid_ssim', label: 'Finding Aid', metadata: 'collection_information', helper_method: :link_to_url

--- a/spec/presenters/yul/metadata_presenter_spec.rb
+++ b/spec/presenters/yul/metadata_presenter_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe Yul::MetadataPresenter do
           expect(fields.any? { |field| field.include? 'sourceTitle_tesim' }).to be_truthy
         end
 
-        it 'returns the Container/Volume Information Key' do
+        it 'returns the Container/Volume Key' do
           expect(fields.any? { |field| field.include? 'containerGrouping_tesim' }).to be_truthy
         end
 

--- a/spec/system/view_fields_in_display_spec.rb
+++ b/spec/system/view_fields_in_display_spec.rb
@@ -190,7 +190,7 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       expect(document).to have_content("2345678")
     end
 
-    it 'displays the Container/Volume Information in results' do
+    it 'displays the Container/Volume in results' do
       expect(document).to have_content("this is the container information")
     end
     it 'displays the Orbis Bib ID in results' do


### PR DESCRIPTION
# Summary
Shortens the Container / Volume field label on an item's show page to match the search results page.

# Related Ticket
[#1641](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1641)

# Screenshots
### Before
![image](https://user-images.githubusercontent.com/36549923/134745748-aa5af41c-2a2e-4857-a91a-2dac2bfc81ce.png)

### After
![image](https://user-images.githubusercontent.com/36549923/134745848-b8dbc1e7-70c9-406f-8538-cf517fd85f5a.png)
