### PR TITLE
Add error handling for NoSuchKey

### DIFF
--- a/app/controllers/download_original_controller.rb
+++ b/app/controllers/download_original_controller.rb
@@ -37,6 +37,17 @@ class DownloadOriginalController < ApplicationController
     con.use_ssl = true
     con.start { |http| http.request(req) }
     redirect_to '/download_original/downloading.html', status: 202
+  rescue Aws::S3::Errors::NoSuchKey => e
+    Rails.logger.error("TIFF with id [#{params[:child_oid]}] not found - staging for download: #{e.message}")
+    stage_params = { oid: params[:child_oid] }
+    url = URI.parse("https://#{root_path}/management/api/download/stage/child/#{params[:child_oid]}")
+    req = Net::HTTP::Post.new(url.path)
+    req.form_data = stage_params
+    req.basic_auth url.user, url.password if url.user
+    con = Net::HTTP.new(url.host, url.port)
+    con.use_ssl = true
+    con.start { |http| http.request(req) }
+    redirect_to '/download_original/downloading.html', status: 202
   rescue StandardError => e
     Rails.logger.error("TIFF with id [#{params[:child_oid]}] - error: #{e.message}")
     redirect_to root_path


### PR DESCRIPTION
# Summary
In testing on demo the process would not work.  In development this seemed to be due to an uncaught error for NoSuchKey on Aws.  This PR adds error handling for the uncaught error that was previously redirecting to root path.

# Related Ticket
[#2331](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/gh/yalelibrary/yul-dc/2331)