### PR TITLE
Redirect for UV4 iframe link

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,7 +56,7 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
   get '/pdfs/*id', to: 'pdfs#show', as: :pdf
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 
-  get '/uv.html', to: redirect { |_params, request| URI.parse(request.original_url).query ? "/posts?#{URI.parse(request.original_url).query}" : "/uv/uv.html" }
+  get '/uv.html', to: redirect { |_params, request| URI.parse(request.original_url).query ? "/uv.html?#{URI.parse(request.original_url).query}" : "/uv/uv.html" }
 
   # Match all unknown paths to the 404 page
   Rails.application.routes.draw do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,8 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
   get '/pdfs/*id', to: 'pdfs#show', as: :pdf
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 
+  get '/uv.html', to: redirect { |params, request| URI.parse(request.original_url).query ? "/posts?#{URI.parse(request.original_url).query}" : "/uv/uv.html" }
+
   # Match all unknown paths to the 404 page
   Rails.application.routes.draw do
     match '*path' => 'errors#not_found', via: :all

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,7 +56,7 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
   get '/pdfs/*id', to: 'pdfs#show', as: :pdf
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 
-  get '/uv.html', to: redirect { |_params, request| URI.parse(request.original_url).query ? "/uv.html?#{URI.parse(request.original_url).query}" : "/uv/uv.html" }
+  get '/uv.html', to: redirect { |_params, request| URI.parse(request.original_url).query ? "/uv/uv.html?#{URI.parse(request.original_url).query}" : "/uv/uv.html" }
 
   # Match all unknown paths to the 404 page
   Rails.application.routes.draw do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,7 +56,7 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
   get '/pdfs/*id', to: 'pdfs#show', as: :pdf
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 
-  get '/uv.html', to: redirect { |params, request| URI.parse(request.original_url).query ? "/posts?#{URI.parse(request.original_url).query}" : "/uv/uv.html" }
+  get '/uv.html', to: redirect { |_params, request| URI.parse(request.original_url).query ? "/posts?#{URI.parse(request.original_url).query}" : "/uv/uv.html" }
 
   # Match all unknown paths to the 404 page
   Rails.application.routes.draw do


### PR DESCRIPTION
The iframe link in the share panel in UV4 links to `/uv.html` instead of `/uv/uv.html`.   This is probably because of the embedded flag/not having access to the containing iframe.   This PR adds a redirect so that the iframe works.