### PR TITLE
Update UV4 to most current published version and fix Safari exit fullscreen issue

### DIFF
--- a/app/views/catalog/_uv.html.erb
+++ b/app/views/catalog/_uv.html.erb
@@ -9,6 +9,7 @@
 <div class='uv-container'>
 <iframe
     class='universal-viewer-iframe'
+    id='uv-iframe'
     title='Universal Viewer'
     src='<%= request&.base_url %>/uv/uv.html#?manifest=<%= manifest_url(oid) %><%= order_param %><%= uv_fulltext_search_param %>'
     width='924'

--- a/config/uv/uv.html
+++ b/config/uv/uv.html
@@ -98,13 +98,15 @@
     <script>
         window.addEventListener("DOMContentLoaded", function () {
             var $UV = document.getElementById("uv");
+            var $UV_Iframe = document.getElementById("uv-iframe");
 
             function resize() {
                 $UV.setAttribute("style", `width: ${window.innerWidth}px`);
-                $UV.setAttribute("style", `height: ${window.innerHeight}px`);
+                $UV.setAttribute("style", `height: ${window.innerHeight}px`); 
             }
 
             window.addEventListener("resize", function () {
+                $UV_Iframe.contentDocument.location.reload(true)
                 resize();
             });
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "three": "0.137.0",
     "trim-newlines": "^4.0.2",
     "turbolinks": "^5.2.0",
-    "universalviewer": "^4.0.0-pre.103",
+    "universalviewer": "^4.0.0-pre.105",
     "ws": "^7.4.6",
     "xmldom": "^0.6.0",
     "yargs-parser": "^13.1.2"


### PR DESCRIPTION
## Summary 
Update UV4 to most current published version and fix Safari exit fullscreen issue.

## Related Ticket
[2054](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/2054)

## Screencast

https://user-images.githubusercontent.com/39319859/166499673-2fde503a-ce61-4bd2-ba32-d0aa97bd7197.mp4




