### PR TITLE
Add repository name to object page i1660

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -234,6 +234,7 @@ class CatalogController < ApplicationController
     # ancestorDisplayStrings must be first and the information of the ASpace tree
     # archiveSpaceUri and findingAid must be last
     #
+    config.add_show_field 'repository_ssi', label: 'Repository', metadata: 'collection_information'
     config.add_show_field 'callNumber_ssim', label: 'Call Number', metadata: 'collection_information', link_to_facet: true
     config.add_show_field 'sourceTitle_tesim', label: 'Collection Title', metadata: 'collection_information'
     config.add_show_field 'sourceCreator_tesim', label: 'Collection/Other Creator', metadata: 'collection_information'

--- a/spec/system/view_fields_in_display_spec.rb
+++ b/spec/system/view_fields_in_display_spec.rb
@@ -60,6 +60,7 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       publisher_ssim: "this is the publisher",
       copyrightDate_ssim: "this is the copyright date",
       source_ssim: "this is the source",
+      repository_ssi: "this is the repository name",
       recordType_ssi: "this is the record type",
       sourceTitle_tesim: "this is the source title",
       sourceCreator_tesim: "this is the source creator",
@@ -213,6 +214,9 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
     end
     it 'displays the Edition in results' do
       expect(document).to have_content("this is the edition")
+    end
+    it 'displays the repository name in results' do
+      expect(document).to have_content("this is the repository name")
     end
     it 'displays the call number in results as link' do
       expect(page).to have_link("this is the call number", href: '/catalog?f%5BcallNumber_ssim%5D%5B%5D=this+is+the+call+number')


### PR DESCRIPTION
**Story**

We need to display the repository name within the Collection Information section on each object page, for all metadata sources. 

![image](https://user-images.githubusercontent.com/41123693/135512316-f0efcffa-a6cb-47bf-b856-191cbd22f14a.png)


**Acceptance**
- [x] Repository should display as the first field under Collection Information section header on an object page
- [x] It should display with the field label "Repository" in bold, matching the other field labels in this cluster. 
- [x] The value in this field should not link.  