### PR TITLE
UV and breadcrumbs cyrillic font

### DIFF
--- a/app/assets/stylesheets/customOverrides/show_page.scss
+++ b/app/assets/stylesheets/customOverrides/show_page.scss
@@ -7,9 +7,9 @@ DEFAULT MOBILE STYLING
 .blacklight-ancestortitles_tesim {
   padding-right: 4px;
   width: 1080px;
-  font-family: $mallory_medium;
+  font-family: $mallory_medium, Arial;
+  font-weight: 600;
   color: $medium_grey;
-  font-weight: 500;
   font-size: 14px;
 }
 

--- a/public/uv/uv.css
+++ b/public/uv/uv.css
@@ -1,3 +1,6 @@
+.uv .centerPanel .title {
+  font-size: 50px;
+}
 .uv > div {
   width: 100%;
   height: 100%;
@@ -9,4 +12,12 @@
 
 .uv > div.loaded {
   background-image: none;
+}
+
+.mainPanel .centerPanel .title {
+  font-family: Arial !important;
+}
+
+.uv .rightPanel .main {
+  font-family: Arial !important;
 }

--- a/public/uv/uv.css
+++ b/public/uv/uv.css
@@ -1,6 +1,3 @@
-.uv .centerPanel .title {
-  font-size: 50px;
-}
 .uv > div {
   width: 100%;
   height: 100%;


### PR DESCRIPTION
## Summary  
Cyrillic fonts now render correctly in Chrome for UV and breadcrumbs.  
  
## Screenshot:  
<img width="1349" alt="image" src="https://github.com/yalelibrary/yul-dc-blacklight/assets/24666568/a6392cce-f6c0-4883-beeb-82f4b5b78ff9">
