### PR TITLE
2543 add contributor field

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -223,6 +223,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'title_tesim', label: 'Title', metadata: 'description', helper_method: :join_with_br
     config.add_show_field 'alternativeTitle_tesim', label: 'Alternative Title', metadata: 'description', helper_method: :join_with_br
     config.add_show_field 'creator_ssim', label: 'Creator', metadata: 'description', link_to_facet: true, helper_method: :generate_creators_links
+    config.add_show_field 'contributor_tsim', label: 'Contributor', metadata: 'description', link_to_facet: true, helper_method: :generate_contributor_links
     config.add_show_field 'date_ssim', label: 'Published / Created', metadata: 'description'
     config.add_show_field 'copyrightDate_ssim', label: 'Copyright Date', metadata: 'description'
     config.add_show_field 'creationPlace_ssim', label: 'Publication Place', metadata: 'description'

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -324,6 +324,25 @@ module BlacklightHelper
     safe_join(out, '<br/>'.html_safe)
   end
 
+  def generate_contributor_links(args)
+    generate_contributor(args) do |creator|
+      creator
+    end
+  end
+
+  def generate_contributor(args)
+    out = []
+
+    creator_values = args[:document][args[:field]]
+    creator_highlight = args[:document].highlight_field(args[:field])
+    creator_values.each_with_index.map do |creator, ix|
+      creator_change = yield creator, creator_highlight.try(:[], ix) || creator
+      label = 'From the Collection: ' if args[:document]['contributor_tsim']&.include?(creator)
+      out << safe_join(["<span class = 'from-the-collection' >".html_safe, label, "</span>".html_safe, creator_change])
+    end
+    safe_join(out, '<br/>'.html_safe)
+  end
+
   def link_to_url_with_label(arg, filters = [])
     links = arg[:value].map do |value|
       link_part = value.split('|')

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -337,7 +337,7 @@ module BlacklightHelper
     creator_highlight = args[:document].highlight_field(args[:field])
     creator_values.each_with_index.map do |creator, ix|
       creator_change = yield creator, creator_highlight.try(:[], ix) || creator
-      label = 'From the Collection: ' if args[:document]['contributor_tsim']&.include?(creator)
+      label = 'From the Collection: ' if args[:document][:source_ssim].first == "aspace"
       out << safe_join(["<span class = 'from-the-collection' >".html_safe, label, "</span>".html_safe, creator_change])
     end
     safe_join(out, '<br/>'.html_safe)


### PR DESCRIPTION
## Summary  
"Contributor" is now listed in objects Description metadata block.  
"From the Collection:" is present only for ASpace objects:  
  
## Screenshots:  
<img width="1255" alt="image" src="https://github.com/yalelibrary/yul-dc-blacklight/assets/24666568/96286c95-06b7-4bcb-bb9c-c30bae5b0e00">
