### PR TITLE
Specifies to check user auth only on one method

### DIFF
--- a/app/controllers/download_original_controller.rb
+++ b/app/controllers/download_original_controller.rb
@@ -6,7 +6,7 @@ class DownloadOriginalController < ApplicationController
   include Blacklight::Catalog
   include CheckAuthorization
 
-  before_action :check_authorization
+  before_action :check_authorization, only: [:tiff]
 
   def tiff
     if S3Service.exists_in_s3(tiff_pairtree_path)


### PR DESCRIPTION
# Summary
Implements recommendation to not check user authentication before the 'stage_download' method.  Will now only check user auth on public method.

# Related Ticket
[#2331](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/gh/yalelibrary/yul-dc/2331)