### PR TITLE
Show Full Text button will now render on 'Partial' fulltext status'

### DIFF
--- a/app/views/catalog/_fulltext_transcription.html.erb
+++ b/app/views/catalog/_fulltext_transcription.html.erb
@@ -1,4 +1,4 @@
-<% if @document['has_fulltext_ssi'] == 'Yes' && client_can_view_digital?(@document) %>
+<% if @document['has_fulltext_ssi'] == 'Yes' || @document['has_fulltext_ssi'] == "Partial" && client_can_view_digital?(@document) %>
   <section class='item-page-fulltext-wrapper'>
     <button class='fulltext-button'>
       Show Full Text

--- a/spec/system/show_page_spec.rb
+++ b/spec/system/show_page_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe 'Show Page', type: :system, js: true, clean: true do
       .to_return(status: 200, body: File.open(File.join('spec', 'fixtures', '2041002.json')).read)
     stub_request(:get, 'https://yul-dc-development-samples.s3.amazonaws.com/manifests/22/22/222.json')
       .to_return(status: 200, body: File.open(File.join('spec', 'fixtures', '2041002.json')).read)
+    stub_request(:get, 'https://yul-dc-development-samples.s3.amazonaws.com/manifests/12/11/112.json')
+      .to_return(status: 200, body: File.open(File.join('spec', 'fixtures', '2041002.json')).read)
 
     solr = Blacklight.default_index.connection
     solr.add([llama,
@@ -56,7 +58,8 @@ RSpec.describe 'Show Page', type: :system, js: true, clean: true do
       genre_ssim: 'Maps',
       resourceType_ssim: 'Maps, Atlases & Globes',
       creator_ssim: ['Anna Elizabeth Dewdney'],
-      fulltext_tesim: ['fulltext text for llama child one.']
+      fulltext_tesim: ['fulltext text for llama child one.'],
+      has_fulltext_ssi: 'Partial'
     }
   end
 
@@ -195,6 +198,12 @@ RSpec.describe 'Show Page', type: :system, js: true, clean: true do
     context 'with full text available' do
       it 'has a "Show Full Text" button' do
         visit 'catalog/111'
+
+        expect(page).to have_css('.fulltext-button')
+        expect(page).to have_content('Show Full Text')
+      end
+      it 'has a "Show Full Text" button with a partial fulltext status' do
+        visit 'catalog/112'
 
         expect(page).to have_css('.fulltext-button')
         expect(page).to have_content('Show Full Text')


### PR DESCRIPTION
# Summary
"Show Full Text" button will now display if the object has a "Partial" Fulltext status:  
Object with "Partial" status:  
![Image 2021-11-09 at 3 46 10 PM](https://user-images.githubusercontent.com/24666568/141023836-aa761cfc-63c5-4603-ae32-cd8e06b38bfb.jpg)  
  
![Image 2021-11-09 at 3 46 19 PM](https://user-images.githubusercontent.com/24666568/141023890-10846ec0-8e74-432f-8e22-7657655213de.jpg)


