### PR TITLE
DRAFT: Repair sidebar resizing

### DIFF
--- a/app/views/layouts/blacklight.html.erb
+++ b/app/views/layouts/blacklight.html.erb
@@ -5,7 +5,7 @@
       <%= yield %>
     </section>
 
-    <section id="sidebar" class="<%= sidebar_classes %> order-first" aria-label="<%= t('blacklight.search.documents.aria.limit_search') %>">
+    <section id="sidebar" class="page-sidebar order-first" aria-label="<%= t('blacklight.search.documents.aria.limit_search') %>">
       <%= content_for(:sidebar) %>
     </section>
   <% else %>


### PR DESCRIPTION
# Summary
For some specific searches the 'sidebar classes' included 'col-lg-3' and this set a max width of 25% making the text waterfall.  In order to prevent the resizing the 'col' class was removed from the layout.

# Related Ticket
[#2474](https://github.com/yalelibrary/YUL-DC/issues/2474)

# Screenshots

### Before
![image](https://user-images.githubusercontent.com/36549923/236247729-16e2da94-1bac-4a2b-a59f-bf3bbd2aae84.png)

### After
![image](https://user-images.githubusercontent.com/36549923/236247660-5f75f8f5-0fc1-4e3b-a1a1-82675776c1d8.png)

# Notes
Includes an unrelated change to update a hard coded color to use the variable instead.