### PR TITLE
Fix route for pdf not found page

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,7 +46,7 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
   end
 
   get '/check-iiif', to: 'iiif#show', as: :iiif
-  get '/pdfs/not_found.html', to: 'pdfs#not_found'
+  get '/pdfs/not_found', to: 'pdfs#not_found'
 
   # Custom error page
   get '/404', to: 'errors#not_found', via: :all

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -28,4 +28,10 @@ RSpec.describe 'Errors', type: :request do
       expect(response.body).to include("The page you were looking for doesn't exist.")
     end
   end
+
+  it 'has content for PDF not found page' do
+    get '/pdfs/not_found.html'
+    expect(response.body).to include("We're sorry, but the item you've requested does not appear to exist")
+    expect(response).to have_http_status(:not_found)
+  end
 end


### PR DESCRIPTION
Fix route for PDF not found page (until we disable the link.)