### PR TITLE
returns nil if oai xml is requested on a redirected object

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -629,7 +629,7 @@ class CatalogController < ApplicationController
     if @document["visibility_ssi"] == "Redirect" && @document["redirect_to_tesi"].present? && !request.original_url.include?("oai_dc_xml")
       redirect_to @document["redirect_to_tesi"]
     elsif @document["visibility_ssi"] == "Redirect" && @document["redirect_to_tesi"].present? && request.original_url.include?("oai_dc_xml")
-      nil
+      not_found
     else
       render "catalog/show_unauthorized", status: :unauthorized unless client_can_view_metadata?(@document)
     end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -622,12 +622,19 @@ class CatalogController < ApplicationController
     super
   end
 
+  # rubocop:disable Metrics/PerceivedComplexity
   def show
     super
     @search_params = session[:search_params]
-    redirect_to @document["redirect_to_tesi"] and return if @document["visibility_ssi"] == "Redirect" && @document["redirect_to_tesi"].present?
-    render "catalog/show_unauthorized", status: :unauthorized unless client_can_view_metadata?(@document)
+    if @document["visibility_ssi"] == "Redirect" && @document["redirect_to_tesi"].present? && !request.original_url.include?("oai_dc_xml")
+      redirect_to @document["redirect_to_tesi"]
+    elsif @document["visibility_ssi"] == "Redirect" && @document["redirect_to_tesi"].present? && request.original_url.include?("oai_dc_xml")
+      nil
+    else
+      render "catalog/show_unauthorized", status: :unauthorized unless client_can_view_metadata?(@document)
+    end
   end
+  # rubocop:enable Metrics/PerceivedComplexity
 
   def iiif_suggest
     @query = params[:q] || ""


### PR DESCRIPTION
## Summary  
returns nil if oai xml is requested on a redirected object  
  
## Screenshot:  
Returns not_found page with 404 status if redirected oai_dc_xml url is hit:  
<img width="1792" alt="image" src="https://github.com/yalelibrary/yul-dc-blacklight/assets/24666568/6f247227-a184-4a12-801e-09b766c6cf61">
