### PR TITLE
1845 creator a space mapping

### DIFF
--- a/app/assets/stylesheets/customOverrides/show_page.scss
+++ b/app/assets/stylesheets/customOverrides/show_page.scss
@@ -385,6 +385,10 @@ p.yale-restricted-work-text{
   width: 15px;
 }
 
+.from-the-collection{
+  font-style: italic;
+}
+
 @media screen and (min-width: $medium_device) {
   .constraints-container {
     margin-left: -.5%;

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -181,7 +181,7 @@ class CatalogController < ApplicationController
 
     # solr fields to be displayed in the index (search results) view
     #   The ordering of the field names is the order of the display
-    config.add_index_field 'creator_tesim', label: 'Creator', highlight: true, solr_params: disp_req_fieldmatch_on_search_params
+    config.add_index_field 'creator_tesim', label: 'Creator', highlight: true, solr_params: disp_req_fieldmatch_on_search_params, helper_method: :generate_creators_links
     config.add_index_field 'date_ssim', label: 'Published / Created', highlight: true, solr_params: disp_req_fieldmatch_on_search_params
     config.add_index_field 'callNumber_tesim', label: 'Call Number', highlight: true, solr_params: disp_req_fieldmatch_on_search_params
     config.add_index_field 'sourceTitle_tesim', label: 'Collection Title', highlight: true, solr_params: disp_req_fieldmatch_on_search_params
@@ -217,7 +217,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'ancestorTitles_tesim', label: 'Found In', metadata: 'ancestorTitles', helper_method: :archival_display_show
     config.add_show_field 'title_tesim', label: 'Title', metadata: 'description', helper_method: :join_with_br
     config.add_show_field 'alternativeTitle_tesim', label: 'Alternative Title', metadata: 'description', helper_method: :join_with_br
-    config.add_show_field 'creator_ssim', label: 'Creator', metadata: 'description', link_to_facet: true
+    config.add_show_field 'creator_ssim', label: 'Creator', metadata: 'description', link_to_facet: true, helper_method: :generate_creators_links
     config.add_show_field 'date_ssim', label: 'Published / Created', metadata: 'description'
     config.add_show_field 'copyrightDate_ssim', label: 'Copyright Date', metadata: 'description'
     config.add_show_field 'creationPlace_ssim', label: 'Publication Place', metadata: 'description'

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -181,7 +181,7 @@ class CatalogController < ApplicationController
 
     # solr fields to be displayed in the index (search results) view
     #   The ordering of the field names is the order of the display
-    config.add_index_field 'creator_tesim', label: 'Creator', highlight: true, solr_params: disp_req_fieldmatch_on_search_params, helper_method: :generate_creators_links
+    config.add_index_field 'creator_tesim', label: 'Creator', highlight: true, solr_params: disp_req_fieldmatch_on_search_params, helper_method: :generate_creators_text
     config.add_index_field 'date_ssim', label: 'Published / Created', highlight: true, solr_params: disp_req_fieldmatch_on_search_params
     config.add_index_field 'callNumber_tesim', label: 'Call Number', highlight: true, solr_params: disp_req_fieldmatch_on_search_params
     config.add_index_field 'sourceTitle_tesim', label: 'Collection Title', highlight: true, solr_params: disp_req_fieldmatch_on_search_params

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -275,8 +275,8 @@ module BlacklightHelper
   end
 
   def generate_creators_text(args)
-    generate_creators(args) do |creator|
-      creator
+    generate_creators(args) do |_creator, creator_highlight|
+      creator_highlight
     end
   end
 
@@ -291,8 +291,9 @@ module BlacklightHelper
     out = []
 
     creator_values = args[:document][args[:field]]
-    creator_values.map do |creator|
-      creator_change = yield creator
+    creator_highlight = args[:document].highlight_field(args[:field])
+    creator_values.each_with_index.map do |creator, ix|
+      creator_change = yield creator, creator_highlight.try(:[], ix) || creator
       label = 'From the Collection: ' if args[:document]['collectionCreators_ssim']&.include?(creator)
       out << safe_join(["<span class = 'from-the-collection' >".html_safe, label, "</span>".html_safe, creator_change])
     end

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -274,6 +274,19 @@ module BlacklightHelper
     links.first
   end
 
+  def generate_creators_links(args)
+    out = []
+
+    creator_values = args[:document][args[:field]]
+    creator_values.map do |creator|
+
+      link = "/catalog?f%5Bcreator_ssim%5D%5B%5D=#{creator}"
+      label= 'From the collection: ' if args[:document]['collectionCreators_ssim']&.include?(creator)
+      out << safe_join([label, link_to(creator, link)])
+    end
+    safe_join(out, ", " )
+  end
+
   def link_to_url_with_label(arg, filters = [])
     links = arg[:value].map do |value|
       link_part = value.split('|')

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -274,17 +274,29 @@ module BlacklightHelper
     links.first
   end
 
+  def generate_creators_text(args)
+    generate_creators(args) do |creator|
+      creator
+    end
+  end
+
   def generate_creators_links(args)
+    generate_creators(args) do |creator|
+      link = "/catalog?f%5Bcreator_ssim%5D%5B%5D=#{creator}"
+      link_to(creator, link)
+    end
+  end
+
+  def generate_creators(args)
     out = []
 
     creator_values = args[:document][args[:field]]
     creator_values.map do |creator|
-
-      link = "/catalog?f%5Bcreator_ssim%5D%5B%5D=#{creator}"
-      label= 'From the collection: ' if args[:document]['collectionCreators_ssim']&.include?(creator)
-      out << safe_join([label, link_to(creator, link)])
+      creator_change = yield creator
+      label = 'From the Collection: ' if args[:document]['collectionCreators_ssim']&.include?(creator)
+      out << safe_join(["<span class = 'from-the-collection' >".html_safe, label, "</span>".html_safe, creator_change])
     end
-    safe_join(out, ", " )
+    safe_join(out, '<br/>'.html_safe)
   end
 
   def link_to_url_with_label(arg, filters = [])

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -57,6 +57,7 @@ class SearchBuilder < Blacklight::SearchBuilder
       uri_ssim
       viewing_hint_ssi
       visibility_ssi
+      collectionCreators_ssim
     ]
   end
 

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -38,6 +38,7 @@ class SearchBuilder < Blacklight::SearchBuilder
       timestamp
       score
       box_ssim
+      collectionCreators_ssim
       collectionId_ssim
       containerGrouping_ssim
       dependentUris_ssim
@@ -57,7 +58,6 @@ class SearchBuilder < Blacklight::SearchBuilder
       uri_ssim
       viewing_hint_ssi
       visibility_ssi
-      collectionCreators_ssim
     ]
   end
 

--- a/spec/system/highlight_in_search_spec.rb
+++ b/spec/system/highlight_in_search_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Search results displays field', type: :system, clean: true do
     {
       id: '111',
       title_tesim: 'Jack or Dan the Bulldog',
-      creator_ssim: 'Me and You',
+      creator_tesim: 'Me and You',
       abstract_tesim: 'Binding: white with gold embossing.',
       alternativeTitle_tesim: 'The Yale Bulldogs',
       description_tesim: 'in black ink on thin white paper',

--- a/spec/system/highlight_in_search_spec.rb
+++ b/spec/system/highlight_in_search_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Search results displays field', type: :system, clean: true do
     {
       id: '111',
       title_tesim: 'Jack or Dan the Bulldog',
-      creator_tesim: 'Me and You',
+      creator_ssim: 'Me and You',
       abstract_tesim: 'Binding: white with gold embossing.',
       alternativeTitle_tesim: 'The Yale Bulldogs',
       description_tesim: 'in black ink on thin white paper',

--- a/spec/system/view_fields_in_display_spec.rb
+++ b/spec/system/view_fields_in_display_spec.rb
@@ -103,9 +103,6 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       expect(page.html).to match("Diversity Bull Dogs<br/>")
       expect(document).to have_content("this is the second title")
     end
-    it 'displays Creator in results' do
-      expect(document).to have_content("Frederick, Eric & Maggie")
-    end
     it 'displays format in results' do
       expect(document).to have_content("three dimensional object")
     end
@@ -259,13 +256,13 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
     it 'contains a link on the Orbis Bib ID to the Orbis catalog record' do
       expect(page).to have_link('1234567', href: 'http://hdl.handle.net/10079/bibid/1234567')
     end
-    it 'contains a link for the Creator field to the facet' do
+    it 'contains a link for the Creator field to the facet and displays' do
       expect(page).to have_link('Frederick', href: '/catalog?f%5Bcreator_ssim%5D%5B%5D=Frederick')
       expect(page).to have_link('Eric', href: '/catalog?f%5Bcreator_ssim%5D%5B%5D=Eric')
       expect(page).to have_link('Martin', href: '/catalog?f%5Bcreator_ssim%5D%5B%5D=Martin')
       expect(page).to have_link('Maggie', href: '/catalog?f%5Bcreator_ssim%5D%5B%5D=Maggie')
     end
-    it 'contains a link for the From Collection Creator field to the facet' do
+    it 'contains a link for the From Collection Creator field to the facet and displays' do
       expect(page).to have_content("From the Collection: Maggie")
       expect(page).to have_content("From the Collection: Martin")
       expect(page).not_to have_content("From the Collection: Frederick")

--- a/spec/system/view_fields_in_display_spec.rb
+++ b/spec/system/view_fields_in_display_spec.rb
@@ -42,8 +42,8 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
     {
       id: '111',
       title_tesim: ["Diversity Bull Dogs", "this is the second title"],
-      creator_ssim: ['Frederick',  'Martin', 'Eric', 'Maggie'],
-      collectionCreators_ssim: ['Martin', 'Maggie'] ,
+      creator_ssim: ['Frederick', 'Martin', 'Eric', 'Maggie'],
+      collectionCreators_ssim: ['Martin', 'Maggie'],
       format: 'three dimensional object',
       url_suppl_ssim: 'http://0.0.0.0:3000/catalog/111',
       language_ssim: ['en', 'eng', 'zz'],

--- a/spec/system/view_fields_in_display_spec.rb
+++ b/spec/system/view_fields_in_display_spec.rb
@@ -42,7 +42,8 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
     {
       id: '111',
       title_tesim: ["Diversity Bull Dogs", "this is the second title"],
-      creator_ssim: ['Frederick,  Eric & Maggie'],
+      creator_ssim: ['Frederick',  'Martin', 'Eric', 'Maggie'],
+      collectionCreators_ssim: ['Martin', 'Maggie'] ,
       format: 'three dimensional object',
       url_suppl_ssim: 'http://0.0.0.0:3000/catalog/111',
       language_ssim: ['en', 'eng', 'zz'],
@@ -259,7 +260,16 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       expect(page).to have_link('1234567', href: 'http://hdl.handle.net/10079/bibid/1234567')
     end
     it 'contains a link for the Creator field to the facet' do
-      expect(page).to have_link('Frederick, Eric & Maggie', href: '/catalog?f%5Bcreator_ssim%5D%5B%5D=Frederick%2C++Eric+%26+Maggie')
+      expect(page).to have_link('Frederick', href: '/catalog?f%5Bcreator_ssim%5D%5B%5D=Frederick')
+      expect(page).to have_link('Eric', href: '/catalog?f%5Bcreator_ssim%5D%5B%5D=Eric')
+      expect(page).to have_link('Martin', href: '/catalog?f%5Bcreator_ssim%5D%5B%5D=Martin')
+      expect(page).to have_link('Maggie', href: '/catalog?f%5Bcreator_ssim%5D%5B%5D=Maggie')
+    end
+    it 'contains a link for the From Collection Creator field to the facet' do
+      expect(page).to have_content("From the Collection: Maggie")
+      expect(page).to have_content("From the Collection: Martin")
+      expect(page).not_to have_content("From the Collection: Frederick")
+      expect(page).not_to have_content("From the Collection: Eric")
     end
     it 'contains a link on the more info to the more info record' do
       expect(page).to have_link('http://0.0.0.0:3000/catalog/111', href: 'http://0.0.0.0:3000/catalog/111')


### PR DESCRIPTION
Co-authored-by: Martin Lovell <martin.lovell@yale.edu>
Co-authored-by: Yue Ji <yue.ji@yale.edu>
Co-authored-by: Maggie Zhao <maggie.zhao@yale.edu>


DCS metadata mapping to ArchivesSpace currently pulls in creator information for an object from the collection level of a finding aid, if a creator is not presented at the file/item level. For example, for this parent object https://collections-uat.library.yale.edu/catalog/15603880 the creator listed, is the creator of the collection, listed at the collection level in ArchivesSpace for the collection this item belongs to. This is made obvious on the Archives at Yale record for this item https://archives.yale.edu/repositories/12/archival_objects/802216 which shows that the Creator is "From the collection".

We would like to follow this same principal in DCS. When the creator of an object is inherited from a higher level of description in the archival hierarchy in ASpace, the entry in DCS should be prepended with _From the Collection:_

So for the example listed above, the entry would be _From the Collection:_ Goel, Ravi D.

**Acceptance**
- [ ] For objects associated with ASpace, when Creator information is inherited from a higher level of description in ArchivesSpace, the entry should be prepended with the statement _From the Collection:_
- [ ] Reindex ASpace sources for all admin sets


-----
**ITEM PAGE**
![Screen Shot 2022-01-12 at 12.03.41 PM.png](https://images.zenhubusercontent.com/5e6013c029e314c92afd4769/d3f20d8b-eba3-4084-95ca-8b84e131b7a2)

------
**RESULT PAGE**

![Screen Shot 2022-01-12 at 12.03.18 PM.png](https://images.zenhubusercontent.com/5e6013c029e314c92afd4769/bf811faf-8e35-4f53-a176-dbe629dabc9f)

With the correct facet search: 
![image.png](https://images.zenhubusercontent.com/5e6013c029e314c92afd4769/04611b6f-8c24-42fb-a5c4-524e5bfac525)
https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1799
