### PR TITLE
Format morris record url

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -277,6 +277,7 @@ class CatalogController < ApplicationController
 
     # Identifiers Group
     config.add_show_field 'orbisBibId_ssi', label: 'Orbis Record', metadata: 'identifiers', helper_method: :link_to_orbis_bib_id
+    config.add_show_field 'bibId_ssi', label: 'Morris Record', metadata: 'identifiers', helper_method: :link_to_morris_bib_id
     config.add_show_field 'quicksearchId_ssi', label: 'Quicksearch ID', metadata: 'identifiers', helper_method: :link_to_quicksearch_id
     config.add_show_field 'oid_ssi', label: 'Object ID (OID)', metadata: 'identifiers'
     config.add_show_field 'url_suppl_ssim', label: 'More Information', metadata: 'identifiers', helper_method: :link_to_url

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -277,7 +277,7 @@ class CatalogController < ApplicationController
 
     # Identifiers Group
     config.add_show_field 'orbisBibId_ssi', label: 'Orbis Record', metadata: 'identifiers', helper_method: :link_to_orbis_bib_id
-    config.add_show_field 'bibId_ssi', label: 'Morris Record', metadata: 'identifiers', helper_method: :link_to_morris_bib_id
+    config.add_show_field 'morris_link', field: 'orbisBibId_ssi', label: 'Morris Record', metadata: 'identifiers', helper_method: :link_to_morris_bib_id
     config.add_show_field 'quicksearchId_ssi', label: 'Quicksearch ID', metadata: 'identifiers', helper_method: :link_to_quicksearch_id
     config.add_show_field 'oid_ssi', label: 'Object ID (OID)', metadata: 'identifiers'
     config.add_show_field 'url_suppl_ssim', label: 'More Information', metadata: 'identifiers', helper_method: :link_to_url

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -71,7 +71,7 @@ module BlacklightHelper
 
     link_to(bib_id, link)
   end
-  
+
   def link_to_morris_bib_id(arg)
     return nil if arg[:document][:source_ssim].first != "sierra"
     bib_id = arg[:document][arg[:field]]

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -65,8 +65,17 @@ module BlacklightHelper
   end
 
   def link_to_orbis_bib_id(arg)
+    return nil if arg[:document][:source_ssim].first == "sierra"
     bib_id = arg[:document][arg[:field]]
     link = "http://hdl.handle.net/10079/bibid/#{bib_id}"
+
+    link_to(bib_id, link)
+  end
+  
+  def link_to_morris_bib_id(arg)
+    return nil if arg[:document][:source_ssim].first != "sierra"
+    bib_id = arg[:document][arg[:field]]
+    link = "https://morris.law.yale.edu/record=b#{bib_id}"
 
     link_to(bib_id, link)
   end


### PR DESCRIPTION
## Summary  
Sierra sources now display correctly as "Morris Record" in Blacklight with the correct URL:  
  
## Screenshot:  
<img width="890" alt="image" src="https://github.com/yalelibrary/yul-dc-blacklight/assets/24666568/0ddb1a66-76f6-4ad2-aa89-8521a4193de0">
