### PR TITLE
Configure Honeybadger to use cluster name as env

### DIFF
--- a/config/honeybadger.yml
+++ b/config/honeybadger.yml
@@ -1,2 +1,8 @@
 ---
 api_key:  <%= ENV.fetch('HONEYBADGER_API_KEY_BLACKLIGHT', '') %>
+env:  <%= ENV.fetch('CLUSTER_NAME', 'local') %>
+development_environments:
+  - development
+  - test
+  - cucumber
+  - local


### PR DESCRIPTION
Set env to cluster name.  Ignore `local`