### PR TITLE
WIP: Spike redirect of parent

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -262,6 +262,7 @@ class CatalogController < ApplicationController
 
     # Access and Usage Rights Group
     config.add_show_field 'visibility_ssi', label: 'Access', metadata: 'access_and_usage_rights'
+    config.add_show_field 'redirect_to_tesim', label: 'Redirect To', metadata: 'access_and_usage_rights'
     config.add_show_field 'rights_ssim', label: 'Rights', metadata: 'access_and_usage_rights', helper_method: :html_safe_converter
     config.add_show_field 'preferredCitation_tesim', label: 'Citation', metadata: 'access_and_usage_rights', helper_method: :join_with_br
 
@@ -603,7 +604,12 @@ class CatalogController < ApplicationController
   def show
     super
     @search_params = session[:search_params]
-    render "catalog/show_unauthorized", status: :unauthorized unless client_can_view_metadata?(@document)
+    # raise "#{(@document["visibility_ssi"] == "Redirect" && @document["redirect_to_tesim"].present?)}"
+    if @document["visibility_ssi"] == "Redirect" && @document["redirect_to_tesim"].present?
+      redirect_to @document["redirect_to_tesim"].first
+    else
+      render "catalog/show_unauthorized", status: :unauthorized unless client_can_view_metadata?(@document)
+    end
   end
 
   def iiif_suggest


### PR DESCRIPTION
# Summary
Spike for redirecting users to another link when they attempt to access a parent object that has been deleted.

# Related Ticket
[#1696](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1696)

# Video

https://user-images.githubusercontent.com/36549923/142078154-dd9b8e56-3d06-4685-8e05-dd1137d7ded6.mp4


