### PR TITLE
Implements redirect handling

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -605,7 +605,6 @@ class CatalogController < ApplicationController
 
   def show
     super
-    # byebug
     @search_params = session[:search_params]
     if @document["visibility_ssi"] == "Redirect" && @document["redirect_to_tesi"].present?
       redirect_to @document["redirect_to_tesi"]

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -265,6 +265,7 @@ class CatalogController < ApplicationController
 
     # Access and Usage Rights Group
     config.add_show_field 'visibility_ssi', label: 'Access', metadata: 'access_and_usage_rights'
+    config.add_show_field 'redirect_to_tesi', label: 'Redirect To', metadata: 'access_and_usage_rights'
     config.add_show_field 'rights_ssim', label: 'Rights', metadata: 'access_and_usage_rights', helper_method: :html_safe_converter
     config.add_show_field 'preferredCitation_tesim', label: 'Citation', metadata: 'access_and_usage_rights', helper_method: :join_with_br
 
@@ -604,8 +605,13 @@ class CatalogController < ApplicationController
 
   def show
     super
+    # byebug
     @search_params = session[:search_params]
-    render "catalog/show_unauthorized", status: :unauthorized unless client_can_view_metadata?(@document)
+    if @document["visibility_ssi"] == "Redirect" && @document["redirect_to_tesi"].present?
+      redirect_to @document["redirect_to_tesi"]
+    else
+      render "catalog/show_unauthorized", status: :unauthorized unless client_can_view_metadata?(@document)
+    end
   end
 
   def iiif_suggest

--- a/app/helpers/access_helper.rb
+++ b/app/helpers/access_helper.rb
@@ -1,13 +1,15 @@
 # frozen_string_literal: true
 module AccessHelper
   def viewable_metadata_visibilities
-    ["Public", "Yale Community Only"]
+    ["Public", "Redirect", "Yale Community Only"]
   end
 
   def client_can_view_digital?(document)
     Rails.logger.warn("starting client can view digital check for #{request.env['HTTP_X_ORIGIN_URI']}")
     case document['visibility_ssi']
     when 'Public'
+      return true
+    when 'Redirect'
       return true
     when 'Yale Community Only'
       return true if current_user || User.on_campus?(request.remote_ip)

--- a/spec/requests/manifests_request_spec.rb
+++ b/spec/requests/manifests_request_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Manifests', type: :request, clean: true do
   let(:user) { FactoryBot.create(:user) }
   let(:public_work) { WORK_WITH_PUBLIC_VISIBILITY }
+  let(:redirected_work) { WORK_REDIRECTED }
   let(:yale_work) do
     {
       "id": "1618909",
@@ -40,7 +41,7 @@ RSpec.describe 'Manifests', type: :request, clean: true do
       )
 
     solr = Blacklight.default_index.connection
-    solr.add([public_work, yale_work, no_visibility_work])
+    solr.add([public_work, yale_work, no_visibility_work, redirected_work])
     solr.commit
     allow(User).to receive(:on_campus?).and_return(false)
   end
@@ -106,6 +107,11 @@ RSpec.describe 'Manifests', type: :request, clean: true do
       manifest = JSON.parse(response.body)
 
       expect(manifest['error']).to eq('unauthorized')
+    end
+
+    it 'returns a 404 if redirected' do
+      get '/manifests/16685691'
+      expect(response.body).to include "the item you've requested does not appear to exist"
     end
   end
 

--- a/spec/requests/pdfs_request_spec.rb
+++ b/spec/requests/pdfs_request_spec.rb
@@ -31,6 +31,8 @@ RSpec.describe 'PdfController', type: :request do
       "title_tesim": ["Fake Work"]
     }
   end
+  let(:redirected_work) { WORK_REDIRECTED }
+
   describe 'PDFs' do
     before do
       stub_request(:get, 'https://yul-test-samples.s3.amazonaws.com/pdfs/00/20/34/60/2034600.pdf')
@@ -38,7 +40,7 @@ RSpec.describe 'PdfController', type: :request do
       stub_request(:get, 'https://yul-test-samples.s3.amazonaws.com/pdfs/09/16/18/90/1618909.pdf')
         .to_return(status: 200, body: File.open(File.join('spec', 'fixtures', '2034600.pdf')).read)
       solr = Blacklight.default_index.connection
-      solr.add([public_work, yale_work, no_visibility_work, pubic_work_with_no_pdf])
+      solr.add([public_work, yale_work, no_visibility_work, pubic_work_with_no_pdf, redirected_work])
       solr.commit
       allow(User).to receive(:on_campus?).and_return(false)
     end
@@ -65,6 +67,10 @@ RSpec.describe 'PdfController', type: :request do
       it 'returns unauthorized for oid with Yale Only' do
         get '/pdfs/1618909.pdf'
         expect(response).to have_http_status(:unauthorized)
+      end
+      it 'returns not found for oid with Redirect' do
+        get '/pdfs/16685691.pdf'
+        expect(response).to have_http_status(:not_found)
       end
     end
 

--- a/spec/support/solr_documents/metadata_cloud_with_visibility.rb
+++ b/spec/support/solr_documents/metadata_cloud_with_visibility.rb
@@ -114,3 +114,9 @@ WORK_WITH_YALE_ONLY_VISIBILITY = {
   "public_bsi": true,
   "visibility_ssi": "Yale Community Only"
 }.freeze
+
+WORK_REDIRECTED = {
+  "id": 1_668_591,
+  "redirect_to_tesi": "https://collections-uat.library.yale.edu/catalog/234567",
+  "visibility_ssi": "Redirect"
+}.freeze


### PR DESCRIPTION
# Summary
Allows for redirected parent objects to redirect to their intended destination.

# Related Ticket
[#1782](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1782)

# Video

https://user-images.githubusercontent.com/36549923/148467248-e9826b02-4990-4e8e-883d-da3d2e517c9e.mp4


