### PR TITLE
updated extent of digitization field value

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -225,7 +225,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'abstract_tesim', label: 'Abstract', metadata: 'description', helper_method: :join_as_paragraphs
     config.add_show_field 'description_tesim', label: 'Description', metadata: 'description', helper_method: :sanitize_join_with_br
     config.add_show_field 'extent_ssim', label: 'Extent', metadata: 'description', helper_method: :join_with_br
-    config.add_show_field 'extentOfDigitization_ssim', label: 'Extent of Digitization', metadata: 'description'
+    config.add_show_field 'extentOfDigitization_ssim', label: 'Extent of Digitization', metadata: 'description', helper_method: :format_digitization
     config.add_show_field 'digitization_note_tesi', label: 'Digitization Note', metadata: 'description'
     config.add_show_field 'digitization_funding_source_tesi', label: 'Digitization Funding Source', metadata: 'description'
     config.add_show_field 'projection_tesim', label: 'Projection', metadata: 'description'

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -114,6 +114,10 @@ module BlacklightHelper
     values[2] = series_full_title if values[2] && series_full_title&.include?(values[2])
   end
 
+  def format_digitization(arg)
+    "This object has been #{arg[:value]&.first&.downcase}." unless arg[:value].empty?
+  end
+
   def archival_display(arg)
     values = arg[:document][arg[:field]].reverse
     swap_out_series_title(values, arg[:document][:series_ssi])


### PR DESCRIPTION
## Summary  
"Partially digitized" and "Completely digitized" now reads "This object has been completely digitized." and "This object has been partially digitized."  
  
## Ticket  
[2335](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/gh/yalelibrary/yul-dc/2335)  
  
## Screenshot  
<img width="1759" alt="image" src="https://user-images.githubusercontent.com/24666568/216192492-b65ef3d3-75af-4d0c-a0c4-a45b9b51dde6.png">
