### PR TITLE
Add subject heading show field with links to facets

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -150,6 +150,8 @@ class CatalogController < ApplicationController
     config.add_facet_field 'callNumber_ssim', label: 'Call Number', show: false
     config.add_facet_field 'ancestor_titles_hierarchy_ssim', label: "Found In", show: false
     config.add_facet_field 'subjectGeographic_ssim', label: 'Subject (Geographic)', show: false
+    config.add_facet_field 'subjectHeadingFacet_ssim', label: 'Subject Heading', show: false
+
     config.add_facet_field 'has_fulltext_ssi', label: "Full Text Available", limit: true
 
     # This was example code after running rails generate blacklight_range_limit:install
@@ -259,6 +261,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'subjectGeographic_ssim', label: 'Subject (Geographic)', metadata: 'subjects,_formats,_and_genres', link_to_facet: true, helper_method: :faceted_join_with_br
     config.add_show_field 'subjectName_ssim', label: 'Subject (Name)', metadata: 'subjects,_formats,_and_genres', link_to_facet: true, helper_method: :faceted_join_with_br
     config.add_show_field 'subjectTopic_ssim', label: 'Subject (Topic)', metadata: 'subjects,_formats,_and_genres', link_to_facet: true, helper_method: :faceted_join_with_br
+    config.add_show_field 'subjectHeading_ssim', label: 'Subjects', metadata: 'subjects,_formats,_and_genres', helper_method: :subject_heading_display
 
     # Access and Usage Rights Group
     config.add_show_field 'visibility_ssi', label: 'Access', metadata: 'access_and_usage_rights'

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -81,6 +81,22 @@ module BlacklightHelper
     '<p>'.html_safe + safe_join(values, '</p><p>'.html_safe) + '</p>'.html_safe if values
   end
 
+  def subject_heading_display(arg)
+    values = arg[:value]
+    links = values.map do |value|
+      subject_heading_fields = []
+      subject_heading_links = []
+      value.split(" > ").each do |subject_heading|
+        subject_heading_fields << subject_heading
+        path = subject_heading_fields.join(" > ")
+        subject_heading_links << link_to(subject_heading.to_s, search_catalog_path({ "f[subjectHeadingFacet_ssim][]" => path }),
+                                         { "title" => path })
+      end
+      safe_join(subject_heading_links, " > ")
+    end
+    safe_join(links, "<br />".html_safe)
+  end
+
   def archival_display(arg)
     values = arg[:document][arg[:field]].reverse
     title = link_to arg[:document][:title_tesim] ? arg[:document][:title_tesim].join(", ") : arg[:document][:id], solr_document_path(arg[:document][:id])

--- a/spec/system/view_fields_in_display_spec.rb
+++ b/spec/system/view_fields_in_display_spec.rb
@@ -69,6 +69,8 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       sourceCreator_tesim: "this is the source creator",
       sourceDate_tesim: "this is the source date",
       sourceNote_tesim: "this is the source note",
+      subjectHeading_ssim: ["Dog > Horse", "Fish"],
+      subjectHeadingFacet_ssim: ["Dog", "Dog > Horse", "Fish"],
       preferredCitation_tesim: ["these are the references", "this is the second reference"],
       date_ssim: "this is the date",
       oid_ssi: '2345678',
@@ -384,6 +386,16 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       expect(finding_aid_link).to be_truthy
       expect(finding_aid_link).to have_content "View full finding aid for this is the collection title"
       expect(finding_aid_link).to have_css("img[src ^= '/assets/YULPopUpWindow']")
+    end
+
+    it 'contains subject heading links' do
+      subject_heading_link = page.find("a[title = 'Dog > Horse']")
+      expect(subject_heading_link).to be_truthy
+      expect(subject_heading_link).to have_content("Horse")
+      expect(subject_heading_link['href']).to eq("/catalog?f%5BsubjectHeadingFacet_ssim%5D%5B%5D=Dog+%3E+Horse")
+      subject_heading_link.click
+      expect(page).to have_css ".filter-name", text: "Subject Heading", count: 1
+      expect(page).to have_css ".filter-value", text: "Dog > Horse", count: 1
     end
   end
   it 'has expected css' do


### PR DESCRIPTION
- Adds Subject Heading link to Show page
- Each part of the subject heading links to the facet.

![SubjectHeadingTEMP](https://user-images.githubusercontent.com/32851993/146831738-8c5357be-b60e-48bb-a912-14971386c479.gif)

