### PR TITLE
Removed codeline numbers

### DIFF
--- a/app/views/shared/_modal.html.erb
+++ b/app/views/shared/_modal.html.erb
@@ -1,9 +1,9 @@
 <div id="blacklight-modal" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
-  2	  <div class="modal-dialog modal-lg" role="document">
-  3	    <div class="modal-content">
+  	  <div class="modal-dialog modal-lg" role="document">
+  	    <div class="modal-content">
           <% @documents&.each do |document| %>
             <h2 class="modal-title"><%= document_heading(document) %></h2>
           <% end %>
-  4	    </div>
-  5	  </div>
-  6	</div>
+  	    </div>
+  	  </div>
+</div>


### PR DESCRIPTION
As the product owner, I do not want unnecessary general text in the modal. 

Acceptance Criterion:
- [x] Remove numbers appearing in the modal view of the code. 

<img width="1084" alt="Screen Shot 2021-12-18 at 11 27 06 AM" src="https://user-images.githubusercontent.com/41123693/146651284-a4bf3983-9d3b-4cf4-a093-93bb795b91c9.png">


Addtional Infomation:
The code had line numbers in it from copy, cut, and dump blacklight project code.  This PR removed the numbers in the codelines for the file.  