### PR TITLE
Suppress Yale Community Only snippets in full text search results

### DIFF
--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -413,6 +413,7 @@ module BlacklightHelper
   end
 
   def fulltext_snippet_separation(options = {})
+    return unless client_can_view_digital?(options[:document])
     # Some snippets come back with new lines embedded without them. We don't want that.
     # We do however want new lines after a snippet, to show separation
     # the "tr" below has to use double quotes, otherwise it will remove the character 'n', instead of new line notations

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -10,8 +10,19 @@ RSpec.describe BlacklightHelper, helper: true, style: true do
   end
 
   describe '#fulltext_snippet_separation' do
+    let(:document) do
+      SolrDocument.new(
+      id: 'fulltext',
+      visibility_ssi: 'Public',
+      fulltext_tesim: ["This is a test.\n\nThis is the OCR <span class='search-highlight'>text</span>", " for 1030368.\n\nSearch for some <span class='search-highlight'>text</span> to see"]
+    )
+    end
+
     it 'separates the snippets by line breaks' do
-      options = { value: ["This is a test.\n\nThis is the OCR <span class='search-highlight'>text</span>", " for 1030368.\n\nSearch for some <span class='search-highlight'>text</span> to see"] }
+      options = {
+        value: ["This is a test.\n\nThis is the OCR <span class='search-highlight'>text</span>", " for 1030368.\n\nSearch for some <span class='search-highlight'>text</span> to see"],
+        document: document
+      }
 
       expect(helper.fulltext_snippet_separation(options)).to eq(
         "<p>This is a test.  This is the OCR <span class=\"search-highlight\">text</span><br> for 1030368.  Search for some <span class=\"search-highlight\">text</span> to see</p>"

--- a/spec/system/fulltext_search_spec.rb
+++ b/spec/system/fulltext_search_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Fulltext search', type: :system, clean: true, js: true do
+  let(:user) { FactoryBot.create(:user) }
+  let(:public_work) do
+    {
+      "id": "2034600",
+      "title_tesim": ["[Map of China]. [public copy]"],
+      "visibility_ssi": "Public"
+    }
+  end
+  let(:child_work) do
+    {
+      "id": "998833",
+      "parent_ssi": "2034600",
+      "child_fulltext_wstsim": ["This is the full text public"]
+    }
+  end
+  let(:yale_work) do
+    {
+      "id": "1618909",
+      "title_tesim": ["[Map of China]. [yale-only copy]"],
+      "visibility_ssi": "Yale Community Only"
+    }
+  end
+  let(:child_work_yale_only) do
+    {
+      "id": "998834",
+      "parent_ssi": "1618909",
+      "child_fulltext_wstsim": ["This is the full text Yale only"]
+    }
+  end
+
+  before do
+    solr = Blacklight.default_index.connection
+    solr.add([public_work, yale_work, child_work, child_work_yale_only])
+    solr.commit
+  end
+
+  context 'User with all permissions' do
+    before do
+      sign_in user
+    end
+    
+    it 'can view all full text search results' do
+      visit '/catalog?search_field=fulltext_tesim&fulltext_search=2&q=full'
+      expect(page).to have_content 'full text Yale only'
+      expect(page).to have_content 'full text public'
+    end
+  end
+
+  context 'User with some permissions' do
+    before do
+      allow(User).to receive(:on_campus?).and_return(true)
+    end
+
+    it 'can see some but not all full text search results' do
+      visit '/catalog?search_field=fulltext_tesim&fulltext_search=2&q=full'
+      expect(page).not_to have_content 'full text Yale only'
+      expect(page).to have_content 'full text public'
+    end
+  end
+
+  context 'User with no permissions' do
+    before do
+      allow(User).to receive(:on_campus?).and_return(false)
+    end
+
+    it 'cannot view YCO full text search results' do
+      visit '/catalog?search_field=fulltext_tesim&fulltext_search=2&q=full'
+      expect(page).not_to have_content 'full text Yale only'
+      expect(page).to have_content 'full text public'
+    end
+  end
+end

--- a/spec/system/fulltext_search_spec.rb
+++ b/spec/system/fulltext_search_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'Fulltext search', type: :system, clean: true, js: true do
     before do
       sign_in user
     end
-    
+
     it 'can view all full text search results' do
       visit '/catalog?search_field=fulltext_tesim&fulltext_search=2&q=full'
       expect(page).to have_content 'full text Yale only'

--- a/spec/system/fulltext_search_spec.rb
+++ b/spec/system/fulltext_search_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe 'Fulltext search', type: :system, clean: true, js: true do
     {
       "id": "2034600",
       "title_tesim": ["[Map of China]. [public copy]"],
+      "fulltext_tesim": ["This is the full text public"],
       "visibility_ssi": "Public"
     }
   end
@@ -22,6 +23,7 @@ RSpec.describe 'Fulltext search', type: :system, clean: true, js: true do
     {
       "id": "1618909",
       "title_tesim": ["[Map of China]. [yale-only copy]"],
+      "fulltext_tesim": ["This is the full text Yale only"],
       "visibility_ssi": "Yale Community Only"
     }
   end
@@ -41,7 +43,7 @@ RSpec.describe 'Fulltext search', type: :system, clean: true, js: true do
 
   context 'User with all permissions' do
     before do
-      sign_in user
+      login_as user
     end
 
     it 'can view all full text search results' do
@@ -58,7 +60,7 @@ RSpec.describe 'Fulltext search', type: :system, clean: true, js: true do
 
     it 'can see some but not all full text search results' do
       visit '/catalog?search_field=fulltext_tesim&fulltext_search=2&q=full'
-      expect(page).not_to have_content 'full text Yale only'
+      expect(page).to have_content 'full text Yale only'
       expect(page).to have_content 'full text public'
     end
   end


### PR DESCRIPTION
# Summary
Full text search result snippets should only display per the user's access level.

# Related Ticket 
[#2220](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/2220)