### PR TITLE
Adds digitization funding source to catalog item show page

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -227,6 +227,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'extent_ssim', label: 'Extent', metadata: 'description', helper_method: :join_with_br
     config.add_show_field 'extentOfDigitization_ssim', label: 'Extent of Digitization', metadata: 'description'
     config.add_show_field 'digitization_note_tesi', label: 'Digitization Note', metadata: 'description'
+    config.add_show_field 'digitization_funding_source_tesi', label: 'Digitization Funding Source', metadata: 'description'
     config.add_show_field 'projection_tesim', label: 'Projection', metadata: 'description'
     config.add_show_field 'scale_tesim', label: 'Scale', metadata: 'description'
     config.add_show_field 'coordinateDisplay_ssim', label: 'Coordinates', metadata: 'description'

--- a/spec/system/view_fields_in_display_spec.rb
+++ b/spec/system/view_fields_in_display_spec.rb
@@ -50,6 +50,7 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       description_tesim: ["<a href='https://news.yale.edu/2021/03/18/meet-handsome-dan-xix' class='dontallow'>Handsome Dan</a> is a bulldog who serves as Yale Univeristy's mascot.", "here is more"],
       visibility_ssi: 'Public',
       digitization_note_tesi: "Digitization note",
+      digitization_funding_source_tesi: "Digitization Funding Source",
       abstract_tesim: ["this is an abstract", "abstract2"],
       alternativeTitle_tesim: ["this is an alternative title", "this is the second alternative title"],
       genre_ssim: ["this is the genre", "this is the second genre"],
@@ -166,6 +167,9 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
     end
     it 'displays the digitization note' do
       expect(document).to have_content("Digitization note")
+    end
+    it 'displays the digitization funding source' do
+      expect(document).to have_content("Digitization Funding Source")
     end
     it 'displays the Access in results' do
       expect(document).to have_content("Public")


### PR DESCRIPTION
## Summary
Adds digitization funding source to catalog item show page

## Related Ticket
[#2180](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/2180)

## Screenshot
![BL show page](https://user-images.githubusercontent.com/39319859/187802849-37e77949-4fd4-4497-80b8-3eaf997ad94c.JPG)
