### PR TITLE
Modified Container/Volume CSS for ASpace objects

### DIFF
--- a/app/assets/stylesheets/customOverrides/show_page.scss
+++ b/app/assets/stylesheets/customOverrides/show_page.scss
@@ -14,7 +14,7 @@ DEFAULT MOBILE STYLING
 }
 
 dt.blacklight-containergrouping_tesim.metadata-block__label-key {
-  width: 30%;
+  width: 30.5%;
   margin-bottom: 2%;
 }
 
@@ -22,7 +22,7 @@ dd.blacklight-containergrouping_tesim.metadata-block__label-value.metadata-block
   flex: available;
   flex: -moz-available;
   position: relative;
-  left: 0;
+  left: -0.50%;
   min-width: 5%;
   max-width: 30%;
 }
@@ -472,6 +472,9 @@ p.yale-restricted-work-text{
   .showpage_no_label_tag.blacklight-archivespaceuri_ssi {
     height: 42px;
   }
+  dd.blacklight-containergrouping_tesim.metadata-block__label-value.metadata-block__label-value--yul {
+    left: -0.85%;
+  }
 }
 
 
@@ -571,12 +574,14 @@ p.yale-restricted-work-text{
   dt.blacklight-containergrouping_tesim.metadata-block__label-key{
     padding-bottom: 2%;
   }
-
   .showpage_no_label_tag{
     #popup_window{
       padding-left: 1.5%;
       padding-bottom: 0.75%;
     }
+  }
+  dd.blacklight-containergrouping_tesim.metadata-block__label-value.metadata-block__label-value--yul {
+    left: -0.5%;
   }
 }
 


### PR DESCRIPTION
Co-authored-by: JP Engstrom <jp@notch8.com>

**Story**

We recently deployed a fix for the "Container/Volume" field label, see (#1838). However, this fix appears to have created a new issue, where this field is now misaligned on objects that are associated with ASpace.

See example https://collections.library.yale.edu/catalog/32309327 

Also here is a screenshot for quick reference
![MicrosoftTeams-image.png](https://images.zenhubusercontent.com/60786c408c8643227aa47d8f/0c4638aa-8938-4c45-9242-9a1f2813ba00)

**Acceptance**
- [x] Container/Volume field aligns left below the collection hierarchy display 