### PR TITLE
Adds cache meta tags on UV3 uv.html

### DIFF
--- a/config/uv/uv.html
+++ b/config/uv/uv.html
@@ -6,6 +6,9 @@
         This is what the embed iframe src links to. It doesn't need to communicate with the parent page, only fill the available space and look for #? parameters
     -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <meta http-equiv="Cache-Control" content="no-cache" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
     <link rel="icon" href="favicon.ico">
     <link rel="stylesheet" type="text/css" href="uv.css">
     <script type="text/javascript" src="lib/offline.js"></script>

--- a/public/uv/uv.html
+++ b/public/uv/uv.html
@@ -6,6 +6,9 @@
         This is what the embed iframe src links to. It doesn't need to communicate with the parent page, only fill the available space and look for #? parameters
     -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <meta http-equiv="Cache-Control" content="no-cache" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
     <link rel="icon" href="favicon.ico">
     <link rel="stylesheet" type="text/css" href="uv.css">
     <script type="text/javascript" src="lib/offline.js"></script>


### PR DESCRIPTION
## Summary
Adds cache meta tags to the uv.html file for UV3

## Related Ticket
[2041](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/2041)

## Screenshots

### Before
![Screen Shot 2022-04-26 at 12 24 38 PM](https://user-images.githubusercontent.com/39319859/165397882-998423c7-5a74-4350-860b-70e35db94ae2.JPG)


### After
![Screen Shot 2022-04-26 at 1 00 20 PM](https://user-images.githubusercontent.com/39319859/165397896-8a254487-f56c-41f3-af96-2efdcf4f9bdd.JPG)

