### PR TITLE
Changes record not found error handling

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,8 +8,10 @@ class ApplicationController < ActionController::Base
 
   layout :determine_layout if respond_to? :layout
 
-  rescue_from Blacklight::Exceptions::RecordNotFound do
-    render template: 'errors/not_found'
+  rescue_from Blacklight::Exceptions::RecordNotFound, with: :not_found
+
+  def not_found
+    send_file 'public/not_found.html', disposition: 'inline', type: 'text/html; charset=utf-8', status: 404
   end
 
   def landing

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,5 +1,5 @@
 <div class='record-not-found'>
     <h1>The page you were looking for doesn't exist.</h1>
-    <p>You may have mistyped the address or the page may have moved.</p>
-    <p>If you are the application owner check the logs for more information.</p>
+    <p>You may have mistyped the address, provided an invalid Object ID, or the page may have moved.</p>
+    <p>If the resource is a manifest or PDF it can take time to generate these files; please check back in 24 hours.</p>
 </div>

--- a/public/not_found.html
+++ b/public/not_found.html
@@ -5,7 +5,7 @@
 <body>
 <h3>We're sorry, but the item you've requested does not appear to exist</h3>
 <ul>
-    <li>If this is a new item, PDF generation may take some time, please check back in 24 hours</li>
+    <li>If this is a new item, Manifest or PDF generation may take some time, please check back in 24 hours</li>
     <li>If this item is restricted, please log-in with your Yale NetID</li>
     <li>If you believe you've received this notice in error please contact LIT support</li>
 </ul>

--- a/spec/requests/manifests_request_spec.rb
+++ b/spec/requests/manifests_request_spec.rb
@@ -108,4 +108,25 @@ RSpec.describe 'Manifests', type: :request, clean: true do
       expect(manifest['error']).to eq('unauthorized')
     end
   end
+
+  describe 'Not found Manifests' do
+    before do
+      stub_request(:get, 'https://yul-test-samples.s3.amazonaws.com/manifests/02/20/202')
+        .to_return(status: 404, body: 'not found')
+    end
+
+    around do |example|
+      original_sample_bucket = ENV['S3_SOURCE_BUCKET_NAME']
+      ENV['S3_SOURCE_BUCKET_NAME'] = 'yul-test-samples'
+      example.run
+      ENV['S3_SOURCE_BUCKET_NAME'] = original_sample_bucket
+    end
+
+    describe 'GET /show' do
+      it 'redirects to HTML page' do      
+        get '/manifests/202'
+        expect(response.body).to include "the item you've requested does not appear to exist"
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Summary
When a manifest was not found in aws that triggered UrlGeneration errors.  This PR updates the error handling to direct to the public/not_found pictured below in the case of a missing manifest and retains missing manifest url rather than redirecting.

# Related Ticket
[#1651](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1651)

# Screenshot / Video

https://user-images.githubusercontent.com/36549923/136099980-5f2074ad-4dfe-40a4-8537-36256e733651.mp4

 
![image](https://user-images.githubusercontent.com/36549923/136100071-3c9ea779-0927-47ee-9fc6-aa7ca4721886.png)

