### PR TITLE
Added sytling to more modal

### DIFF
--- a/app/assets/stylesheets/customOverrides/modal_dialogbox.scss
+++ b/app/assets/stylesheets/customOverrides/modal_dialogbox.scss
@@ -19,12 +19,21 @@ span.active.numeric.btn.btn-outline-secondary{
   background-color: $light_grey;
 }
 
+.facet-pagination .prev_next_links:nth-child(1)::before {
+  content: "«";
+  margin: 5px -10px 0px 0px;
+}
+
+.facet-pagination .prev_next_links:nth-child(1)::after{
+  content:"»";
+  margin: 5px 20px 0 -10px;
+}
+
 @media screen and (min-width: $medium_device) {
 }
 
 @media screen and (min-width: $large_device) {
 }
-
 
 @media screen and (min-width: $xlarge_device) {
 }

--- a/app/assets/stylesheets/customOverrides/modal_dialogbox.scss
+++ b/app/assets/stylesheets/customOverrides/modal_dialogbox.scss
@@ -1,0 +1,30 @@
+/********************************************************
+DEFAULT MOBILE STYLING
+********************************************************/
+
+.modal-body a.facet-select {
+  font-size: 14px;
+}
+
+.modal-body span.facet-count {
+  font-size: 14px;
+}
+
+a.sort_change.az.btn.btn-outline-secondary{
+  background-color: $light_grey;
+  margin-right: 10px;
+}
+
+span.active.numeric.btn.btn-outline-secondary{
+  background-color: $light_grey;
+}
+
+@media screen and (min-width: $medium_device) {
+}
+
+@media screen and (min-width: $large_device) {
+}
+
+
+@media screen and (min-width: $xlarge_device) {
+}

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -3,8 +3,8 @@ en:
     pagination:
       first: "&laquo;"
       last: "&raquo;"
-      previous: '« PREVIOUS'
-      next: 'NEXT »'
+      previous: 'PREVIOUS'
+      next: 'NEXT'
   blacklight:
     application_name: 'Yale University Library'
     sidebar:

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -3,8 +3,8 @@ en:
     pagination:
       first: "&laquo;"
       last: "&raquo;"
-      previous: 'PREVIOUS'
-      next: 'NEXT'
+      previous: '« PREVIOUS'
+      next: 'NEXT »'
   blacklight:
     application_name: 'Yale University Library'
     sidebar:


### PR DESCRIPTION
This is an overview of styling changes that should be made in the "More" modals (facet links)to enhance legibility/readability and improve color contrast. 
Modal Body: 
- [x] Change font size of facet links to 14px.
- [x] Change item count font size to 14px.

Modal Footer:
- [x] Give the first sort button, A-Z sort, a margin-right of 10px so that the focus outlines do not get cut off or overlap.
- [x] Button background-color: make darker, as there is not enough contrast between the button color and the white background. The color I used for this mockup was #e1dfdf; but I need to do a bit more testing or for an approved color in the application $medium_grey.
- [x] Add arrows to the Previous and Next buttons (&laquo;Previous and Next&raquo;). I can provide the HTML for this.
     - [x] <<  and >> ought to be centered to the text, similar to the styling in the rest of the code. 

See the mockup below for reference. (Each of these changes can be put into separate tickets if necessary.)

**Proposed Design Image**
![Screen Shot 2021-11-30 at 12.19.16 PM.png](https://images.zenhubusercontent.com/604a2edec7bb2836333e6ec0/b7262675-fa1d-4df1-8955-833018eefd32)

**Actual System Image** 
![image](https://user-images.githubusercontent.com/41123693/146259513-37f67960-1736-4cd5-bfac-b568a7ec50d7.png)

