### PR TITLE
Resizes finding aid links

### DIFF
--- a/app/assets/stylesheets/customOverrides/show_page.scss
+++ b/app/assets/stylesheets/customOverrides/show_page.scss
@@ -301,6 +301,7 @@ p.yale-restricted-work-text{
 .showpage_no_label_tag,
 .blacklight-archivespaceuri_ssi {
   font-family: Mallory-Bold;
+  font-size: 14px;
   background-color: $lighter_grey;
   margin: 0;
   padding-left: 2%;


### PR DESCRIPTION
# Summary 
Brings font size of finding aid and archives at Yale links down to match rest of page.  

# Related Ticket
[#1662](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1662)

# Before
![Screen Shot 2021-09-30 at 11 24 49 AM](https://user-images.githubusercontent.com/36549923/135510870-bf728055-de47-4720-a39b-8b31dc24da5b.png)

# After
![Screen Shot 2021-09-30 at 11 25 25 AM](https://user-images.githubusercontent.com/36549923/135510886-8c561856-8246-4a12-afb5-b5c2864c5060.png)

