### PR TITLE
Resolves missing bug with date created facet

### DIFF
--- a/app/assets/stylesheets/customOverrides/constraints.scss
+++ b/app/assets/stylesheets/customOverrides/constraints.scss
@@ -13,6 +13,11 @@ DEFAULT MOBILE STYLING
 
 }
 
+// hides duplicate range constraint
+.btn-group.applied-filter.constraint.query.year_isim {
+  display: none;
+}
+
 .constraints-container-index.constraints-container {
   background-color: $lighter_grey;
   padding: 5px 0;

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -12,7 +12,7 @@ module BlacklightHelper
     label = "Date"
 
     # if date is unknown
-    if params["range"].try(:[], "year_isim").try(:[], "missing")
+    if params["range"].try(:[], "-year_isim")
       value = "Unknown"
       remove_url = range_unknown_remove_url(url)
     else
@@ -32,7 +32,7 @@ module BlacklightHelper
 
   # removes date range params from link with unknown date
   def range_unknown_remove_url(url_in)
-    url = url_in.gsub(/[?&]range%5Byear_.*%5D%5Bmissing%5D=true/, '')
+    url = url_in.gsub(/[?&]range%5B-year_isim%5D%5B%5D=%5B*+TO+*%5D/, '')
     url.gsub!("&commit=Apply", '')
     url.gsub(/[?&]range%5Byear_.*%5D%5Bmissing%5D=true/, '')
   end

--- a/spec/system/date_slider_spec.rb
+++ b/spec/system/date_slider_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe "Blacklight Range Limit", type: :system, clean: true, js: true do
     end
 
     within '.constraints-container' do
-      expect(page.text).to match(/Date 11\d\d - 16\d\d/).or(/Date Created 11\d\d - 16\d\d/)
+      expect(page.text).to match(/Date Created 11\d\d To 16\d\d/)
     end
 
     # makes sure that it includes the turtle record with years: 1555-1800


### PR DESCRIPTION
# Summary
Addresses bug that was causing clicking on 'Missing' to send the user to a rails error page.  This PR searches records that are missing their date created field instead of erroring out.

# Related Ticket
[#2427](https://github.com/yalelibrary/YUL-DC/issues/2427)

# Video

https://user-images.githubusercontent.com/36549923/231820183-18e75cd8-c338-4267-ade4-a24ab9ba2791.mp4


