### PR TITLE
Filtered digital collection links

### DIFF
--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -337,7 +337,8 @@ module BlacklightHelper
   def link_to_url_with_label_and_filter(arg)
     ils_filters = %w[brbl-archive.library.yale.edu
                      divinity-adhoc.library.yale.edu/FosterPapers digital.library.yale.edu
-                     beinecke.library.yale.edu beinecke1.library.yale.edu collections.library.yale.edu]
+                     beinecke.library.yale.edu beinecke1.library.yale.edu collections.library.yale.edu
+                     hdl.handle.net/10079/digcoll/]
     link_to_url_with_label(arg, ils_filters)
   end
   # rubocop:enable Layout/DefEndAlignment


### PR DESCRIPTION
**Story**

In Blacklight we'd like to filter out/suppress links for ILS items in the format `http://hdl.handle.net/10079/digcoll/ ` since these are handles/permalinks that either point to FindIt or (after they are updated) to the record in DCS.  In other words, they are self-referential.

Reported by Mark C.

See also #1808

**Acceptance**

- [ ] digicoll handles are suppressed for ILS records in the method above
