### PR TITLE
Modified archival item information design

### DIFF
--- a/app/assets/stylesheets/customOverrides/show_page.scss
+++ b/app/assets/stylesheets/customOverrides/show_page.scss
@@ -23,12 +23,13 @@ dd.blacklight-containergrouping_tesim.metadata-block__label-value.metadata-block
   flex: -moz-available;
   position: relative;
   left: 30%;
-  margin-top: -12%;
+  margin-top: -6.25%;
 }
 
 dt.blacklight-ancestordisplaystrings_tesim.metadata-block__label-key {
   width: fit-content;
   width: -moz-fit-content;
+  margin-top: 2%;
 }
 
 .archival-context {
@@ -81,6 +82,7 @@ dt.blacklight-ancestordisplaystrings_tesim.metadata-block__label-key {
   color: $white;
   background-color: $medium_green;
   border: solid 4px $medium_green;
+  font-size: 10px
 }
 
 .yaleASpaceItemThis span {


### PR DESCRIPTION
As the product designer, I want more space on top of the archival tree to cause visual separation, and small text in the green box labeled "This Item."

**Acceptance criteria:**
- [x] Change font in label to 10px
- [x] Add 1.5em margin above "Search for Additional Digitized Material in This Collection"

**Proposed Design**
![Screen Shot 2021-10-14 at 12.43.53 PM.png](https://images.zenhubusercontent.com/604a2edec7bb2836333e6ec0/063754b1-bc8a-4940-a23d-47907da708cf)