### PR TITLE
Change hardcoded url to dynamic path

### DIFF
--- a/app/views/shared/_search_bar.html.erb
+++ b/app/views/shared/_search_bar.html.erb
@@ -9,7 +9,7 @@
   
   <div class="user-subheader" role="heading" aria-level="1">
     <div class="user-subheader-title">
-      <a href="https://collections.library.yale.edu/">Digital Collections</a>
+      <%= link_to "Digital Collections", root_path %> 
     </div>
   </div>
 <%end%>


### PR DESCRIPTION
# Summary
Replace hardcoded url to home page with dynamic root path that won't take users out of their environment.

# Related Ticket
[#2245](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/2245)

# Screenshot
![image](https://user-images.githubusercontent.com/36549923/199289861-fff2c4a0-5558-49e9-987f-37c2dce03228.png)
