### PR TITLE
Update the image size for OG and sitemap …

### DIFF
--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -22,6 +22,15 @@ module CatalogHelper
     constraints.join(' / ')
   end
 
+  def change_iiif_image_size(url, new_size)
+    return nil unless url
+    url = URI.parse(url) # e.g. https://collections-test.library.yale.edu/iiif/2/17120080/full/!200,200/0/default.jpg
+    path_components = url.path.split("/")
+    path_components[5] = new_size
+    url.path = path_components.join("/")
+    url.to_s
+  end
+
   # Extract fulltext param from search
   # Simple: ...search_field=fulltext_tsim&q=XXX
   # Advanced: fulltext_tsim_advanced=XXX

--- a/app/models/concerns/ogp_solr_document.rb
+++ b/app/models/concerns/ogp_solr_document.rb
@@ -3,6 +3,7 @@
 module OgpSolrDocument
   extend ActiveSupport::Concern
   include ActionView::Helpers::TagHelper
+  include CatalogHelper
 
   def to_ogp_metadata
     description = ogp_description
@@ -12,9 +13,9 @@ module OgpSolrDocument
         'og:url': "https://collections.library.yale.edu/catalog/#{id}",
         'og:type': 'website',
         'og:description': description,
-        'og:image': self[:visibility_ssi] == "Public" && self["thumbnail_path_ss"] || nil,
+        'og:image': self[:visibility_ssi] == "Public" && change_iiif_image_size(self["thumbnail_path_ss"], '!1200,630') || nil,
         'og:image:type': self[:visibility_ssi] == "Public" && 'image/jpeg' || nil,
-        'og:image:secure_url': self[:visibility_ssi] == "Public" && self["thumbnail_path_ss"] || nil }.compact
+        'og:image:secure_url': self[:visibility_ssi] == "Public" && change_iiif_image_size(self["thumbnail_path_ss"], '!1200,630') || nil }.compact
 
     meta_tag = []
     ogp_metadata.each do |key, value|

--- a/app/views/blacklight_dynamic_sitemap/sitemap/show.xml.builder
+++ b/app/views/blacklight_dynamic_sitemap/sitemap/show.xml.builder
@@ -15,7 +15,7 @@ xml.urlset(
       xml.lastmod(config.format_last_modified&.call(last_modified) || last_modified)
       if doc['visibility_ssi'] == "Public" && doc['thumbnail_path_ss']
         xml.tag!("image:image") do
-          xml.tag!("image:loc", doc['thumbnail_path_ss'])
+          xml.tag!("image:loc", change_iiif_image_size(doc['thumbnail_path_ss'], "!1200,630"))
         end
       end
     end

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe BlacklightHelper, helper: true, style: true do
   include Devise::Test::ControllerHelpers
-  let(:thumbnail_size) { "!1200,630" }
+  let(:thumbnail_size) { "!200,200" }
 
   # used so render_thumbnail can get user info from rspec
   def user_signed_in?

--- a/spec/system/search_result_spec.rb
+++ b/spec/system/search_result_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe 'search result', type: :system, clean: true do
-  let(:thumbnail_size) { "!1200,630" }
+  let(:thumbnail_size) { "!200,200" }
 
   before do
     solr = Blacklight.default_index.connection

--- a/spec/system/show_page_spec.rb
+++ b/spec/system/show_page_spec.rb
@@ -2,6 +2,9 @@
 require 'rails_helper'
 
 RSpec.describe 'Show Page', type: :system, js: true, clean: true do
+  let(:thumbnail_size_in_opengraph) { "!1200,630" }
+  let(:thumbnail_size_in_solr) { "!200,200" }
+
   before do
     stub_request(:get, 'https://yul-dc-development-samples.s3.amazonaws.com/manifests/11/11/111.json')
       .to_return(status: 200, body: File.open(File.join('spec', 'fixtures', '2041002.json')).read)
@@ -42,7 +45,7 @@ RSpec.describe 'Show Page', type: :system, js: true, clean: true do
       creator_tesim: ['Anna Elizabeth Dewdney'],
       child_oids_ssim: [112, 113],
       oid_ssi: 111,
-      thumbnail_path_ss: 'https://this_is_a_iiif_image/iiif/2/17120080/full/!200,200/0/default.jpg',
+      thumbnail_path_ss: "https://this_is_a_iiif_image/iiif/2/17120080/full/#{thumbnail_size_in_solr}/0/default.jpg",
       callNumber_ssim: "call number",
       has_fulltext_ssi: 'Yes',
       series_ssi: "Series 1: Oversize"
@@ -127,7 +130,7 @@ RSpec.describe 'Show Page', type: :system, js: true, clean: true do
       resourceType_ssim: 'Archives or Manuscripts',
       creator_ssim: ['France A. Cordova'],
       oid_ssi: 555,
-      thumbnail_path_ss: 'https://this_is_a_iiif_image/iiif/2/17120080/full/!200,200/0/default.jpg'
+      thumbnail_path_ss: "https://this_is_a_iiif_image/iiif/2/17120080/full/#{thumbnail_size_in_solr}/0/default.jpg"
     }
   end
 
@@ -218,7 +221,7 @@ RSpec.describe 'Show Page', type: :system, js: true, clean: true do
       expect(page).to have_css("meta[property='og:url'][content='https://collections.library.yale.edu/catalog/111']", visible: false)
       expect(page).to have_css("meta[property='og:type'][content='website']", visible: false)
       expect(page).to have_css("meta[property='og:description'][content='Anna Elizabeth Dewdney']", visible: false)
-      expect(page).to have_css("meta[property='og:image'][content='https://this_is_a_iiif_image/iiif/2/17120080/full/!1200,630/0/default.jpg']", visible: false)
+      expect(page).to have_css("meta[property='og:image'][content='https://this_is_a_iiif_image/iiif/2/17120080/full/#{thumbnail_size_in_opengraph}/0/default.jpg']", visible: false)
       expect(page).to have_css("meta[property='og:image:type'][content='image/jpeg']", visible: false)
     end
     it 'has og namespace' do
@@ -231,7 +234,7 @@ RSpec.describe 'Show Page', type: :system, js: true, clean: true do
       visit 'catalog/555'
     end
     it 'does not have image of og tag' do
-      expect(page).not_to have_css("meta[property='og:image'][content='https://this_is_a_iiif_image/iiif/2/17120080/full/!1200,630/0/default.jpg']", visible: false)
+      expect(page).not_to have_css("meta[property='og:image'][content='https://this_is_a_iiif_image/iiif/2/17120080/full/#{thumbnail_size_in_opengraph}/0/default.jpg']", visible: false)
       expect(page).not_to have_css("meta[property='og:image:type'][content='image/jpeg']", visible: false)
     end
   end

--- a/spec/system/show_page_spec.rb
+++ b/spec/system/show_page_spec.rb
@@ -218,7 +218,7 @@ RSpec.describe 'Show Page', type: :system, js: true, clean: true do
       expect(page).to have_css("meta[property='og:url'][content='https://collections.library.yale.edu/catalog/111']", visible: false)
       expect(page).to have_css("meta[property='og:type'][content='website']", visible: false)
       expect(page).to have_css("meta[property='og:description'][content='Anna Elizabeth Dewdney']", visible: false)
-      expect(page).to have_css("meta[property='og:image'][content='https://collections-test.library.yale.edu/iiif/2/17120080/full/!1200x630/0/default.jpg']", visible: false)
+      expect(page).to have_css("meta[property='og:image'][content='https://collections-test.library.yale.edu/iiif/2/17120080/full/!1200,630/0/default.jpg']", visible: false)
       expect(page).to have_css("meta[property='og:image:type'][content='image/jpeg']", visible: false)
     end
     it 'has og namespace' do
@@ -231,7 +231,7 @@ RSpec.describe 'Show Page', type: :system, js: true, clean: true do
       visit 'catalog/555'
     end
     it 'does not have image of og tag' do
-      expect(page).not_to have_css("meta[property='og:image'][content='https://collections-test.library.yale.edu/iiif/2/17120080/full/!1200x630/0/default.jpg']", visible: false)
+      expect(page).not_to have_css("meta[property='og:image'][content='https://collections-test.library.yale.edu/iiif/2/17120080/full/!1200,630/0/default.jpg']", visible: false)
       expect(page).not_to have_css("meta[property='og:image:type'][content='image/jpeg']", visible: false)
     end
   end

--- a/spec/system/show_page_spec.rb
+++ b/spec/system/show_page_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'Show Page', type: :system, js: true, clean: true do
       creator_tesim: ['Anna Elizabeth Dewdney'],
       child_oids_ssim: [112, 113],
       oid_ssi: 111,
-      thumbnail_path_ss: 'https://this/is/an/image',
+      thumbnail_path_ss: 'https://collections-test.library.yale.edu/iiif/2/17120080/full/!200,200/0/default.jpg',
       callNumber_ssim: "call number",
       has_fulltext_ssi: 'Yes',
       series_ssi: "Series 1: Oversize"
@@ -127,7 +127,7 @@ RSpec.describe 'Show Page', type: :system, js: true, clean: true do
       resourceType_ssim: 'Archives or Manuscripts',
       creator_ssim: ['France A. Cordova'],
       oid_ssi: 555,
-      thumbnail_path_ss: 'https://this/is/an/image'
+      thumbnail_path_ss: 'https://collections-test.library.yale.edu/iiif/2/17120080/full/!200,200/0/default.jpg'
     }
   end
 
@@ -218,7 +218,7 @@ RSpec.describe 'Show Page', type: :system, js: true, clean: true do
       expect(page).to have_css("meta[property='og:url'][content='https://collections.library.yale.edu/catalog/111']", visible: false)
       expect(page).to have_css("meta[property='og:type'][content='website']", visible: false)
       expect(page).to have_css("meta[property='og:description'][content='Anna Elizabeth Dewdney']", visible: false)
-      expect(page).to have_css("meta[property='og:image'][content='https://this/is/an/image']", visible: false)
+      expect(page).to have_css("meta[property='og:image'][content='https://collections-test.library.yale.edu/iiif/2/17120080/full/!1200x630/0/default.jpg']", visible: false)
       expect(page).to have_css("meta[property='og:image:type'][content='image/jpeg']", visible: false)
     end
     it 'has og namespace' do
@@ -231,7 +231,7 @@ RSpec.describe 'Show Page', type: :system, js: true, clean: true do
       visit 'catalog/555'
     end
     it 'does not have image of og tag' do
-      expect(page).not_to have_css("meta[property='og:image'][content='https://this/is/an/image']", visible: false)
+      expect(page).not_to have_css("meta[property='og:image'][content='https://collections-test.library.yale.edu/iiif/2/17120080/full/!1200x630/0/default.jpg']", visible: false)
       expect(page).not_to have_css("meta[property='og:image:type'][content='image/jpeg']", visible: false)
     end
   end

--- a/spec/system/show_page_spec.rb
+++ b/spec/system/show_page_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'Show Page', type: :system, js: true, clean: true do
       creator_tesim: ['Anna Elizabeth Dewdney'],
       child_oids_ssim: [112, 113],
       oid_ssi: 111,
-      thumbnail_path_ss: 'https://collections-test.library.yale.edu/iiif/2/17120080/full/!200,200/0/default.jpg',
+      thumbnail_path_ss: 'https://this_is_a_iiif_image/iiif/2/17120080/full/!200,200/0/default.jpg',
       callNumber_ssim: "call number",
       has_fulltext_ssi: 'Yes',
       series_ssi: "Series 1: Oversize"
@@ -127,7 +127,7 @@ RSpec.describe 'Show Page', type: :system, js: true, clean: true do
       resourceType_ssim: 'Archives or Manuscripts',
       creator_ssim: ['France A. Cordova'],
       oid_ssi: 555,
-      thumbnail_path_ss: 'https://collections-test.library.yale.edu/iiif/2/17120080/full/!200,200/0/default.jpg'
+      thumbnail_path_ss: 'https://this_is_a_iiif_image/iiif/2/17120080/full/!200,200/0/default.jpg'
     }
   end
 
@@ -218,7 +218,7 @@ RSpec.describe 'Show Page', type: :system, js: true, clean: true do
       expect(page).to have_css("meta[property='og:url'][content='https://collections.library.yale.edu/catalog/111']", visible: false)
       expect(page).to have_css("meta[property='og:type'][content='website']", visible: false)
       expect(page).to have_css("meta[property='og:description'][content='Anna Elizabeth Dewdney']", visible: false)
-      expect(page).to have_css("meta[property='og:image'][content='https://collections-test.library.yale.edu/iiif/2/17120080/full/!1200,630/0/default.jpg']", visible: false)
+      expect(page).to have_css("meta[property='og:image'][content='https://this_is_a_iiif_image/iiif/2/17120080/full/!1200,630/0/default.jpg']", visible: false)
       expect(page).to have_css("meta[property='og:image:type'][content='image/jpeg']", visible: false)
     end
     it 'has og namespace' do
@@ -231,7 +231,7 @@ RSpec.describe 'Show Page', type: :system, js: true, clean: true do
       visit 'catalog/555'
     end
     it 'does not have image of og tag' do
-      expect(page).not_to have_css("meta[property='og:image'][content='https://collections-test.library.yale.edu/iiif/2/17120080/full/!1200,630/0/default.jpg']", visible: false)
+      expect(page).not_to have_css("meta[property='og:image'][content='https://this_is_a_iiif_image/iiif/2/17120080/full/!1200,630/0/default.jpg']", visible: false)
       expect(page).not_to have_css("meta[property='og:image:type'][content='image/jpeg']", visible: false)
     end
   end

--- a/spec/system/sitemap_show_spec.rb
+++ b/spec/system/sitemap_show_spec.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe 'Sitemap Show', type: :feature do
-  let(:thumbnail_size) { "!1200,630" }
+  let(:thumbnail_size_in_sitemap) { "!1200,630" }
+  let(:thumbnail_size_in_solr) { "!200,200" }
 
   before do
     solr = Blacklight.default_index.connection
@@ -23,7 +24,7 @@ RSpec.describe 'Sitemap Show', type: :feature do
       isbn_ssim: '2321321389',
       timestamp: "2021-04-05T17:43:23.382Z",
       description_tesim: "Handsome Dan is a bulldog who serves as Yale Univeristy's mascot.",
-      thumbnail_path_ss: "http://localhost:8182/iiif/2/10962176/full/#{thumbnail_size}/0/default.jpg",
+      thumbnail_path_ss: "http://localhost:8182/iiif/2/10962176/full/#{thumbnail_size_in_solr}/0/default.jpg",
       visibility_ssi: 'Public',
       year_isim: (600..1050).to_a
     }
@@ -44,7 +45,7 @@ RSpec.describe 'Sitemap Show', type: :feature do
       timestamp: "2021-04-05T17:43:23.382Z",
       description_tesim: "Handsome Dan is a bulldog who serves as Yale Univeristy's mascot.",
       visibility_ssi: 'Public',
-      thumbnail_path_ss: "http://localhost:8182/iiif/2/10962124/full/#{thumbnail_size}/0/default.jpg",
+      thumbnail_path_ss: "http://localhost:8182/iiif/2/10962124/full/#{thumbnail_size_in_solr}/0/default.jpg",
       year_isim: (1920..2000).to_a
     }
   end
@@ -64,7 +65,7 @@ RSpec.describe 'Sitemap Show', type: :feature do
       timestamp: "2021-04-05T17:43:23.382Z",
       description_tesim: "Handsome Dan is a bulldog who serves as Yale Univeristy's mascot.",
       visibility_ssi: 'Public',
-      thumbnail_path_ss: "http://localhost:8182/iiif/2/10962124/full/#{thumbnail_size}/0/default.jpg",
+      thumbnail_path_ss: "http://localhost:8182/iiif/2/10962124/full/#{thumbnail_size_in_solr}/0/default.jpg",
       year_isim: [1900]
     }
   end
@@ -84,7 +85,7 @@ RSpec.describe 'Sitemap Show', type: :feature do
       timestamp: "2021-04-05T17:43:23.382Z",
       description_tesim: "Handsome Dan is a bulldog who serves as Yale Univeristy's mascot.",
       visibility_ssi: 'Yale Community Only',
-      thumbnail_path_ss: "http://localhost:8182/iiif/2/10962334/full/#{thumbnail_size}/0/default.jpg",
+      thumbnail_path_ss: "http://localhost:8182/iiif/2/10962334/full/#{thumbnail_size_in_solr}/0/default.jpg",
       year_isim: [2020, 2021]
     }
   end
@@ -104,7 +105,7 @@ RSpec.describe 'Sitemap Show', type: :feature do
       timestamp: "2021-04-05T17:43:23.382Z",
       description_tesim: "Handsome Dan is a bulldog who serves as Yale Univeristy's mascot.",
       visibility_ssi: 'Private',
-      thumbnail_path_ss: "http://localhost:8182/iiif/2/10962664/full/#{thumbnail_size}/0/default.jpg",
+      thumbnail_path_ss: "http://localhost:8182/iiif/2/10962664/full/#{thumbnail_size_in_solr}/0/default.jpg",
       year_isim: [2020, 2021]
     }
   end
@@ -126,11 +127,11 @@ RSpec.describe 'Sitemap Show', type: :feature do
   end
   it 'does render a thumbnail for public images' do
     visit blacklight_dynamic_sitemap.sitemap_path('2')
-    expect(page.body).to include("<image:loc>http://localhost:8182/iiif/2/10962124/full/#{thumbnail_size}/0/default.jpg</image:loc>")
+    expect(page.body).to include("<image:loc>http://localhost:8182/iiif/2/10962124/full/#{thumbnail_size_in_sitemap}/0/default.jpg</image:loc>")
   end
   it 'does not render a thumbnail for non-public images' do
     visit blacklight_dynamic_sitemap.sitemap_path('0')
-    expect(page).not_to have_content("http://localhost:8182/iiif/2/10962334/full/#{thumbnail_size}/0/default.jpg")
+    expect(page).not_to have_content("http://localhost:8182/iiif/2/10962334/full/#{thumbnail_size_in_sitemap}/0/default.jpg")
   end
   it 'does not display a private record' do
     visit blacklight_dynamic_sitemap.sitemap_path('0')

--- a/spec/system/view_images_in_search_spec.rb
+++ b/spec/system/view_images_in_search_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Search results displays images', type: :system, clean: true, js: true do
-  let(:thumbnail_size) { "!1200,630" }
+  let(:thumbnail_size) { "!200,200" }
 
   before do
     solr = Blacklight.default_index.connection


### PR DESCRIPTION
This is done only on the blacklight side, by editing the value of thumbnail_ss url that is in SOLR, so thumbnail_ss in SOLR does not need to change.  All other places where thumbnail_ss is used will not change.