### PR TITLE
Modified a submenu name

### DIFF
--- a/config/locales/submenu.en.yml
+++ b/config/locales/submenu.en.yml
@@ -218,7 +218,7 @@ en:
         url: https://web.library.yale.edu/help/scanning-printing-copying
         description: ''
       computersWireless:
-        title: Computers Wireless
+        title: Computers & Wireless
         url: https://web.library.yale.edu/help/computers-and-wireless
         description: ''
       libraryPolicies:

--- a/spec/system/header_spec.rb
+++ b/spec/system/header_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe 'header', type: :system do
     expect(page).to have_link('Services for Persons with Disabilities', href: 'https://web.library.yale.edu/services-persons-disabilities')
     expect(page).to have_link('Copyright Basics', href: 'http://guides.library.yale.edu/copyright-guidance/copyright-basics')
     expect(page).to have_link('Scanning, Printing & Copying', href: 'https://web.library.yale.edu/help/scanning-printing-copying')
-    expect(page).to have_link('Computers Wireless', href: 'https://web.library.yale.edu/help/computers-and-wireless')
+    expect(page).to have_link('Computers & Wireless', href: 'https://web.library.yale.edu/help/computers-and-wireless')
     expect(page).to have_link('Library Policies', href: 'http://guides.library.yale.edu/about/policies')
     expect(page).to have_link('About the Library', href: 'http://guides.library.yale.edu/about')
     expect(page).to have_link('Giving to the Library', href: 'https://library.yale.edu/development')


### PR DESCRIPTION
The submenu for "Computers Wireless" was renamed to "Computers & Wireless"