### PR TITLE
Enable resize from full screen

### DIFF
--- a/config/uv/uv.html
+++ b/config/uv/uv.html
@@ -93,17 +93,18 @@
     <div id="uv" class="uv"></div>
 
     <script>
-        $(function () {
-            var $UV = $('#uv');
+        document.addEventListener("DOMContentLoaded", function () {
+            var $UV = document.getElementById("uv");
+
             function resize() {
-                var windowWidth = window.innerWidth;
-                var windowHeight = window.innerHeight;
-                $UV.width(windowWidth);
-                $UV.height(windowHeight);
+                $UV.setAttribute("style", "width:" + window.innerWidth + "px");
+                $UV.setAttribute("style", "height:" + window.innerHeight + "px");
             }
-            $(window).on('resize', function () {
+
+            document.addEventListener("resize", function () {
                 resize();
             });
+
             resize();
         });
     </script>

--- a/public/uv/uv.html
+++ b/public/uv/uv.html
@@ -93,17 +93,18 @@
     <div id="uv" class="uv"></div>
 
     <script>
-        $(function () {
-            var $UV = $('#uv');
+        document.addEventListener("DOMContentLoaded", function () {
+            var $UV = document.getElementById("uv");
+
             function resize() {
-                var windowWidth = window.innerWidth;
-                var windowHeight = window.innerHeight;
-                $UV.width(windowWidth);
-                $UV.height(windowHeight);
+                $UV.setAttribute("style", "width:" + window.innerWidth + "px");
+                $UV.setAttribute("style", "height:" + window.innerHeight + "px");
             }
-            $(window).on('resize', function () {
+
+            document.addEventListener("resize", function () {
                 resize();
             });
+
             resize();
         });
     </script>


### PR DESCRIPTION
# Summary
Upon resizing UV from full screen there was a bug that put some controls and parts of the image unavailable to the user.  This PR adjusts the resize function to use UV4 example syntax and restores the UV to the appropriate size and with all options upon exiting full screen.

# Related Ticket
[#1987](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1987)

# Video

https://user-images.githubusercontent.com/36549923/163486204-e2a93669-00f7-4cdc-a028-3a8dc8c20a19.mp4


