### PR TITLE
1970 allow links in desc

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -223,7 +223,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'creationPlace_ssim', label: 'Publication Place', metadata: 'description'
     config.add_show_field 'publisher_ssim', label: 'Publisher', metadata: 'description'
     config.add_show_field 'abstract_tesim', label: 'Abstract', metadata: 'description', helper_method: :join_as_paragraphs
-    config.add_show_field 'description_tesim', label: 'Description', metadata: 'description', helper_method: :html_safe_join_with_br
+    config.add_show_field 'description_tesim', label: 'Description', metadata: 'description', helper_method: :sanitize_join_with_br
     config.add_show_field 'extent_ssim', label: 'Extent', metadata: 'description', helper_method: :join_with_br
     config.add_show_field 'extentOfDigitization_ssim', label: 'Extent of Digitization', metadata: 'description'
     config.add_show_field 'digitization_note_tesi', label: 'Digitization Note', metadata: 'description'
@@ -266,7 +266,7 @@ class CatalogController < ApplicationController
     # Access and Usage Rights Group
     config.add_show_field 'visibility_ssi', label: 'Access', metadata: 'access_and_usage_rights'
     config.add_show_field 'redirect_to_tesi', label: 'Redirect To', metadata: 'access_and_usage_rights'
-    config.add_show_field 'rights_ssim', label: 'Rights', metadata: 'access_and_usage_rights', helper_method: :html_safe_converter
+    config.add_show_field 'rights_ssim', label: 'Rights', metadata: 'access_and_usage_rights', helper_method: :sanitize_first_value
     config.add_show_field 'preferredCitation_tesim', label: 'Citation', metadata: 'access_and_usage_rights', helper_method: :join_with_br
 
     # Identifiers Group

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -223,7 +223,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'creationPlace_ssim', label: 'Publication Place', metadata: 'description'
     config.add_show_field 'publisher_ssim', label: 'Publisher', metadata: 'description'
     config.add_show_field 'abstract_tesim', label: 'Abstract', metadata: 'description', helper_method: :join_as_paragraphs
-    config.add_show_field 'description_tesim', label: 'Description', metadata: 'description', helper_method: :join_with_br
+    config.add_show_field 'description_tesim', label: 'Description', metadata: 'description', helper_method: :html_safe_join_with_br
     config.add_show_field 'extent_ssim', label: 'Extent', metadata: 'description', helper_method: :join_with_br
     config.add_show_field 'extentOfDigitization_ssim', label: 'Extent of Digitization', metadata: 'description'
     config.add_show_field 'digitization_note_tesi', label: 'Digitization Note', metadata: 'description'

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -83,6 +83,11 @@ module BlacklightHelper
     safe_join(values, '<br/>'.html_safe)
   end
 
+  def html_safe_join_with_br(arg)
+    values = arg[:document][arg[:field]]
+    sanitize_values(values)
+  end
+
   def join_as_paragraphs(arg)
     values = arg[:value]
     '<p>'.html_safe + safe_join(values, '</p><p>'.html_safe) + '</p>'.html_safe if values
@@ -351,6 +356,10 @@ module BlacklightHelper
   def html_safe_converter(arg)
     value = arg[:value].first
     values = value.split("\n")
+    sanitize_values(values)
+  end
+
+  def sanitize_values(values)
     sanitized_values = []
     values.each do |v|
       sanitized_values << sanitize(v, tags: %w[a], attributes: %w[href])

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -83,7 +83,7 @@ module BlacklightHelper
     safe_join(values, '<br/>'.html_safe)
   end
 
-  def html_safe_join_with_br(arg)
+  def sanitize_join_with_br(arg)
     values = arg[:document][arg[:field]]
     sanitize_values(values)
   end
@@ -353,7 +353,7 @@ module BlacklightHelper
     link_to(arg[:value][0], arg[:value][0])
   end
 
-  def html_safe_converter(arg)
+  def sanitize_first_value(arg)
     value = arg[:value].first
     values = value.split("\n")
     sanitize_values(values)

--- a/spec/system/view_fields_in_display_spec.rb
+++ b/spec/system/view_fields_in_display_spec.rb
@@ -47,7 +47,7 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       format: 'three dimensional object',
       url_suppl_ssim: 'http://0.0.0.0:3000/catalog/111',
       language_ssim: ['en', 'eng', 'zz'],
-      description_tesim: ["Handsome Dan is a bulldog who serves as Yale Univeristy's mascot.", "here is something else about it"],
+      description_tesim: ["<a href='https://news.yale.edu/2021/03/18/meet-handsome-dan-xix' class='dontallow'>Handsome Dan</a> is a bulldog who serves as Yale Univeristy's mascot.", "here is more"],
       visibility_ssi: 'Public',
       digitization_note_tesi: "Digitization note",
       abstract_tesim: ["this is an abstract", "abstract2"],
@@ -134,8 +134,7 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
     end
     it 'displays description in results' do
       expect(document).to have_content("Handsome Dan is a bulldog who serves as Yale Univeristy's mascot.")
-      # extent should be separated by new line
-      expect(page).to have_text("Handsome Dan is a bulldog who serves as Yale Univeristy's mascot.here is something else about it")
+      expect(page.html).to include('<a href="https://news.yale.edu/2021/03/18/meet-handsome-dan-xix">Handsome Dan</a> is a bulldog who serves as Yale Univeristy\'s mascot.<br/>here is more')
     end
     it 'displays the Abstract in results' do
       expect(page.html).to match("<p>this is an abstract</p><p>abstract2</p>")


### PR DESCRIPTION
- Allows links in Description field in show page
- Factor out `sanitize_values` for use by `sanitize_first_value` (which just uses the first value and splits at linebreaks and joins with `<br/>`) and  `sanitize_join_with_br` (which joins all values in `<br/>)`
- Renamed `html_safe_converter` to `sanitize_first_value` to make it a clear how it differs from `sanitize_join_with_br`