### PR TITLE
Increase delay time for tab closure

### DIFF
--- a/app/assets/javascripts/download_original.js
+++ b/app/assets/javascripts/download_original.js
@@ -21,7 +21,7 @@ function checkAvailability(childOid, hostPath) {
                 $('#download-instructions').html('The file could not be downloaded at this time. Please try again later.');
             } else if (r.responseText === 'true') {
                 window.location.href = hostPath + '/download/tiff/' + childOid;
-                setTimeout(() => window.close(), 3000);
+                setTimeout(() => window.close(), 10000);
             }
         }
     });


### PR DESCRIPTION
## Summary  
Increases the time a download tab will close from 3 seconds to 10 seconds.   
  
## Ticket  
[2443](https://github.com/orgs/yalelibrary/projects/1/views/1?pane=issue&itemId=24187688)