### PR TITLE
Adds project id to search fields

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -343,6 +343,7 @@ class CatalogController < ApplicationController
       'publicationPlace_tesim',
       'publisher_tesim',
       'preferredCitation_tesim',
+      'project_identifier_tesi',
       'repository_ssim',
       "repository_ssi",
       'resourceType_tesim',

--- a/app/views/catalog/_constraints_element.html.erb
+++ b/app/views/catalog/_constraints_element.html.erb
@@ -10,7 +10,11 @@
 <span class="btn-group applied-filter constraint query <%= options[:classes].join if options[:classes] %>">
   <button class="constraint-value btn btn-outline-secondary href-button" href="<%=options[:remove]%>">
     <% unless label.blank? %>
-      <span class="filter-name"><%= label %> </span>
+      <% if label == "Project Identifier Tesi" %>
+        <span class="filter-name"><%= label[0...label.rindex(" ")] %> </span>
+      <% else %>
+        <span class="filter-name"><%= label %> </span>
+      <% end %>
     <% end %>
 
     <% unless value.blank? %>

--- a/spec/system/project_id_search_spec.rb
+++ b/spec/system/project_id_search_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe "Project Identifier Search", type: :system, clean: true, js: false do
+  let(:user) { FactoryBot.create(:user) }
+
+  let(:yale_work) do
+    {
+      id: "1234567",
+      title_tesim: ["Fake Work"],
+      project_identifier_tesi: "def",
+      visibility_ssi: 'Public'
+    }
+  end
+  let(:child_work1) do
+    {
+      id: "3456789",
+      title_tesim: ["Faker Work"],
+      project_identifier_tesi: "abc",
+      visibility_ssi: 'Public'
+    }
+  end
+  let(:child_work2) do
+    {
+      id: "3457873",
+      title_tesim: ["Fakest Work"],
+      project_identifier_tesi: "abc",
+      visibility_ssi: 'Public'
+    }
+  end
+
+  before do
+    solr = Blacklight.default_index.connection
+    solr.add([yale_work, child_work1, child_work2])
+    solr.commit
+    allow(User).to receive(:on_campus?).and_return(true)
+  end
+
+  describe "Project Identifier search" do
+    it 'matches document when query does match' do
+      visit "/catalog?f[project_identifier_tesi][]=abc&q=&search_field=all_fields"
+      expect(page).to have_content 'Faker Work'
+      expect(page).to have_content 'Fakest Work'
+      expect(page).not_to have_content 'Fake Work'
+    end
+  end
+end


### PR DESCRIPTION
# Summary
Adds the ability to craft groupings by project identifier field.

# Related Ticket
[#1655](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1665)

# Screenshot
![image](https://user-images.githubusercontent.com/36549923/136284530-368f81e4-68ed-47fd-9d39-9db87c96efe5.png)
