### PR TITLE
Draft: Adds facet filtering for archival context

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -236,7 +236,7 @@ class CatalogController < ApplicationController
     # ancestorDisplayStrings must be first and the information of the ASpace tree
     # archiveSpaceUri and findingAid must be last
     #
-    config.add_show_field 'repository_ssi', label: 'Repository', metadata: 'collection_information'
+    config.add_show_field 'repository_ssi', label: 'Repository', metadata: 'collection_information', link_to_facet: true
     config.add_show_field 'callNumber_ssim', label: 'Call Number', metadata: 'collection_information', link_to_facet: true
     config.add_show_field 'sourceTitle_tesim', label: 'Collection Title', metadata: 'collection_information'
     config.add_show_field 'sourceCreator_tesim', label: 'Collection/Other Creator', metadata: 'collection_information'

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -124,7 +124,7 @@ class CatalogController < ApplicationController
     config.add_facet_field 'extentOfDigitization_ssim', label: 'Extent of Digitization', limit: true
     config.add_facet_field 'visibility_ssi', label: 'Access', limit: true
     config.add_facet_field 'repository_ssi', label: 'Repository', limit: true
-    config.add_facet_field 'collection_title_ssi', label: 'Collection Title', limit: true, if: :repository_facet?
+    config.add_facet_field 'collection_title_ssi', label: 'Collection Title', limit: true
     config.add_facet_field 'series_ssi', label: 'Grouping', limit: true, if: :collection_facet?
     config.add_facet_field 'format', label: 'Format', limit: true
     config.add_facet_field 'genre_ssim', label: 'Genre', limit: true
@@ -237,8 +237,8 @@ class CatalogController < ApplicationController
     # archiveSpaceUri and findingAid must be last
     #
     config.add_show_field 'repository_ssi', label: 'Repository', metadata: 'collection_information', link_to_facet: true
+    config.add_show_field 'collection_title_ssi', label: 'Collection Title', metadata: 'collection_information', link_to_facet: true
     config.add_show_field 'callNumber_ssim', label: 'Call Number', metadata: 'collection_information', link_to_facet: true
-    config.add_show_field 'sourceTitle_tesim', label: 'Collection Title', metadata: 'collection_information'
     config.add_show_field 'sourceCreator_tesim', label: 'Collection/Other Creator', metadata: 'collection_information'
     config.add_show_field 'sourceCreated_tesim', label: 'Collection Created', metadata: 'collection_information'
     config.add_show_field 'sourceDate_tesim', label: 'Collection Date', metadata: 'collection_information'
@@ -576,10 +576,6 @@ class CatalogController < ApplicationController
   # This is for iiif_search
   def search_for_item
     search_service.fetch(params[:solr_document_id])
-  end
-
-  def repository_facet?
-    helpers.facet_field_in_params?('repository_ssi')
   end
 
   def collection_facet?

--- a/spec/presenters/yul/metadata_presenter_spec.rb
+++ b/spec/presenters/yul/metadata_presenter_spec.rb
@@ -147,6 +147,10 @@ RSpec.describe Yul::MetadataPresenter do
     let(:fields) { identifier_presenter_object.metadata_fields_to_render('collection_information') }
     context 'containing overview metadata' do
       describe 'config' do
+        it 'returns the Repository Key' do
+          expect(fields.any? { |field| field.include? 'repository_ssi' }).to be_truthy
+        end
+
         it 'returns the Call Number Key' do
           expect(fields.any? { |field| field.include? 'callNumber_ssim' }).to be_truthy
         end
@@ -167,8 +171,8 @@ RSpec.describe Yul::MetadataPresenter do
           expect(fields.any? { |field| field.include? 'sourceNote_tesim' }).to be_truthy
         end
 
-        it 'returns the Source Title Key' do
-          expect(fields.any? { |field| field.include? 'sourceTitle_tesim' }).to be_truthy
+        it 'returns the Collection Title Key' do
+          expect(fields.any? { |field| field.include? 'collection_title_ssi' }).to be_truthy
         end
 
         it 'returns the Container/Volume Key' do

--- a/spec/support/solr_documents/all_fields_record.rb
+++ b/spec/support/solr_documents/all_fields_record.rb
@@ -35,6 +35,8 @@ WORK_WITH_ALL_FIELDS = {
   sourceDate_tesim: "this is the source date",
   sourceNote_tesim: "this is the source note",
   sourceEdition_tesim: 'Source Edition',
+  repository_ssi: "this is the repository name",
+  collection_title_ssi: 'this is the collection title',
   preferredCitation_tesim: "these are the references",
   date_ssim: "this is the date",
   children_ssim: "these are the children",

--- a/spec/system/view_facet_spec.rb
+++ b/spec/system/view_facet_spec.rb
@@ -92,10 +92,6 @@ RSpec.describe 'Facets should display', type: :system, js: :true, clean: true do
     expect(page).not_to have_content('Aquila Eccellenza')
   end
 
-  it 'does not display the collection title facet by default' do
-    expect(page).not_to have_css('.blacklight-collection_title_ssi')
-  end
-
   it 'does not display the series title facet by default' do
     expect(page).not_to have_css('.blacklight-series_ssi')
   end

--- a/spec/system/view_fields_in_display_spec.rb
+++ b/spec/system/view_fields_in_display_spec.rb
@@ -189,8 +189,8 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
     it 'does not display the Record Type in results' do
       expect(document).not_to have_content("this is the record type")
     end
-    it 'displays the Source Title in results' do
-      expect(document).to have_content("this is the source title")
+    it 'displays the Collection Title in results' do
+      expect(document).to have_content("this is the collection title")
     end
     it 'displays the Source Date in results' do
       expect(document).to have_content("this is the source date")

--- a/spec/system/view_fields_in_display_spec.rb
+++ b/spec/system/view_fields_in_display_spec.rb
@@ -220,8 +220,8 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
     it 'displays the Edition in results' do
       expect(document).to have_content("this is the edition")
     end
-    it 'displays the repository name in results' do
-      expect(document).to have_content("this is the repository name")
+    it 'displays the repository name in results as a link' do
+      expect(document).to have_link("this is the repository name", href: '/catalog?f%5Brepository_ssi%5D%5B%5D=this+is+the+repository+name')
     end
     it 'displays the item location header correctly' do
       expect(document).to have_content("Item Location")


### PR DESCRIPTION
# Summary
Makes the Repository and Collection Title fields on the show page of an individual object facetable.

# Related Ticket
[#1688](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1688)

# Video
https://user-images.githubusercontent.com/36549923/140585703-02ff1511-d93a-4768-84aa-85d061e0e175.mp4


