### PR TITLE
Adds rel="noopener" attribute to footer links per Sonarcloud feedback

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -5,19 +5,19 @@
       <div class="footer-links">
         <ul>
           <li>
-            <a href="http://web.library.yale.edu/gsearch" target="_blank">Search</a>
+            <a href="http://web.library.yale.edu/gsearch" target="_blank" rel="noopener">Search</a>
           </li>
           <li>
-            <a href="http://www.library.yale.edu/librarynews" target="_blank">News</a>
+            <a href="http://www.library.yale.edu/librarynews" target="_blank" rel="noopener">News</a>
           </li>
           <li>
-            <a href="http://status.library.yale.edu" target="_blank">Systems Status</a>
+            <a href="http://status.library.yale.edu" target="_blank" rel="noopener">Systems Status</a>
           </li>
           <li>
-            <a href="http://www.yale.edu/privacy.html" target="_blank">Privacy Policy</a>
+            <a href="http://www.yale.edu/privacy.html" target="_blank" rel="noopener">Privacy Policy</a>
           </li>
           <li>
-            <a href="https://guides.library.yale.edu/about/policies/access" target="_blank">Terms</a>
+            <a href="https://guides.library.yale.edu/about/policies/access" target="_blank" rel="noopener">Terms</a>
           </li>
           <!--<% url = request.path() %>-->
           <% url = request.original_url %>
@@ -25,28 +25,28 @@
             <%= link_to(:"Feedback", "http://web.library.yale.edu/form/findit-feedback?findITURL=#{url}", :target => '_blank' ) %>
           </li>
           <li>
-            <a href="https://web.library.yale.edu/data-use" target="_blank">Data Use</a>
+            <a href="https://web.library.yale.edu/data-use" target="_blank" rel="noopener">Data Use</a>
           </li>
           <li>
-            <a href="https://usability.yale.edu/web-accessibility/accessibility-yale" target="_blank">Accessibility at Yale</a>
+            <a href="https://usability.yale.edu/web-accessibility/accessibility-yale" target="_blank" rel="noopener">Accessibility at Yale</a>
           </li>
         </ul>
       </div>
     </div>
     <div class="footer-socmedia">
-      <a href="http://yaleuniversity.tumblr.com/" target="_blank">
+      <a href="http://yaleuniversity.tumblr.com/" target="_blank" rel="noopener">
         <%= image_tag("soc_media/icon_tumblr.png", {id: 'tumblr', alt: 'Yale University Tumblr'})%>
         <span class="sr-only">Yale University Library on Tumblr</span>
       </a>
-      <a href="https://www.instagram.com/yalelibrary" target="_blank">
+      <a href="https://www.instagram.com/yalelibrary" target="_blank" rel="noopener">
         <%= image_tag("soc_media/icon_instagram.png", {id: 'instagram', alt: 'Yale Library Instagram'})%>
         <span class="sr-only">Yale University Library on Instagram</span>
       </a>
-      <a href="https://twitter.com/yalelibrary" target="_blank">
+      <a href="https://twitter.com/yalelibrary" target="_blank" rel="noopener">
         <%= image_tag("soc_media/icon_twitter.png", {id: 'twitter', alt: 'Yale Library Twitter'})%>
       <span class="sr-only">Yale University Library on Twitter</span>
       </a>
-      <a href="https://www.facebook.com/yalelibrary" target="_blank">
+      <a href="https://www.facebook.com/yalelibrary" target="_blank" rel="noopener">
         <%= image_tag("soc_media/icon_facebook.png", {id: 'facebook', alt: 'Yale Library Facebook'}) %>
         <span class="sr-only">Yale University Library Facebook Page</span>
       </a>


### PR DESCRIPTION
## Summary
Adds rel="noopener" attribute to all footer links per Sonarcloud feedback. The ticket said "external" links but Sonarcloud flagged all links within the footer with the exception of the erb link to "Feedback". Please advise if you would like this attribute added here as well.

![image](https://user-images.githubusercontent.com/39319859/166842106-f9d25853-de89-43f4-be21-671972843df9.png)

## Related Ticket
[2058](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/2058)