### PR TITLE
Add conditional sort by Collection Order

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -518,6 +518,7 @@ class CatalogController < ApplicationController
     # whether the sort is ascending or descending (it must be asc or desc
     # except in the relevancy case).
     config.add_sort_field 'score desc, pub_date_si desc, title_si asc, archivalSort_ssi asc', label: 'relevance'
+    config.add_sort_field 'archivalSort_ssi asc, score desc, pub_date_si desc, title_si asc', label: 'Collection Order', if: :collection_order_sort?
     config.add_sort_field 'creator_ssim asc, title_ssim asc, archivalSort_ssi asc', label: 'Creator (A --> Z)'
     config.add_sort_field 'creator_ssim desc, title_ssim asc, archivalSort_ssi asc', label: 'Creator (Z --> A)'
     config.add_sort_field 'title_ssim asc, oid_ssi desc, archivalSort_ssi asc', label: 'Title (A --> Z)'
@@ -589,6 +590,10 @@ class CatalogController < ApplicationController
 
   def collection_facet?
     helpers.facet_field_in_params?('collection_title_ssi')
+  end
+
+  def collection_order_sort?
+    helpers.facet_field_in_params?('collection_title_ssi') || helpers.facet_field_in_params?('series_sort_ssi')
   end
 
   def gallery_view?

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -517,8 +517,8 @@ class CatalogController < ApplicationController
     # label in pulldown is followed by the name of the SOLR field to sort by and
     # whether the sort is ascending or descending (it must be asc or desc
     # except in the relevancy case).
-    config.add_sort_field 'score desc, pub_date_si desc, title_si asc, archivalSort_ssi asc', label: 'relevance'
-    config.add_sort_field 'archivalSort_ssi asc, score desc, pub_date_si desc, title_si asc', label: 'Collection Order', if: :collection_order_sort?
+    config.add_sort_field 'score desc, pub_date_si desc, title_ssim asc, archivalSort_ssi asc', label: 'relevance'
+    config.add_sort_field 'archivalSort_ssi asc, score desc, pub_date_si desc, title_ssim asc', label: 'Collection Order', if: :collection_order_sort?
     config.add_sort_field 'creator_ssim asc, title_ssim asc, archivalSort_ssi asc', label: 'Creator (A --> Z)'
     config.add_sort_field 'creator_ssim desc, title_ssim asc, archivalSort_ssi asc', label: 'Creator (Z --> A)'
     config.add_sort_field 'title_ssim asc, oid_ssi desc, archivalSort_ssi asc', label: 'Title (A --> Z)'

--- a/spec/system/sort_in_search_spec.rb
+++ b/spec/system/sort_in_search_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe 'Search results should be sorted', type: :system, js: :true, clea
       creator_tesim: 'Andy Graves',
       creator_ssim: ['Andy Graves'],
       dateStructured_ssim: ['1755'],
+      collection_title_ssi: "Test",
       year_isim: [1755]
     }
   end
@@ -62,6 +63,7 @@ RSpec.describe 'Search results should be sorted', type: :system, js: :true, clea
       creator_tesim: 'Paulo Coelho',
       creator_ssim: ['Paulo Coelho'],
       dateStructured_ssim: ['1972'],
+      collection_title_ssi: "Test",
       year_isim: [1790]
     }
   end
@@ -195,6 +197,31 @@ RSpec.describe 'Search results should be sorted', type: :system, js: :true, clea
       expect(content).to have_content("2.\nRhett Lecheire")
       expect(content).to have_content("3.\nHandsomeDan Bulldog")
       expect(content).to have_content("4.\nAmor Llama")
+    end
+  end
+
+  context 'sorts by collection with correct facets' do
+    it 'does not have sort by collection by default' do
+      click_on 'search'
+      click_on 'Sort by relevance'
+      within('div#sort-dropdown') do
+        expect(page).not_to have_content("Collection Order")
+      end
+    end
+  end
+
+  context 'sorts by collection with correct facets' do
+    it 'does not have sort by collection by default' do
+      visit "/catalog?f[collection_title_ssi][]=Test"
+      click_on 'search'
+      click_on 'Sort by relevance'
+      within('div#sort-dropdown') do
+        expect(page).to have_content("Collection Order")
+        click_on "Collection Order"
+      end
+      content = find(:css, '#content')
+      expect(content).to have_content("1.\nRhett Lecheire")
+      expect(content).to have_content("2.\nHandsomeDan Bulldog")
     end
   end
 end

--- a/spec/system/sort_in_search_spec.rb
+++ b/spec/system/sort_in_search_spec.rb
@@ -213,7 +213,9 @@ RSpec.describe 'Search results should be sorted', type: :system, js: :true, clea
   context 'sorts by collection with correct facets' do
     it 'does not have sort by collection by default' do
       visit "/catalog?f[collection_title_ssi][]=Test"
-      click_on 'search'
+      content = find(:css, '#content')
+      expect(content).to have_content("1.\nHandsomeDan Bulldog")
+      expect(content).to have_content("2.\nRhett Lecheire")
       click_on 'Sort by relevance'
       within('div#sort-dropdown') do
         expect(page).to have_content("Collection Order")


### PR DESCRIPTION
- Adds conditional sort by Collection Order using archivalSort_ssi with the default sort fields as secondary, etc., sorts.
- Checks for Collection facet (collection_title_ssi) and Grouping facet (series_sort_ssi) via CatalogController.collection_order_sort?
- Fixes bug in relevance sort which included `title_si` instead of `title_ssim`