### PR TITLE
Font-weight for Cyrillic fonts

### DIFF
--- a/app/assets/stylesheets/customOverrides/search_result.scss
+++ b/app/assets/stylesheets/customOverrides/search_result.scss
@@ -11,6 +11,7 @@ DEFAULT MOBILE STYLING
     max-width: 420px;
     font-family: $mallory_medium, Arial, Helvetica, sans-serif;
     font-size: 15px;
+    font-weight: 600;
   }
 
   .search-highlight {
@@ -86,6 +87,7 @@ DEFAULT MOBILE STYLING
   .dl-invert dd {
     font-size: 12px;
     font-family:  $mallory_medium, Arial, Helvetica, sans-serif;
+    font-weight: 600;
     color: $medium_grey;
     flex-wrap: wrap;
     margin-top: -21px;
@@ -182,6 +184,7 @@ DEFAULT MOBILE STYLING
     .dl-invert dd {
       font-size: 12px;
       font-family: $mallory_medium, Arial, Helvetica, sans-serif;
+      font-weight: 600;
       color: $medium_grey;
       flex-wrap: wrap;
       margin-top: -21px;
@@ -265,6 +268,7 @@ DEFAULT MOBILE STYLING
     .dl-invert dd {
       font-size: 12px;
       font-family: $mallory_medium, Arial, Helvetica, sans-serif;
+      font-weight: 600;
       color: $medium_grey;
       flex-wrap: wrap;
       margin-top: -21px;


### PR DESCRIPTION
## Summary  
Increased font-weight to 600 since Arial does not include a default bold font. This enables Cyrillic fonts to match non-Cyrillic font weights.  
  
## Screenshot:  
<img width="981" alt="image" src="https://github.com/yalelibrary/yul-dc-blacklight/assets/24666568/77934c38-4f05-4fc8-88fe-704397a6ee82">
