### PR TITLE
adds return to redirect

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -625,7 +625,7 @@ class CatalogController < ApplicationController
   def show
     super
     @search_params = session[:search_params]
-    redirect_to @document["redirect_to_tesi"] and return if @document["visibility_ssi"] == "Redirect" && @document["redirect_to_tesi"].present?
+    redirect_to @document["redirect_to_tesi"] if @document["visibility_ssi"] == "Redirect" && @document["redirect_to_tesi"].present? and return
     render "catalog/show_unauthorized", status: :unauthorized unless client_can_view_metadata?(@document)
   end
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -625,7 +625,7 @@ class CatalogController < ApplicationController
   def show
     super
     @search_params = session[:search_params]
-    redirect_to @document["redirect_to_tesi"] if @document["visibility_ssi"] == "Redirect" && @document["redirect_to_tesi"].present? and return
+    redirect_to @document["redirect_to_tesi"] if @document["visibility_ssi"] == "Redirect" && @document["redirect_to_tesi"].present? && return
     render "catalog/show_unauthorized", status: :unauthorized unless client_can_view_metadata?(@document)
   end
 


### PR DESCRIPTION
## Summary  
.oai_dc_xml path on redirected objects will no longer throw an error.  
  
To test:  
visit https://collections-test.library.yale.edu/catalog/17451921.oai_dc_xml  
ensure no error is thrown