### PR TITLE
Modified modal trigger link

### DIFF
--- a/app/assets/stylesheets/customOverrides/facets.scss
+++ b/app/assets/stylesheets/customOverrides/facets.scss
@@ -127,7 +127,7 @@ h2.facets-heading {
 
 .more_facets a {
   font-size: 12px;
-  margin-left: -4px;
+  margin-left: -5px;
   color: $light_blue;
   text-transform: capitalize;
 }

--- a/app/assets/stylesheets/customOverrides/facets.scss
+++ b/app/assets/stylesheets/customOverrides/facets.scss
@@ -125,6 +125,13 @@ h2.facets-heading {
   padding: 0 0.25px 0 0.25px;
 }
 
+.more_facets a {
+  font-size: 12px;
+  margin-left: -4px;
+  color: $light_blue;
+  text-transform: capitalize;
+}
+
 @media screen and (min-width: $small_device) {
 
 }


### PR DESCRIPTION
The modal trigger link in the facets should be the same font size and color as the links above it. 

**Current Design**
![Screen Shot 2021-11-23 at 12.34.58 PM.png](https://images.zenhubusercontent.com/604a2edec7bb2836333e6ec0/3ff2771f-cb89-44d5-b657-84c32ebf8482)

**Propose Design**
![modal-link-mock.png](https://images.zenhubusercontent.com/604a2edec7bb2836333e6ec0/bef4e7a6-eb02-4993-a7a3-e34f4268049f)

**Acceptance criteria:**
- [x] Font size should be 12px
- [x] Link color should be #006EF5
- [x] First letter should be capitalized (More >>)

**Actual Design Implementation**
![image](https://user-images.githubusercontent.com/41123693/144470164-ca3885d1-c23d-4cf9-89b6-e126826c45e8.png)
