### PR TITLE
Adds alt text to placeholder restricted image

### DIFF
--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -385,7 +385,9 @@ module BlacklightHelper
 
   def render_thumbnail(document, _options)
     # return placeholder image if not logged in for yale only works
-    return image_tag('placeholder_restricted.png', alt: 'Access Available on YALE network only due to copyright or other restrictions. OFF-SITE? Log in with NetID') unless client_can_view_digital?(document)
+    unless client_can_view_digital?(document)
+      return image_tag('placeholder_restricted.png', alt: 'Access Available on YALE network only due to copyright or other restrictions. OFF-SITE? Log in with NetID')
+    end
     url = document[:thumbnail_path_ss]
     if url.present?
       error_image_url = image_url('image_not_found.png')

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -385,7 +385,7 @@ module BlacklightHelper
 
   def render_thumbnail(document, _options)
     # return placeholder image if not logged in for yale only works
-    return image_tag('placeholder_restricted.png') unless client_can_view_digital?(document)
+    return image_tag('placeholder_restricted.png', alt: 'Access Available on YALE network only due to copyright or other restrictions. OFF-SITE? Log in with NetID') unless client_can_view_digital?(document)
     url = document[:thumbnail_path_ss]
     if url.present?
       error_image_url = image_url('image_not_found.png')

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -157,8 +157,10 @@ RSpec.describe BlacklightHelper, helper: true, style: true do
           .to_return(status: 200, body: File.open("spec/fixtures/images/Sun.png").read, headers: { "Content-Type" => /image\/.+/ })
       end
 
-      it 'returns placeholder when logged out' do
-        expect(helper.render_thumbnail(yale_only_document, {})).to include("<img src=\"/assets/placeholder_restricted-")
+      it 'returns placeholder with alt text when logged out' do
+        placeholder_image = "/assets/placeholder_restricted-"
+        alt_text = "Access Available on YALE network only due to copyright or other restrictions. OFF-SITE? Log in with NetID"
+        expect(helper.render_thumbnail(yale_only_document, {})).to include(alt_text, placeholder_image)
       end
 
       it 'returns image when logged in' do


### PR DESCRIPTION
## Summary
Adds alt text to placeholder_restricted image.

## Related Ticket
[2062](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/2062)

## Screenshot
![image](https://user-images.githubusercontent.com/39319859/167908228-5080a87c-7e5d-4d45-a3b3-4bdc54e28f2b.png)
