### PR TITLE
Change parent OID filter to a filter query

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -628,7 +628,7 @@ class CatalogController < ApplicationController
       "rows": 0,
       "facet.field": "child_fulltext_wstsim",
       "facet": "on",
-      "q": "parent_ssi:#{@document_id}",
+      "fq": "parent_ssi:#{@document_id}",
       "facet.contains": @query,
       "facet.contains.ignoreCase": "true"
     }


### PR DESCRIPTION
Changes SOLR query for the children based on parent OID from `q` to `fq`  yalelibrary/YUL-DC#2095