### PR TITLE
Changes redirect to new page

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,6 +12,7 @@
 //= require twitter/typeahead
 //= require bootstrap
 //= require blacklight/blacklight
+//= require download_original
 //= require show_more
 
 

--- a/app/assets/javascripts/download_original.js
+++ b/app/assets/javascripts/download_original.js
@@ -7,21 +7,25 @@ $(document).on('turbolinks:load', function () {
         const childOid = fullPath.replace(/\D/g, '');
 
         // check if file is on S3
-        const available = $.ajax(hostPath + '/download/tiff/' + childOid + '/available');
+        function available() { 
+            $.ajax(hostPath + '/download/tiff/' + childOid + '/available');
+        };
 
         // create loop that checks for the file every minute
         function sleep(ms) {
             return new Promise(resolve => setTimeout(resolve, ms));
-        }
+        };
         do {
             sleep(60000);
-            available;
+            available();
         } while (available.responseText == 'false')
 
         if (available.responseText == 'true') {
             // trigger download once
-            const download = $.ajax(hostPath + '/download/tiff/' + childOid)
-            download
+            function download() { 
+                $.ajax(hostPath + '/download/tiff/' + childOid)
+            };
+            download();
         }
     }
 

--- a/app/assets/javascripts/download_original.js
+++ b/app/assets/javascripts/download_original.js
@@ -1,0 +1,28 @@
+$(document).on('turbolinks:load', function () {
+    const stagedBlurb = $('.tiff-staged');
+
+    if (stagedBlurb.length) {
+        const fullPath = window.location.pathname;
+        const hostPath = window.location.origin;
+        const childOid = fullPath.replace(/\D/g, '');
+
+        // check if file is on S3
+        const available = $.ajax(hostPath + '/download/tiff/' + childOid + '/available');
+
+        // create loop that checks for the file every minute
+        function sleep(ms) {
+            return new Promise(resolve => setTimeout(resolve, ms));
+        }
+        do {
+            sleep(60000);
+            available;
+        } while (available.responseText == 'false')
+
+        if (available.responseText == 'true') {
+            // trigger download once
+            const download = $.ajax(hostPath + '/download/tiff/' + childOid)
+            download
+        }
+    }
+
+})

--- a/app/assets/javascripts/download_original.js
+++ b/app/assets/javascripts/download_original.js
@@ -1,32 +1,23 @@
 $(document).on('turbolinks:load', function () {
     const stagedBlurb = $('.tiff-staged');
-
+    const fullPath = window.location.pathname;
+    const hostPath = window.location.origin;
+    const childOid = fullPath.replace(/\D/g, '');
     if (stagedBlurb.length) {
-        const fullPath = window.location.pathname;
-        const hostPath = window.location.origin;
-        const childOid = fullPath.replace(/\D/g, '');
-
-        // check if file is on S3
-        function available() { 
-            $.ajax(hostPath + '/download/tiff/' + childOid + '/available');
-        };
-
-        // create loop that checks for the file every minute
-        function sleep(ms) {
-            return new Promise(resolve => setTimeout(resolve, ms));
-        };
-        do {
-            sleep(60000);
-            available();
-        } while (available.responseText == 'false')
-
-        if (available.responseText == 'true') {
-            // trigger download once
-            function download() { 
-                $.ajax(hostPath + '/download/tiff/' + childOid)
-            };
-            download();
-        }
+        check_availability(childOid, hostPath);
     }
-
 })
+
+
+function check_availability(childOid, hostPath) {
+    $.ajax({
+        url: hostPath + '/download/tiff/' + childOid + '/available',
+        complete: function(r) {
+            if (r.responseText === 'false') {
+                setTimeout(()=> check_availability(childOid, hostPath), 30000)
+            } else if (r.responseText === 'true') {
+                window.location.href = hostPath + '/download/tiff/' + childOid
+            }
+        }
+    });
+}

--- a/app/assets/stylesheets/customOverrides/show_page.scss
+++ b/app/assets/stylesheets/customOverrides/show_page.scss
@@ -129,6 +129,10 @@ dt.blacklight-ancestordisplaystrings_tesim.metadata-block__label-key {
   font-family: $yale_new_roman;
 }
 
+.tiff-staged {
+  font-family: $yale_new_roman;
+}
+
 .show-tools .list-group {
   flex-direction: row;
   flex-wrap: wrap;

--- a/app/controllers/download_original_controller.rb
+++ b/app/controllers/download_original_controller.rb
@@ -13,7 +13,7 @@ class DownloadOriginalController < ApplicationController
       send_tiff
     else
       stage_download(params)
-      redirect_to search_catalog_path(search_field: 'child_oids_ssim', q: params[:child_oid].to_s), status: 202, notice: 'Item not available for download yet.  Please try again later.'
+      redirect_to "#{root_url}download/tiff/#{params[:child_oid]}/staged", status: 202
     end
   end
 

--- a/app/controllers/download_original_controller.rb
+++ b/app/controllers/download_original_controller.rb
@@ -6,7 +6,7 @@ class DownloadOriginalController < ApplicationController
   include Blacklight::Catalog
   include CheckAuthorization
 
-  before_action :check_authorization
+  before_action :check_authorization, except: [:staged]
 
   def tiff
     if S3Service.exists_in_s3(tiff_pairtree_path)
@@ -14,6 +14,12 @@ class DownloadOriginalController < ApplicationController
     else
       stage_download(params)
       redirect_to search_catalog_path(search_field: 'child_oids_ssim', q: params[:child_oid].to_s), status: 202, notice: 'Item not available for download yet.  Please try again later.'
+    end
+  end
+
+  def staged
+    respond_to do |format|
+      format.html { render 'tiff_staged.html' }
     end
   end
 

--- a/app/controllers/download_original_controller.rb
+++ b/app/controllers/download_original_controller.rb
@@ -18,8 +18,14 @@ class DownloadOriginalController < ApplicationController
   end
 
   def staged
-    respond_to do |format|
-      format.html { render 'tiff_staged.html' }
+    render 'tiff_staged.html'
+  end
+
+  def available
+    if S3Service.exists_in_s3(tiff_pairtree_path)
+      render plain: 'true'
+    else
+      render plain: 'false'
     end
   end
 

--- a/app/controllers/download_original_controller.rb
+++ b/app/controllers/download_original_controller.rb
@@ -13,7 +13,7 @@ class DownloadOriginalController < ApplicationController
       send_tiff
     else
       stage_download(params)
-      redirect_to "#{root_url}download/tiff/#{params[:child_oid]}/staged", status: 202
+      redirect_to "#{root_url}download/tiff/#{params[:child_oid]}/staged", status: 303
     end
   end
 

--- a/app/views/download_original/tiff_staged.html.erb
+++ b/app/views/download_original/tiff_staged.html.erb
@@ -1,0 +1,5 @@
+<div class='tiff-staged'>
+    <h1>You have been redirected to a new tab.</h1>
+    <p>The image is not available for download yet.</p>
+    <p>This page will refresh every minute.  The image will download when it is available.</p>
+</div>

--- a/app/views/download_original/tiff_staged.html.erb
+++ b/app/views/download_original/tiff_staged.html.erb
@@ -1,5 +1,4 @@
 <div class='tiff-staged'>
     <h1>You have been redirected to a new tab.</h1>
-    <p>The image is not available for download yet.</p>
-    <p>The image will download when it is available.</p>
+    <p>The image is not available for download yet.  The image will download when it is available.</p>
 </div>

--- a/app/views/download_original/tiff_staged.html.erb
+++ b/app/views/download_original/tiff_staged.html.erb
@@ -1,5 +1,5 @@
 <div class='tiff-staged'>
     <h1>You have been redirected to a new tab.</h1>
     <p>The image is not available for download yet.</p>
-    <p>This page will refresh every minute.  The image will download when it is available.</p>
+    <p>The image will download when it is available.</p>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,14 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
   get 'mirador/:oid', to: 'mirador#show'
 
   get '/download/tiff/:child_oid', to: 'download_original#tiff'
+  # resources :download_original do
+  #   get 'tiff_staged'
+  # end
+
+  get '/download/tiff/:child_oid/staged', to: 'download_original#staged'
+
+  # get 'download/tiff/staged', to: 'download_original#staged'
+  # resource :download_original, only: [:index]
 
   resource :catalog, only: [:index], as: 'catalog', path: '/catalog', controller: 'catalog' do
     concerns :oai_provider

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,14 +25,9 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
   get 'mirador/:oid', to: 'mirador#show'
 
   get '/download/tiff/:child_oid', to: 'download_original#tiff'
-  # resources :download_original do
-  #   get 'tiff_staged'
-  # end
-
   get '/download/tiff/:child_oid/staged', to: 'download_original#staged'
-
-  # get 'download/tiff/staged', to: 'download_original#staged'
-  # resource :download_original, only: [:index]
+  get '/download/tiff/:child_oid', to: 'download_original#index'
+  get '/download/tiff/:child_oid/suggest', to: 'download_original#suggest'
 
   resource :catalog, only: [:index], as: 'catalog', path: '/catalog', controller: 'catalog' do
     concerns :oai_provider

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,7 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
   get '/download/tiff/:child_oid/staged', to: 'download_original#staged'
   get '/download/tiff/:child_oid', to: 'download_original#index'
   get '/download/tiff/:child_oid/suggest', to: 'download_original#suggest'
+  get '/download/tiff/:child_oid/available', to: 'download_original#available'
 
   resource :catalog, only: [:index], as: 'catalog', path: '/catalog', controller: 'catalog' do
     concerns :oai_provider

--- a/spec/requests/download_original_spec.rb
+++ b/spec/requests/download_original_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe "Download Original", type: :request, clean: true do
       it 'presents user with try again message' do
         get "/download/tiff/#{not_available_yet[:child_oids_ssim].first}"
         expect(response).to have_http_status(:accepted) # 202
-        expect(response.redirect_url).to eq 'http://www.example.com/catalog?q=3333333&search_field=child_oids_ssim'
+        expect(response.redirect_url).to eq 'http://www.example.com/download/tiff/3333333/staged'
       end
     end
     context 'when child object does not exist' do

--- a/spec/requests/download_original_spec.rb
+++ b/spec/requests/download_original_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe "Download Original", type: :request, clean: true do
     context 'when file is not present on S3' do
       it 'presents user with try again message' do
         get "/download/tiff/#{not_available_yet[:child_oids_ssim].first}"
-        expect(response).to have_http_status(:accepted) # 202
+        expect(response).to have_http_status(:see_other) # 303
         expect(response.redirect_url).to eq 'http://www.example.com/download/tiff/3333333/staged'
       end
     end


### PR DESCRIPTION
# Summary
Changes redirect to new page that explains the new tab and download process while triggering the download once when the file is available on S3.

# Related Ticket
[#2416](https://github.com/yalelibrary/YUL-DC/issues/2416)

# Screenshot
![image](https://user-images.githubusercontent.com/36549923/225708372-630ad125-1aa2-4d9d-b90d-356aeb944fab.png)
