### PR TITLE
Manifest/Mirador/PDF links are enabled or disabled based on visibility and user permission

### DIFF
--- a/app/assets/stylesheets/customOverrides/show_page.scss
+++ b/app/assets/stylesheets/customOverrides/show_page.scss
@@ -174,7 +174,6 @@ dt.blacklight-ancestordisplaystrings_tesim.metadata-block__label-key {
   top: -47px;
   margin-left: 55px;
   background: transparent;
-
 }
 
 .show-tools a, .show-tools a#citationLink {
@@ -186,6 +185,14 @@ dt.blacklight-ancestordisplaystrings_tesim.metadata-block__label-key {
 
 .show-tools a:hover {
   text-decoration: underline;
+}
+
+.show-tools .not-found span {
+  color: $medium_grey !important;
+}
+
+.show-tools .not-found a:hover {
+  text-decoration: none;
 }
 
 .show-tools a.nav-link, .show-tools span.nav-link {

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
+
+require "net/http"
+
 module CatalogHelper
   include Blacklight::CatalogHelperBehavior
 
@@ -34,5 +37,19 @@ module CatalogHelper
       q = search_params['fulltext_tsim_advanced']
     end
     "&q=#{url_encode(q)}" if q
+  end
+
+  def remote_file_exists?(given_url)
+    if given_url.include?('mirador')
+      url = URI.parse("#{ENV["BLACKLIGHT_BASE_URL"]}" + given_url)
+      Net::HTTP.start(url.host, url.port) do |http|
+        return http.head(url.request_uri).code == "200"
+      end
+    else
+      url = URI.parse(given_url)
+      Net::HTTP.start(url.host, url.port) do |http|
+        return http.head(url.request_uri).code == "200"
+      end
+    end
   end
 end

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 module CatalogHelper
   include Blacklight::CatalogHelperBehavior
 

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -38,15 +38,4 @@ module CatalogHelper
     end
     "&q=#{url_encode(q)}" if q
   end
-
-  def remote_file_exists?(given_url)
-    url = if given_url.include?('mirador')
-            URI.parse((ENV['BLACKLIGHT_BASE_URL']).to_s + given_url)
-          else
-            URI.parse(given_url)
-          end
-    Net::HTTP.start(url.host, url.port) do |http|
-      return http.head(url.request_uri).code == "200"
-    end
-  end
 end

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "net/http"
-
 module CatalogHelper
   include Blacklight::CatalogHelperBehavior
 

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -40,16 +40,13 @@ module CatalogHelper
   end
 
   def remote_file_exists?(given_url)
-    if given_url.include?('mirador')
-      url = URI.parse("#{ENV["BLACKLIGHT_BASE_URL"]}" + given_url)
-      Net::HTTP.start(url.host, url.port) do |http|
-        return http.head(url.request_uri).code == "200"
-      end
-    else
-      url = URI.parse(given_url)
-      Net::HTTP.start(url.host, url.port) do |http|
-        return http.head(url.request_uri).code == "200"
-      end
+    url = if given_url.include?('mirador')
+            URI.parse((ENV['BLACKLIGHT_BASE_URL']).to_s + given_url)
+          else
+            URI.parse(given_url)
+          end
+    Net::HTTP.start(url.host, url.port) do |http|
+      return http.head(url.request_uri).code == "200"
     end
   end
 end

--- a/app/views/catalog/_show_tools.html.erb
+++ b/app/views/catalog/_show_tools.html.erb
@@ -14,7 +14,7 @@
             <% oid = @document.id %>
 
             <%# MANIFEST LINK %>
-            <% if false %>
+            <% if remote_file_exists?(manifest_url(oid)) %>
                 <li class="list-group-item manifestItem">
                     <span class='nav-link'>
                         <%= link_to(image_tag('iiif.png', alt: '') + t('blacklight.sidebar.manifest'), manifest_url(oid), target: '_blank', id: 'manifestLink', class: 'iiif-logo')
@@ -31,7 +31,7 @@
             <% end %>
 
             <%# MIRADOR LINK %>
-            <% if false %>
+            <% if remote_file_exists?(mirador_url(oid)) %>
                 <li class="list-group-item miradorItem">
                     <%= link_to 'View in Mirador', mirador_url(oid), target: '_blank', id: 'miradorLink', class: 'nav-link' %>
                 </li>
@@ -44,7 +44,7 @@
             <% end %>
 
             <%# PDF LINK %>
-            <% if false %>
+            <% if remote_file_exists?(pdf_url(oid)) %>
                 <li class="list-group-item pdfItem">
                     <%= link_to 'Download as PDF', pdf_url(oid, format: 'pdf'), target: '_blank', id: 'pdfLink', rel: 'external', class: 'nav-link' %>
                 </li>

--- a/app/views/catalog/_show_tools.html.erb
+++ b/app/views/catalog/_show_tools.html.erb
@@ -14,7 +14,7 @@
             <% oid = @document.id %>
 
             <%# MANIFEST LINK %>
-            <% if remote_file_exists?(manifest_url(oid)) %>
+            <% if client_can_view_digital?(@document) %>
                 <li class="list-group-item manifestItem">
                     <span class='nav-link'>
                         <%= link_to(image_tag('iiif.png', alt: '') + t('blacklight.sidebar.manifest'), manifest_url(oid), target: '_blank', id: 'manifestLink', class: 'iiif-logo')
@@ -31,7 +31,7 @@
             <% end %>
 
             <%# MIRADOR LINK %>
-            <% if remote_file_exists?(mirador_url(oid)) %>
+            <% if client_can_view_digital?(@document) %>
                 <li class="list-group-item miradorItem">
                     <%= link_to 'View in Mirador', mirador_url(oid), target: '_blank', id: 'miradorLink', class: 'nav-link' %>
                 </li>
@@ -44,7 +44,7 @@
             <% end %>
 
             <%# PDF LINK %>
-            <% if remote_file_exists?(pdf_url(oid)) %>
+            <% if client_can_view_digital?(@document) %>
                 <li class="list-group-item pdfItem">
                     <%= link_to 'Download as PDF', pdf_url(oid, format: 'pdf'), target: '_blank', id: 'pdfLink', rel: 'external', class: 'nav-link' %>
                 </li>

--- a/app/views/catalog/_show_tools.html.erb
+++ b/app/views/catalog/_show_tools.html.erb
@@ -12,18 +12,49 @@
             <% end %>
 
             <% oid = @document.id %>
-            <li class="list-group-item manifestItem">
-                <span class='nav-link'>
-                  <%= link_to(image_tag('iiif.png', alt: '') + t('blacklight.sidebar.manifest'), manifest_url(oid), target: '_blank', id: 'manifestLink', class: 'iiif-logo')
-                  %>
-                </span>
-            </li>
-            <li class="list-group-item miradorItem">
-              <%= link_to 'View in Mirador', mirador_url(oid), target: '_blank', id: 'miradorLink', class: 'nav-link' %>
-            </li>
-            <li class="list-group-item pdfItem">
-              <%= link_to 'Download as PDF', pdf_url(oid, format: 'pdf'), target: '_blank', id: 'pdfLink', rel: 'external', class: 'nav-link' %>
-            </li>
+
+            <%# MANIFEST LINK %>
+            <% if false %>
+                <li class="list-group-item manifestItem">
+                    <span class='nav-link'>
+                        <%= link_to(image_tag('iiif.png', alt: '') + t('blacklight.sidebar.manifest'), manifest_url(oid), target: '_blank', id: 'manifestLink', class: 'iiif-logo')
+                        %>
+                    </span>
+                </li>
+            <% else %>
+                <li class="list-group-item manifestItem">
+                    <span class='nav-link not-found iiif-logo' title='The digital version of this work is restricted due to copyright or other restrictions.  Please log in using your Yale NetID or contact library staff to inquire about access to a physical copy.' >
+                        <%= image_tag('iiif.png', alt: '', id: 'manifestLink') %> 
+                        <span id="manifestLink"> Manifest Link</span>
+                    </span>
+                </li>
+            <% end %>
+
+            <%# MIRADOR LINK %>
+            <% if false %>
+                <li class="list-group-item miradorItem">
+                    <%= link_to 'View in Mirador', mirador_url(oid), target: '_blank', id: 'miradorLink', class: 'nav-link' %>
+                </li>
+            <% else %>
+                <li class="list-group-item manifestItem">
+                    <span class='nav-link not-found iiif-logo' title='The digital version of this work is restricted due to copyright or other restrictions.  Please log in using your Yale NetID or contact library staff to inquire about access to a physical copy.' >
+                    <span id="miradorLink"> View in Mirador </span>
+                    </span>
+                </li>
+            <% end %>
+
+            <%# PDF LINK %>
+            <% if false %>
+                <li class="list-group-item pdfItem">
+                    <%= link_to 'Download as PDF', pdf_url(oid, format: 'pdf'), target: '_blank', id: 'pdfLink', rel: 'external', class: 'nav-link' %>
+                </li>
+            <% else %>
+                <li class="list-group-item manifestItem">
+                    <span class='nav-link not-found iiif-logo' title='The digital version of this work is restricted due to copyright or other restrictions.  Please log in using your Yale NetID or contact library staff to inquire about access to a physical copy.' >
+                    <span id="pdfLink"> Download as PDF </span>
+                    </span>
+                </li>
+            <% end %>
         </ul>
     </div>
 <% end %>

--- a/spec/system/access_restrictions_spec.rb
+++ b/spec/system/access_restrictions_spec.rb
@@ -43,6 +43,13 @@ RSpec.describe "access restrictions", type: :system, clean: true do
       expect(page).not_to have_content('[Map of China]. [private copy]')
     end
 
+    it 'manifest, mirador, and pdf links are disabled' do
+      visit '/catalog/16189097-yale'
+      expect(page).not_to have_link 'Manifest Link'
+      expect(page).not_to have_link 'View in Mirador'
+      expect(page).not_to have_link 'Download as PDF'
+    end
+
     it "displays universal viewer for public works" do
       visit solr_document_path(public_work[:id])
       expect(page.html).to match(/universal-viewer-iframe/)
@@ -110,6 +117,13 @@ RSpec.describe "access restrictions", type: :system, clean: true do
     it "displays universal viewer for public works" do
       visit solr_document_path(public_work[:id])
       expect(page.html).to match(/universal-viewer-iframe/)
+    end
+
+    it 'manifest, mirador, and pdf links are disabled' do
+      visit '/catalog/2055095'
+      expect(page).to have_link 'Manifest Link'
+      expect(page).to have_link 'View in Mirador'
+      expect(page).to have_link 'Download as PDF'
     end
 
     it "displays universal viewer for yale-only works" do

--- a/spec/views/catalog/_show_tools.html.erb_spec.rb
+++ b/spec/views/catalog/_show_tools.html.erb_spec.rb
@@ -14,20 +14,47 @@ RSpec.describe 'catalog/_show_tools.html.erb' do
     end
   end
 
-  describe 'links' do
-    it 'renders the iiif manifest link' do
-      render partial: 'catalog/show_tools'
-      expect(rendered).to have_link 'Manifest Link', href: "http://test.host/manifests/xyz"
-    end
+  context 'with documents and user access' do
 
-    it 'renders the mirador link' do
-      render partial: 'catalog/show_tools'
-      expect(rendered).to have_link 'View in Mirador', href: "/mirador/xyz"
+    before do
+      stub_request(:head, "http://test.host/manifests/xyz").
+          with(
+            headers: {
+            'Accept'=>'*/*',
+            'User-Agent'=>'Ruby'
+            }).
+          to_return(status: 200, body: "", headers: {})
+      stub_request(:head, "http://test.host/mirador/xyz").
+          with(
+            headers: {
+            'Accept'=>'*/*',
+            'User-Agent'=>'Ruby'
+            }).
+          to_return(status: 200, body: "", headers: {})
+      stub_request(:head, "http://test.host/pdfs/xyz").
+          with(
+            headers: {
+            'Accept'=>'*/*',
+            'User-Agent'=>'Ruby'
+            }).
+          to_return(status: 200, body: "", headers: {})
     end
+    
+    describe 'links' do
+      it 'renders the iiif manifest link' do
+        render partial: 'catalog/show_tools'
+        expect(rendered).to have_link 'Manifest Link', href: "http://test.host/manifests/xyz"
+      end
 
-    it 'renders the pdf link' do
-      render partial: 'catalog/show_tools'
-      expect(rendered).to have_link 'Download as PDF', href: "http://test.host/pdfs/xyz.pdf"
+      it 'renders the mirador link' do
+        render partial: 'catalog/show_tools'
+        expect(rendered).to have_link 'View in Mirador', href: "/mirador/xyz"
+      end
+
+      it 'renders the pdf link' do
+        render partial: 'catalog/show_tools'
+        expect(rendered).to have_link 'Download as PDF', href: "http://test.host/pdfs/xyz.pdf"
+      end
     end
   end
 end

--- a/spec/views/catalog/_show_tools.html.erb_spec.rb
+++ b/spec/views/catalog/_show_tools.html.erb_spec.rb
@@ -15,31 +15,33 @@ RSpec.describe 'catalog/_show_tools.html.erb' do
   end
 
   context 'with documents and user access' do
-
     before do
-      stub_request(:head, "http://test.host/manifests/xyz").
-          with(
+      stub_request(:head, "http://test.host/manifests/xyz")
+        .with(
             headers: {
-            'Accept'=>'*/*',
-            'User-Agent'=>'Ruby'
-            }).
-          to_return(status: 200, body: "", headers: {})
-      stub_request(:head, "http://test.host/mirador/xyz").
-          with(
+              'Accept' => '*/*',
+              'User-Agent' => 'Ruby'
+            }
+          )
+        .to_return(status: 200, body: "", headers: {})
+      stub_request(:head, "http://test.host/mirador/xyz")
+        .with(
             headers: {
-            'Accept'=>'*/*',
-            'User-Agent'=>'Ruby'
-            }).
-          to_return(status: 200, body: "", headers: {})
-      stub_request(:head, "http://test.host/pdfs/xyz").
-          with(
+              'Accept' => '*/*',
+              'User-Agent' => 'Ruby'
+            }
+          )
+        .to_return(status: 200, body: "", headers: {})
+      stub_request(:head, "http://test.host/pdfs/xyz")
+        .with(
             headers: {
-            'Accept'=>'*/*',
-            'User-Agent'=>'Ruby'
-            }).
-          to_return(status: 200, body: "", headers: {})
+              'Accept' => '*/*',
+              'User-Agent' => 'Ruby'
+            }
+          )
+        .to_return(status: 200, body: "", headers: {})
     end
-    
+
     describe 'links' do
       it 'renders the iiif manifest link' do
         render partial: 'catalog/show_tools'


### PR DESCRIPTION
# Summary  
Links are enabled when a works visibility is set to "Public" or a user has permission to view.
Links are disabled when a works visibility is set to "Yale Community Only" and user does not have permission to view.

Visibility: Public  
![Image 2021-10-15 at 10 13 51 AM](https://user-images.githubusercontent.com/24666568/137529394-98372570-d8e3-482a-8f28-b1bdeb082116.jpg)

Visibility: Yale Community Only with unauthorized user:
<img width="795" alt="image" src="https://user-images.githubusercontent.com/24666568/137529477-9a4310e5-d9ea-4e22-be52-31563b9f565a.png">

