### PR TITLE
Restore CSS for parent-oid

### DIFF
--- a/app/assets/stylesheets/customOverrides/show_page.scss
+++ b/app/assets/stylesheets/customOverrides/show_page.scss
@@ -140,7 +140,8 @@ DEFAULT MOBILE STYLING
   align-content: center;
 }
 
-#uv-pages {
+#uv-pages,
+#parent-oid {
   display: none;
 }
 


### PR DESCRIPTION
The archival branch merge removed a CSS style, resulting in an OID displaying beneath the UV.  This restores the style.