### PR TITLE
Changed circle ci to use the latest solr i1545

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
             POSTGRES_PASSWORD: password
             SOLR_CORE: blacklight-test
             SOLR_TEST_URL: http://localhost:8983/solr/blacklight-test
-      - image: yalelibraryit/dc-solr:1362_fulltext_suggest_retain_case
+      - image: yalelibraryit/dc-solr:v1.0.8
         command: bash -c 'precreate-core blacklight-test /opt/config; chown -R solr:solr /var/solr/data/ ; /boot.sh'
       - image: circleci/postgres:9.5-alpine-ram
         environment:


### PR DESCRIPTION
Co-authored-by: Keith Boyd-Carter <keith.boyd-carter@yale.edu>
Co-authored-by: McClain Looney <mcclain@curationexperts.com>

**Story**

We have a new Solr release (v1.0.8).  CircleCI is referencing a branch build: `image: yalelibraryit/dc-solr:1362_fulltext_suggest_retain_case`

**Acceptance**
- [x] use the 1.0.8 Solr image in the .circleci/config.yml. 
