### PR TITLE
Patched image opg metadata

### DIFF
--- a/app/models/concerns/ogp_solr_document.rb
+++ b/app/models/concerns/ogp_solr_document.rb
@@ -13,7 +13,8 @@ module OgpSolrDocument
         'og:type': 'website',
         'og:description': description,
         'og:image': self[:visibility_ssi] == "Public" && self["thumbnail_path_ss"] || nil,
-        'og:image:type': self[:visibility_ssi] == "Public" && 'image/jpeg' || nil }.compact
+        'og:image:type': self[:visibility_ssi] == "Public" && 'image/jpeg' || nil,
+        'og:image:secure_url': self[:visibility_ssi] == "Public" && self["thumbnail_path_ss"] || nil}.compact,
 
     meta_tag = []
     ogp_metadata.each do |key, value|

--- a/app/models/concerns/ogp_solr_document.rb
+++ b/app/models/concerns/ogp_solr_document.rb
@@ -14,9 +14,9 @@ module OgpSolrDocument
         'og:description': description,
         'og:image': self[:visibility_ssi] == "Public" && self["thumbnail_path_ss"] || nil,
         'og:image:type': self[:visibility_ssi] == "Public" && 'image/jpeg' || nil,
-        'og:image:secure_url': self[:visibility_ssi] == "Public" && self["thumbnail_path_ss"] || nil}.compact,
+        'og:image:secure_url': self[:visibility_ssi] == "Public" && self["thumbnail_path_ss"] || nil }.compact,
 
-    meta_tag = []
+      meta_tag = []
     ogp_metadata.each do |key, value|
       meta_tag << tag.meta({ property: key, content: value })
     end

--- a/app/models/concerns/ogp_solr_document.rb
+++ b/app/models/concerns/ogp_solr_document.rb
@@ -16,7 +16,7 @@ module OgpSolrDocument
         'og:image:type': self[:visibility_ssi] == "Public" && 'image/jpeg' || nil,
         'og:image:secure_url': self[:visibility_ssi] == "Public" && self["thumbnail_path_ss"] || nil }.compact
 
-      meta_tag = []
+    meta_tag = []
     ogp_metadata.each do |key, value|
       meta_tag << tag.meta({ property: key, content: value })
     end

--- a/app/models/concerns/ogp_solr_document.rb
+++ b/app/models/concerns/ogp_solr_document.rb
@@ -14,7 +14,7 @@ module OgpSolrDocument
         'og:description': description,
         'og:image': self[:visibility_ssi] == "Public" && self["thumbnail_path_ss"] || nil,
         'og:image:type': self[:visibility_ssi] == "Public" && 'image/jpeg' || nil,
-        'og:image:secure_url': self[:visibility_ssi] == "Public" && self["thumbnail_path_ss"] || nil }.compact,
+        'og:image:secure_url': self[:visibility_ssi] == "Public" && self["thumbnail_path_ss"] || nil }.compact
 
       meta_tag = []
     ogp_metadata.each do |key, value|


### PR DESCRIPTION
Co-Authored-By: Martin Lovell <martin.lovell@yale.edu>

**Story**

Received a report that Facebook is showing the IIIF logo and not the page thumbnail that is provided in the object page's Open Graph metadata.

https://ogp.me

![Screen Shot 2021-11-29 at 11.51.58 AM.png](https://images.zenhubusercontent.com/5e5d472f410278efd81466ab/84f259db-72ef-4561-bca0-07d85c98c5aa)

https://collections.library.yale.edu/catalog/11530121

**Acceptance**
Object thumbnail should appear when page link is posted in
- [x] Facebook
- [x] Twitter