### PR TITLE
Add quicksearch id field

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -271,6 +271,7 @@ class CatalogController < ApplicationController
 
     # Identifiers Group
     config.add_show_field 'orbisBibId_ssi', label: 'Orbis Record', metadata: 'identifiers', helper_method: :link_to_orbis_bib_id
+    config.add_show_field 'quicksearchId_ssi', label: 'Quicksearch ID', metadata: 'identifiers', helper_method: :link_to_quicksearch_id
     config.add_show_field 'oid_ssi', label: 'Object ID (OID)', metadata: 'identifiers'
     config.add_show_field 'url_suppl_ssim', label: 'More Information', metadata: 'identifiers', helper_method: :link_to_url
 
@@ -349,6 +350,7 @@ class CatalogController < ApplicationController
       'publisher_tesim',
       'preferredCitation_tesim',
       'project_identifier_tesi',
+      'quicksearchId_ssi',
       'repository_ssim',
       "repository_ssi",
       'resourceType_tesim',
@@ -478,8 +480,8 @@ class CatalogController < ApplicationController
       field.qt = 'search'
       field.include_in_advanced_search = false
       field.solr_parameters = {
-        qf: 'orbisBibId_ssi',
-        pf: 'orbisBibId_ssi'
+        qf: 'orbisBibId_ssi quicksearchId_ssi',
+        pf: 'orbisBibId_ssi quicksearchId_ssi'
       }
     end
 

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -71,6 +71,13 @@ module BlacklightHelper
     link_to(bib_id, link)
   end
 
+  def link_to_quicksearch_id(arg)
+    qs_id = arg[:document][arg[:field]]
+    link = "https://search.library.yale.edu/catalog/#{qs_id}"
+
+    link_to(qs_id, link)
+  end
+
   def join_with_br(arg)
     values = arg[:document][arg[:field]]
     safe_join(values, '<br/>'.html_safe)

--- a/spec/system/view_fields_in_display_spec.rb
+++ b/spec/system/view_fields_in_display_spec.rb
@@ -78,6 +78,7 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       callNumber_ssim: 'this is the call number',
       containerGrouping_tesim: 'this is the container information',
       orbisBibId_ssi: '1234567',
+      quicksearchId_ssi: 'b1234567',
       archiveSpaceUri_ssi: "/repositories/11/archival_objects/214638",
       findingAid_ssim: 'this is the finding aid',
       collection_title_ssi: 'this is the collection title',
@@ -218,6 +219,10 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
     end
     it 'displays the Orbis Bib ID in results' do
       expect(document).to have_content("1234567")
+    end
+    it 'displays the Quicksearch ID in results' do
+      expect(document).to have_content("b1234567")
+      expect(document).to have_link("b1234567", href: "https://search.library.yale.edu/catalog/b1234567")
     end
     it 'displays the Edition in results' do
       expect(document).to have_content("this is the edition")


### PR DESCRIPTION
- Adds the Quicksearch Id field to the identifiers section that links to quicksearch
- Adds quicksearch id to all fields and orbis id search.