### PR TITLE
Hierarchy links to facet

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -125,7 +125,7 @@ class CatalogController < ApplicationController
     config.add_facet_field 'visibility_ssi', label: 'Access', limit: true
     config.add_facet_field 'repository_ssi', label: 'Repository', limit: true
     config.add_facet_field 'collection_title_ssi', label: 'Collection Title', limit: true, if: :repository_facet?
-    config.add_facet_field 'series_ssi', label: 'Grouping', limit: true, if: :collection_facet?
+    config.add_facet_field 'series_sort_ssi', label: 'Grouping', limit: true, if: :collection_facet?, helper_method: :strip_order
     config.add_facet_field 'format', label: 'Format', limit: true
     config.add_facet_field 'genre_ssim', label: 'Genre', limit: true
     config.add_facet_field 'resourceType_ssim', label: 'Resource Type', limit: true

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -125,7 +125,7 @@ class CatalogController < ApplicationController
     config.add_facet_field 'visibility_ssi', label: 'Access', limit: true
     config.add_facet_field 'repository_ssi', label: 'Repository', limit: true
     config.add_facet_field 'collection_title_ssi', label: 'Collection Title', limit: true, if: :repository_facet?
-    config.add_facet_field 'series_sort_ssi', label: 'Grouping', limit: true, if: :collection_facet?, helper_method: :strip_order
+    config.add_facet_field 'series_sort_ssi', label: 'Grouping', limit: true, if: :collection_facet?, helper_method: :strip_order, sort: 'index'
     config.add_facet_field 'format', label: 'Format', limit: true
     config.add_facet_field 'genre_ssim', label: 'Genre', limit: true
     config.add_facet_field 'resourceType_ssim', label: 'Resource Type', limit: true

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -322,6 +322,12 @@ module BlacklightHelper
     simple_format(snippets_separated_by_line_break)
   end
 
+  def strip_order(string)
+    pos = string.index('|')
+    string = string[pos + 1, string.length - pos - 1] if pos && pos >= 0
+    string
+  end
+
   private
 
   def language_code_to_english(language_code)

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -132,7 +132,7 @@ module BlacklightHelper
     start_index = 2
     if document[:series_sort_ssi]
       start_index = 3
-      params = default_params.clone
+      params = default_params
       params["f[series_sort_ssi][]"] = document[:series_sort_ssi]
       hierarchy_params << params
     end

--- a/spec/system/view_facet_spec.rb
+++ b/spec/system/view_facet_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe 'Facets should display', type: :system, js: :true, clean: true do
       genre_ssim: 'Maps',
       resourceType_ssim: 'Maps, Atlases & Globes',
       creator_ssim: ['Anna Elizabeth Dewdney'],
-      series_ssi: "Series Title"
+      series_ssi: "Series Title",
+      series_sort_ssi: "0938203483204|Series Title"
     }
   end
 

--- a/spec/system/view_fields_in_display_spec.rb
+++ b/spec/system/view_fields_in_display_spec.rb
@@ -367,7 +367,8 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
         within '.archival-context' do
           click_on 'second'
         end
-        expect(page).to have_css ".filter-name", text: "Found In", count: 1
+        expect(page).to have_css ".filter-name", text: "Collection Title", count: 1
+        expect(page).to have_css ".filter-name", text: "Repository", count: 1
         expect(page).to have_css ".filter-name", text: "Creator", count: 0
       end
     end

--- a/spec/system/view_fields_in_search_spec.rb
+++ b/spec/system/view_fields_in_search_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe 'Search results displays field', type: :system, clean: true do
       creator_ssim: 'Me and You',
       title_tesim: ['Amor Perro'],
       date_ssim: '1999',
+      repository_ssi: 'Beinecke Rare Book and Manuscript Library (BRBL)',
+      collection_name_ssi: 'Osborn Manuscript Files (OSB MSS FILE)',
       resourceType_ssim: 'Archives or Manuscripts',
       callNumber_tesim: 'Beinecke MS 801',
       containerGrouping_tesim: 'BRBL_091081',

--- a/spec/system/view_fields_in_search_spec.rb
+++ b/spec/system/view_fields_in_search_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe 'Search results displays field', type: :system, clean: true do
 
         click_on "Level0"
 
-        expect(page).to have_css ".filter-name", text: "Found In", count: 1
+        expect(page).to have_css ".filter-name", text: "Repository", count: 1
         expect(page).to have_css ".filter-name", text: "Creator", count: 0
       end
     end


### PR DESCRIPTION
Adjusts the hierarchy links used in Found In and the archival context tree so that they open the Repository, Collection Name, and Series facets then the links are clicked.

![sample_hier.gif](https://images.zenhubusercontent.com/5e5e9bbd38fda217bdabbde0/3f2ba35a-cebe-4bf4-aee7-bcfde8c32ac3)