### PR TITLE
Aligned events on the landing page

### DIFF
--- a/app/assets/stylesheets/customOverrides/landing.scss
+++ b/app/assets/stylesheets/customOverrides/landing.scss
@@ -309,6 +309,9 @@ DEFAULT MOBILE STYLING
     margin-top: -50px;
     margin-bottom: 50px;
   }
+  #coming-soon {
+    left: -4%;
+  }
  }
 
 
@@ -483,5 +486,8 @@ DEFAULT MOBILE STYLING
 
     #content-statement p {
       margin-left:-30px;
+    }
+    #coming-soon {
+      left: -2%;
     }
   }


### PR DESCRIPTION
As the product designer, I want the alignment of the event boxes to have equal spacing between each image.

Acceptance Criteria
- [x] Align the event boxes 
     - [x] Mobile alignment
     - [x] Desktop alignment

Mobile Image:
![image.png](https://images.zenhubusercontent.com/5e6013c029e314c92afd4769/22df1239-d998-4307-beff-f589a319a7bd)

Desktop Image:
![Screen Shot 2021-09-21 at 1.50.01 PM.png](https://images.zenhubusercontent.com/5e6013c029e314c92afd4769/ca5c7ce8-28b2-40bd-bcbf-34f95d8d986f)
----
**DEMO**

https://user-images.githubusercontent.com/41123693/136455223-7bb33620-b069-41d1-830d-0117ce3f060b.mov


