### PR TITLE
Container/Volume Width

### DIFF
--- a/app/assets/stylesheets/customOverrides/show_page.scss
+++ b/app/assets/stylesheets/customOverrides/show_page.scss
@@ -14,7 +14,7 @@ DEFAULT MOBILE STYLING
 }
 
 dt.blacklight-containergrouping_tesim.metadata-block__label-key {
-  width: 31%;
+  width: 30%;
   margin-bottom: 2%;
 }
 
@@ -24,7 +24,7 @@ dd.blacklight-containergrouping_tesim.metadata-block__label-value.metadata-block
   position: relative;
   left: 0;
   min-width: 5%;
-  max-width: 31%;
+  max-width: 30%;
 }
 
 dt.blacklight-ancestordisplaystrings_tesim.metadata-block__label-key {


### PR DESCRIPTION
# Summary  
Container/Volume width now matches the width of the other metadata rows  
  
# Related Ticket
[#1838](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1838)  
  
# Screenshots  
<img width="986" alt="image" src="https://user-images.githubusercontent.com/24666568/155217708-1f0d70c6-5844-4a78-9a68-668c0244813a.png">
