### PR TITLE
added digitization note under extent of digitization

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -223,6 +223,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'description_tesim', label: 'Description', metadata: 'description', helper_method: :join_with_br
     config.add_show_field 'extent_ssim', label: 'Extent', metadata: 'description', helper_method: :join_with_br
     config.add_show_field 'extentOfDigitization_ssim', label: 'Extent of Digitization', metadata: 'description'
+    config.add_show_field 'digitization_note_tesi', label: 'Digitization Note', metadata: 'description'
     config.add_show_field 'projection_tesim', label: 'Projection', metadata: 'description'
     config.add_show_field 'scale_tesim', label: 'Scale', metadata: 'description'
     config.add_show_field 'coordinates_ssim', label: 'Coordinates', metadata: 'description'

--- a/spec/system/view_fields_in_display_spec.rb
+++ b/spec/system/view_fields_in_display_spec.rb
@@ -47,6 +47,7 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       language_ssim: ['en', 'eng', 'zz'],
       description_tesim: ["Handsome Dan is a bulldog who serves as Yale Univeristy's mascot.", "here is something else about it"],
       visibility_ssi: 'Public',
+      digitization_note_tesi: "Digitization note",
       abstract_tesim: ["this is an abstract", "abstract2"],
       alternativeTitle_tesim: ["this is an alternative title", "this is the second alternative title"],
       genre_ssim: ["this is the genre", "this is the second genre"],
@@ -160,6 +161,9 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
     end
     it 'displays the Extent of Digitization in results' do
       expect(document).to have_content("this is the extent of digitization")
+    end
+    it 'displays the digitization note' do
+      expect(document).to have_content("Digitization note")
     end
     it 'displays the Access in results' do
       expect(document).to have_content("Public")


### PR DESCRIPTION
# Summary  

Digitization Note now displays under Extent of Digitization in the Description metadata block:  
![Image 2021-10-12 at 2 18 59 PM](https://user-images.githubusercontent.com/24666568/137031343-4f2acf83-f619-4f44-8e40-85d00a57928e.jpg)

