### PR TITLE
Enables complex queries in advanced search

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -378,7 +378,7 @@ class CatalogController < ApplicationController
       field.include_in_simple_select = false
       field.solr_parameters = {
         qf: search_fields.join(' '),
-        pf: ''
+        pf: search_fields.join(' ')
       }
     end
 
@@ -388,7 +388,7 @@ class CatalogController < ApplicationController
     config.add_search_field('creator_tesim', label: 'Creator') do |field|
       field.solr_parameters = {
         qf: 'creator_tesim',
-        pf: ''
+        pf: 'creator_tesim'
       }
     end
 
@@ -396,7 +396,7 @@ class CatalogController < ApplicationController
       field.qt = 'search'
       field.solr_parameters = {
         qf: 'title_tesim',
-        pf: ''
+        pf: 'title_tesim'
       }
     end
 
@@ -404,7 +404,7 @@ class CatalogController < ApplicationController
       field.qt = 'search'
       field.solr_parameters = {
         qf: 'callNumber_tesim',
-        pf: ''
+        pf: 'callNumber_tesim'
       }
     end
 
@@ -414,7 +414,7 @@ class CatalogController < ApplicationController
       field.qt = 'search'
       field.solr_parameters = {
         qf: date_fields.join(' '),
-        pf: ''
+        pf: date_fields.join(' ')
       }
     end
 
@@ -426,7 +426,7 @@ class CatalogController < ApplicationController
       field.include_in_advanced_search = false
       field.solr_parameters = {
         qf: 'subjectName_tesim',
-        pf: ''
+        pf: 'subjectName_tesim'
       }
     end
 
@@ -444,7 +444,7 @@ class CatalogController < ApplicationController
       field.include_in_simple_select = false
       field.solr_parameters = {
         qf: subject_fields.join(' '),
-        pf: ''
+        pf: subject_fields.join(' ')
       }
     end
 
@@ -455,7 +455,7 @@ class CatalogController < ApplicationController
       field.include_in_simple_select = false
       field.solr_parameters = {
         qf: genre_fields.join(' '),
-        pf: ''
+        pf: genre_fields.join(' ')
       }
     end
 
@@ -464,7 +464,7 @@ class CatalogController < ApplicationController
       field.include_in_simple_select = false
       field.solr_parameters = {
         qf: 'fulltext_tesim',
-        pf: ''
+        pf: 'fulltext_tesim'
       }
     end
 
@@ -473,7 +473,7 @@ class CatalogController < ApplicationController
       field.include_in_advanced_search = false
       field.solr_parameters = {
         qf: 'orbisBibId_ssi',
-        pf: ''
+        pf: 'orbisBibId_ssi'
       }
     end
 
@@ -482,7 +482,7 @@ class CatalogController < ApplicationController
       field.include_in_advanced_search = false
       field.solr_parameters = {
         qf: 'fulltext_tesim',
-        pf: '',
+        pf: 'fulltext_tesim',
         'hl.requireFieldMatch': true
       }
     end
@@ -492,7 +492,7 @@ class CatalogController < ApplicationController
       field.include_in_simple_select = false
       field.solr_parameters = {
         qf: 'oid_ssi',
-        pf: ''
+        pf: 'oid_ssi'
       }
     end
 
@@ -501,7 +501,7 @@ class CatalogController < ApplicationController
       field.include_in_simple_select = false
       field.solr_parameters = {
         qf: 'child_oids_ssim',
-        pf: ''
+        pf: 'child_oids_ssim'
       }
     end
 

--- a/spec/system/advanced_search_spec.rb
+++ b/spec/system/advanced_search_spec.rb
@@ -307,6 +307,15 @@ RSpec.describe 'Search the catalog using advanced search', type: :system, js: tr
         expect(page).not_to have_content('Record 2')
       end
     end
+
+    it 'combines results with complex "OR" query' do
+      fill_in 'all_fields_advanced', with: '(zeno OR me)'
+      click_on 'SEARCH'
+      within '#documents' do
+        expect(page).to have_content('Record 1')
+        expect(page).to have_content('Record 2')
+      end
+    end
   end
 
   describe 'styling' do


### PR DESCRIPTION
# Summary
Providing the pf param to solr gave all searches from advanced search the ability to perform complex OR, AND, NOT queries

# Related Ticket
[#1642](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1642)

# Screenshot / Video
![image](https://user-images.githubusercontent.com/36549923/136832469-dcb8514b-a788-49d9-bb34-a2fe63166410.png)

https://user-images.githubusercontent.com/36549923/136832594-a2cbfb52-6531-4e22-965b-fd790a8077ae.mp4



