### PR TITLE
Added DCS homepage link to the search result page

### DIFF
--- a/app/views/shared/_search_bar.html.erb
+++ b/app/views/shared/_search_bar.html.erb
@@ -9,7 +9,7 @@
   
   <div class="user-subheader" role="heading" aria-level="1">
     <div class="user-subheader-title">
-      Digital Collections
+      <a href="https://collections.library.yale.edu/">Digital Collections</a>
     </div>
   </div>
 <%end%>


### PR DESCRIPTION
**Story**
Users who have searched the DCS would benefit from a way to return to the DCS homepage after conducting a search. A link to https://collections.library.yale.edu/ should be added to the "Digital Collections" text on the left side of the search results page (this is the text above the search limits).

**Acceptance**
- [ ] Link is added and directs users to https://collections.library.yale.edu/