### PR TITLE
Updates to base image with ruby 3.1.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM yalelibraryit/dc-base:v1.4.1
+FROM yalelibraryit/dc-base:v1.4.2
 
 COPY ops/webapp.conf /etc/nginx/sites-enabled/webapp.conf
 COPY ops/env.conf /etc/nginx/main.d/env.conf
@@ -16,8 +16,6 @@ RUN /sbin/setuser app bash -l -c "bundle check || bundle install"
 
 COPY  --chown=app . $APP_HOME
 
-RUN sh -l -c " \
-  sed -i '/require .enumerator./d' /usr/local/rvm/gems/ruby-2.7.6/gems/oai-1.1.0/lib/oai/provider/resumption_token.rb"
 
 # Assets and packs are moved aside - building them means you find out early if the asset compilation is broken
 # not on final deploy. It means that public/assets and public/packs can be volumes in production allowing for

--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,6 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.7.6'
-
 gem 'awesome_print'
 gem 'aws-sdk-s3'
 gem 'blacklight', '>= 7.0'


### PR DESCRIPTION
# Summary
Updates to new base image that includes ruby version 3.1.3.

# Related Ticket
[#2348](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/gh/yalelibrary/yul-dc/2348)