### PR TITLE
Reduce padding around links to Archives at Yale i1676

### DIFF
--- a/app/assets/stylesheets/customOverrides/show_page.scss
+++ b/app/assets/stylesheets/customOverrides/show_page.scss
@@ -14,9 +14,6 @@ DEFAULT MOBILE STYLING
 }
 
 dt.blacklight-containergrouping_tesim.metadata-block__label-key {
-  //width: available;
-  //width: -webkit-fill-available;
-  //width: -moz-available;
   width: 31%;
   margin-bottom: 2%;
 }
@@ -91,16 +88,15 @@ dt.blacklight-ancestordisplaystrings_tesim.metadata-block__label-key {
   margin-right: 5px;
 }
 
-.showpage_no_label_tag,
-.blacklight-archivespaceuri_ssi {
+.showpage_no_label_tag.blacklight-archivespaceuri_ssi {
   font-family: Mallory-Bold;
   font-size: 14px;
   background-color: $lighter_grey;
   margin: 0;
-  padding-left: 2%;
+  padding-left: 3%;
   width: 100%;
-  padding-top: 2% !important;
-
+  height: 37px;
+  padding-top: 2%!important;
   #popup_window {
     padding-left: 1.5%;
     padding-bottom: 0.75%;
@@ -108,6 +104,20 @@ dt.blacklight-ancestordisplaystrings_tesim.metadata-block__label-key {
     .iiif-logo img {
       margin-top: -3px;
     }
+  }
+}
+
+.showpage_no_label_tag.blacklight-findingaid_ssim {
+  font-family: Mallory-Bold;
+  font-size: 14px;
+  padding-bottom: 2%;
+  padding-left: 3%;
+  background-color: $lighter_grey;
+  width: 100%;
+  padding-top: 0;
+  #popup_window{
+    padding-left: 1.5%;
+    padding-bottom: 0.75%
   }
 }
 
@@ -308,7 +318,6 @@ p.yale-restricted-work-text{
   width: fit-content;
   margin-left: -5%;
   float: left;
-
 }
 
 .aSpace_tree ul{
@@ -363,32 +372,6 @@ p.yale-restricted-work-text{
   position: absolute;
   height: 15px;
   width: 15px;
-}
-.showpage_no_label_tag,
-.blacklight-archivespaceuri_ssi {
-  font-family: Mallory-Bold;
-  font-size: 14px;
-  background-color: $lighter_grey;
-  margin: 0;
-  padding-left: 2%;
-  width: 100%;
-  padding-top: 2%!important;
-  #popup_window{
-    padding-left: 1.5%;
-    padding-bottom: 0.75%
-  }
-}
-
-.showpage_no_label_tag,
-.blacklight-findingaid_ssim {
-  padding-bottom: 3%;
-  padding-left: 2%;
-  width: 100%;
-  padding-top: 0;
-  #popup_window{
-    padding-left: 1.5%;
-    padding-bottom: 0.75%
-  }
 }
 
 @media screen and (min-width: $medium_device) {
@@ -472,6 +455,9 @@ p.yale-restricted-work-text{
   }
   dd.blacklight-containergrouping_tesim.metadata-block__label-value.metadata-block__label-value--yul {
   margin-top: -5.5%;
+  }
+  .showpage_no_label_tag.blacklight-archivespaceuri_ssi {
+    height: 42px;
   }
 }
 
@@ -646,5 +632,8 @@ p.yale-restricted-work-text{
 
   dd.blacklight-containergrouping_tesim.metadata-block__label-value.metadata-block__label-value--yul{
     margin-top: -6.5%;
+  }
+  .showpage_no_label_tag.blacklight-archivespaceuri_ssi {
+    height: 50px;
   }
 }


### PR DESCRIPTION
**Story**

As the product designer, I want less padding around archival context and finding aid links box on the object page.

Actual Design
![Screen Shot 2021-10-05 at 14.44.35.png](https://images.zenhubusercontent.com/60786c408c8643227aa47d8f/c25a0ee4-023c-41e9-946f-afc7b3702c5e)

Propose Design Change
![image.png](https://images.zenhubusercontent.com/5e6013c029e314c92afd4769/72599e2e-1163-474d-9707-1cef3ac28b50)
**Acceptance**

- [x] Padding is reduced between each link only, not around the links.
