### PR TITLE
Updated logo url

### DIFF
--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -1,6 +1,6 @@
 <nav class="navbar navbar-expand-md navbar-dark bg-dark topbar" role="navigation" aria-label="Main">
   <div class="<%= container_classes %>">
-    <%= link_to application_name, root_path, class: 'mb-0 navbar-brand navbar-logo' %>
+    <%= link_to application_name, "https://library.yale.edu/", class: 'mb-0 navbar-brand navbar-logo' %>
     <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#user-util-collapse" aria-controls="user-util-collapse" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>

--- a/spec/system/header_spec.rb
+++ b/spec/system/header_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'header', type: :system do
     expect(page).to have_link('Ask Yale Library', href: 'http://ask.library.yale.edu/')
     expect(page).to have_link('Reserve Rooms', href: 'https://schedule.yale.edu/')
     expect(page).to have_link('Places to Study', href: 'https://web.library.yale.edu/places/to-study')
-    expect(page).to have_link('Yale University Library', href: '/')
+    expect(page).to have_link('Yale University Library', href: 'https://library.yale.edu/')
   end
 
   it 'has expected links in the submenu' do


### PR DESCRIPTION
Header Logo now points to https://library.yale.edu/