### PR TITLE
Added filter for BRBL and other links from ils

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -245,8 +245,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'sourceNote_tesim', label: 'Collection Note', metadata: 'collection_information'
     config.add_show_field 'sourceEdition_tesim', label: 'Collection Edition', metadata: 'collection_information'
     config.add_show_field 'relatedResourceOnline_ssim', label: 'Related Resource Online', metadata: 'collection_information', helper_method: :link_to_url_with_label
-    # config.add_show_field 'resourceVersionOnline_ssim', label: 'Resource Version Online', metadata: 'collection_information', helper_method: :link_to_url_with_label_and_filter
-    config.add_show_field 'resourceVersionOnline_ssim', label: ' ', no_label: false, metadata: 'collection_information', helper_method: :link_to_url_with_label_and_filter
+    config.add_show_field 'resourceVersionOnline_ssim', label: 'Related Version Online', metadata: 'collection_information', helper_method: :link_to_url_with_label_and_filter
     config.add_show_field 'ancestorDisplayStrings_tesim', label: 'Search for Additional Digitized Material in This Collection', metadata: 'collection_information', helper_method: :aspace_tree_display
     config.add_show_field 'containerGrouping_tesim', label: 'Container / Volume', metadata: 'collection_information'
     config.add_show_field 'archiveSpaceUri_ssi', label: ' ', no_label: true, metadata: 'collection_information', helper_method: :aspace_link

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -245,7 +245,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'sourceNote_tesim', label: 'Collection Note', metadata: 'collection_information'
     config.add_show_field 'sourceEdition_tesim', label: 'Collection Edition', metadata: 'collection_information'
     config.add_show_field 'relatedResourceOnline_ssim', label: 'Related Resource Online', metadata: 'collection_information', helper_method: :link_to_url_with_label
-    config.add_show_field 'resourceVersionOnline_ssim', label: 'Resource Version Online', metadata: 'collection_information', helper_method: :link_to_url_with_label
+    config.add_show_field 'resourceVersionOnline_ssim', label: 'Resource Version Online', metadata: 'collection_information', helper_method: :link_to_url_with_label_and_filter
     config.add_show_field 'ancestorDisplayStrings_tesim', label: 'Search for Additional Digitized Material in This Collection', metadata: 'collection_information', helper_method: :aspace_tree_display
     config.add_show_field 'containerGrouping_tesim', label: 'Container / Volume', metadata: 'collection_information'
     config.add_show_field 'archiveSpaceUri_ssi', label: ' ', no_label: true, metadata: 'collection_information', helper_method: :aspace_link

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -245,7 +245,8 @@ class CatalogController < ApplicationController
     config.add_show_field 'sourceNote_tesim', label: 'Collection Note', metadata: 'collection_information'
     config.add_show_field 'sourceEdition_tesim', label: 'Collection Edition', metadata: 'collection_information'
     config.add_show_field 'relatedResourceOnline_ssim', label: 'Related Resource Online', metadata: 'collection_information', helper_method: :link_to_url_with_label
-    config.add_show_field 'resourceVersionOnline_ssim', label: 'Resource Version Online', metadata: 'collection_information', helper_method: :link_to_url_with_label_and_filter
+    # config.add_show_field 'resourceVersionOnline_ssim', label: 'Resource Version Online', metadata: 'collection_information', helper_method: :link_to_url_with_label_and_filter
+    config.add_show_field 'resourceVersionOnline_ssim', label: ' ', no_label: false, metadata: 'collection_information', helper_method: :link_to_url_with_label_and_filter
     config.add_show_field 'ancestorDisplayStrings_tesim', label: 'Search for Additional Digitized Material in This Collection', metadata: 'collection_information', helper_method: :aspace_tree_display
     config.add_show_field 'containerGrouping_tesim', label: 'Container / Volume', metadata: 'collection_information'
     config.add_show_field 'archiveSpaceUri_ssi', label: ' ', no_label: true, metadata: 'collection_information', helper_method: :aspace_link

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -248,7 +248,7 @@ module BlacklightHelper
       labels = link_part.select { |s| !s.start_with? 'http' }
       next unless urls.count == 1
       ils_filters = filters.any? do |ils|
-        urls[0].start_with?(ils)
+        urls[0].include?(ils)
       end
       return nil if ils_filters
       label = labels[0] || urls[0]
@@ -261,7 +261,7 @@ module BlacklightHelper
   # Filters apply to only data on the showpage for the ils information
   # rubocop:disable Layout/DefEndAlignment
   def link_to_url_with_label_and_filter(arg)
-    ils_filters = %w[http://brbl-archive.library.yale.edu http://divinity-adhoc.library.yale.edu/FosterPapers http://digital.library.yale.edu http://beinecke.library.yale.edu http://beinecke1.library.yale.edu]
+    ils_filters = %w[brbl-archive.library.yale.edu divinity-adhoc.library.yale.edu/FosterPapers digital.library.yale.edu beinecke.library.yale.edu beinecke1.library.yale.edu]
     link_to_url_with_label(arg, ils_filters)
   end
   # rubocop:enable Layout/DefEndAlignment

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -240,19 +240,31 @@ module BlacklightHelper
     links.first
   end
 
-  def link_to_url_with_label(arg)
+  def link_to_url_with_label(arg, filters = [])
     links = arg[:value].map do |value|
       link_part = value.split('|')
       next unless link_part.count <= 2
       urls = link_part.select { |s| s.start_with? 'http' }
       labels = link_part.select { |s| !s.start_with? 'http' }
-      if urls.count == 1
-        label = labels[0] || urls[0]
-        link_to(label, urls[0])
+      next unless urls.count == 1
+      ils_filters = filters.any? do |ils|
+        urls[0].start_with?(ils)
       end
+      return nil if ils_filters
+      label = labels[0] || urls[0]
+      link_to(label, urls[0])
     end.compact
+    return nil if links.empty?
     safe_join(links, '<br/>'.html_safe)
   end
+
+  # Filters apply to only data on the showpage for the ils information
+  # rubocop:disable Layout/DefEndAlignment
+  def link_to_url_with_label_and_filter(arg)
+    ils_filters = %w[http://brbl-archive.library.yale.edu http://divinity-adhoc.library.yale.edu/FosterPapers http://digital.library.yale.edu http://beinecke.library.yale.edu http://beinecke1.library.yale.edu]
+    link_to_url_with_label(arg, ils_filters)
+  end
+  # rubocop:enable Layout/DefEndAlignment
 
   def link_to_url(arg)
     link_to(arg[:value][0], arg[:value][0])

--- a/app/views/catalog/record/_item_metadata.html.erb
+++ b/app/views/catalog/record/_item_metadata.html.erb
@@ -10,6 +10,7 @@
 
       <% doc_presenter.metadata_fields_to_render(metadata).each do |field_name, field, field_presenter| %>
         <%unless field[:no_label].presence %>
+          <% next if field_presenter.render.blank? %>
           <!-- KEY -->
           <dt class='blacklight-<%= field_name.parameterize %> metadata-block__label-key'>
             <%= (render_document_show_field_label document, field: field_name).tr(':', '') %>

--- a/app/views/catalog/record/_item_metadata.html.erb
+++ b/app/views/catalog/record/_item_metadata.html.erb
@@ -10,7 +10,6 @@
 
       <% doc_presenter.metadata_fields_to_render(metadata).each do |field_name, field, field_presenter| %>
         <%unless field[:no_label].presence %>
-          <%# next if field_presenter.render.blank? %>
           <!-- KEY -->
           <dt class='blacklight-<%= field_name.parameterize %> metadata-block__label-key'>
             <%= (render_document_show_field_label document, field: field_name).tr(':', '') %>

--- a/app/views/catalog/record/_item_metadata.html.erb
+++ b/app/views/catalog/record/_item_metadata.html.erb
@@ -10,6 +10,7 @@
 
       <% doc_presenter.metadata_fields_to_render(metadata).each do |field_name, field, field_presenter| %>
         <%unless field[:no_label].presence %>
+          <% next unless field_name.eql?('ancestorDisplayStrings_tesim') || field_presenter.render.present? %>
           <!-- KEY -->
           <dt class='blacklight-<%= field_name.parameterize %> metadata-block__label-key'>
             <%= (render_document_show_field_label document, field: field_name).tr(':', '') %>

--- a/app/views/catalog/record/_item_metadata.html.erb
+++ b/app/views/catalog/record/_item_metadata.html.erb
@@ -10,7 +10,7 @@
 
       <% doc_presenter.metadata_fields_to_render(metadata).each do |field_name, field, field_presenter| %>
         <%unless field[:no_label].presence %>
-          <% next if field_presenter.render.blank? %>
+          <%# next if field_presenter.render.blank? %>
           <!-- KEY -->
           <dt class='blacklight-<%= field_name.parameterize %> metadata-block__label-key'>
             <%= (render_document_show_field_label document, field: field_name).tr(':', '') %>

--- a/spec/system/view_fields_in_display_spec.rb
+++ b/spec/system/view_fields_in_display_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       id: '222',
       visibility_ssi: 'Public',
       callNumber_ssim: 'this is the call number',
-      source_ssim: 'this is the source',
+      source_ssim: 'this is the source'
     }
   end
 
@@ -25,9 +25,7 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
     {
       id: '333',
       visibility_ssi: 'Public',
-      callNumber_ssim: 'this is the call number, but different',
-      resourceVersionOnline_ssim: ["this is the online resource|https://this/is/the/link"]
-
+      callNumber_ssim: 'this is the call number, but different'
     }
   end
 
@@ -36,7 +34,7 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       id: '444',
       visibility_ssi: 'Public',
       findingAid_ssim: 'this is the finding aid',
-      resourceVersionOnline_ssim: ["this is the online resource that does not display|https://brbl-archive.library.yale.edu"]
+      resourceVersionOnline_ssim: ["this is the online resource that does not display|http://brbl-archive.library.yale.edu"]
     }
   end
 
@@ -86,6 +84,7 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       coordinates_ssim: "this is the coordinates, using ssim",
       projection_tesim: "this is the projection, using ssim",
       extent_ssim: ["this is the extent, using ssim", "here is another extent"],
+      resourceVersionOnline_ssim: ["this is the online resource|http://this/is/the/link"],
       ancestorTitles_tesim: %w[seventh sixth fifth fourth third second first],
       ancestorDisplayStrings_tesim: %w[seventh sixth fifth fourth third second first],
       ancestor_titles_hierarchy_ssim: ['first > ', 'first > second > ', 'first > second > third > ',
@@ -229,8 +228,7 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       expect(document).to have_content("Item Location")
     end
     it 'displays the resource version online' do
-      expect(page).to have_link("this is the online resource", href: 'https://this/is/the/link')
-      expect(page).not_to have_link(href: 'https://brbl-archive.library.yale.edu')
+      expect(page).to have_link("this is the online resource", href: 'http://this/is/the/link')
     end
     it 'displays the call number in results as link' do
       expect(page).to have_link("this is the call number", href: '/catalog?f%5BcallNumber_ssim%5D%5B%5D=this+is+the+call+number')
@@ -406,6 +404,13 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       expect(finding_aid_link).to be_truthy
       expect(finding_aid_link).to have_content "View full finding aid for this collection"
       expect(finding_aid_link).to have_css("img[src ^= '/assets/YULPopUpWindow']")
+    end
+  end
+
+  context 'when record has no resource version online link' do
+    it 'does not display online resource version' do
+      visit '/catalog/444'
+      expect(page).not_to have_link(href: 'http://brbl-archive.library.yale.edu')
     end
   end
 end

--- a/spec/system/view_fields_in_display_spec.rb
+++ b/spec/system/view_fields_in_display_spec.rb
@@ -75,6 +75,7 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       callNumber_ssim: 'this is the call number',
       containerGrouping_tesim: 'this is the container information',
       orbisBibId_ssi: '1234567',
+      archiveSpaceUri_ssi: "/repositories/11/archival_objects/214638",
       findingAid_ssim: 'this is the finding aid',
       collection_title_ssi: 'this is the collection title',
       edition_ssim: 'this is the edition',

--- a/spec/system/view_fields_in_display_spec.rb
+++ b/spec/system/view_fields_in_display_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       id: '222',
       visibility_ssi: 'Public',
       callNumber_ssim: 'this is the call number',
-      source_ssim: 'this is the source'
+      source_ssim: 'this is the source',
     }
   end
 
@@ -25,7 +25,9 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
     {
       id: '333',
       visibility_ssi: 'Public',
-      callNumber_ssim: 'this is the call number, but different'
+      callNumber_ssim: 'this is the call number, but different',
+      resourceVersionOnline_ssim: ["this is the online resource|https://this/is/the/link"]
+
     }
   end
 
@@ -33,7 +35,8 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
     {
       id: '444',
       visibility_ssi: 'Public',
-      findingAid_ssim: 'this is the finding aid'
+      findingAid_ssim: 'this is the finding aid',
+      resourceVersionOnline_ssim: ["this is the online resource that does not display|https://brbl-archive.library.yale.edu"]
     }
   end
 
@@ -83,7 +86,6 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       coordinates_ssim: "this is the coordinates, using ssim",
       projection_tesim: "this is the projection, using ssim",
       extent_ssim: ["this is the extent, using ssim", "here is another extent"],
-      archiveSpaceUri_ssi: "/repositories/11/archival_objects/214638",
       ancestorTitles_tesim: %w[seventh sixth fifth fourth third second first],
       ancestorDisplayStrings_tesim: %w[seventh sixth fifth fourth third second first],
       ancestor_titles_hierarchy_ssim: ['first > ', 'first > second > ', 'first > second > third > ',
@@ -225,6 +227,10 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
     end
     it 'displays the item location header correctly' do
       expect(document).to have_content("Item Location")
+    end
+    it 'displays the resource version online' do
+      expect(page).to have_link("this is the online resource", href: 'https://this/is/the/link')
+      expect(page).not_to have_link(href: 'https://brbl-archive.library.yale.edu')
     end
     it 'displays the call number in results as link' do
       expect(page).to have_link("this is the call number", href: '/catalog?f%5BcallNumber_ssim%5D%5B%5D=this+is+the+call+number')


### PR DESCRIPTION
**Story**
This ticket is a follow up to #1636. We need to be able to filter the resourceVersionOnline_ssim values currently brought over from Voyager, to exclude:

- Links to the old BRBL DL (in 856:42:$3 - starting http://beinecke.library.yale.edu or http://beinecke1.library.yale.edu)
- Links to YUL's instance of Content DM (in 856:41:$3 starting http://digital.library.yale.edu)
- Divinity's ad hoc server (in 856:42:$3 starting http://divinity-adhoc.library.yale.edu/FosterPapers/)
- Links to Beinecke Library's Digital Images Online database (in 856:41:$3 starting http://brbl-archive.library.yale.edu)

Additionally, all remaining 856 values should map to RelatedResourceOnline not to ResourceVersionOnline

**Acceptance**
- [x] BRBL DL, Content DM, Divinity ad hoc server and BRBL Digital Images Online database links not longer display in DCS when an object is associated with ILS
- [x] All other links brought over from Voyager 856 are labeled as Related Resource Online on object page for object associated with ILS. 

----

![image](https://user-images.githubusercontent.com/41123693/140823937-cec5aee4-7bdc-49f7-9a1b-65b300828d44.png)
