### PR TITLE
YCO access now requires a netid

### DIFF
--- a/app/helpers/access_helper.rb
+++ b/app/helpers/access_helper.rb
@@ -10,7 +10,7 @@ module AccessHelper
     when 'Public'
       return true
     when 'Yale Community Only'
-      return true if current_user || User.on_campus?(request.remote_ip)
+      return true if (current_user && current_user.netid.present?) || User.on_campus?(request.remote_ip)
     end
     false
   end

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -181,11 +181,13 @@ RSpec.describe BlacklightHelper, helper: true, style: true do
         expect(helper.render_thumbnail(yale_only_document, {})).to match("<img [^>]* src=\"http://localhost:8182/iiif/2/1234822/full/#{thumbnail_size}/0/default.jpg\" />")
       end
 
+      # rubocop:disable Layout/LineLength
       it 'user cannot access YCO without a netid' do
         user = FactoryBot.create(:user)
         sign_in(user)
         expect(helper.render_thumbnail(yale_only_document, {})).to match("<img alt=\"Access Available on YALE network only due to copyright or other restrictions. OFF-SITE? Log in with NetID\" src=\"/assets/placeholder_restricted-4d0037c54ed3900f4feaf705e801f4c980164e45ee556f60065c39b4bd4af345.png\" />")
       end
+      # rubocop:enable Layout/LineLength
 
       it 'has lazy loading for the thumbnail image' do
         user = FactoryBot.create(:user, netid: 'net_id')

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -174,15 +174,21 @@ RSpec.describe BlacklightHelper, helper: true, style: true do
         expect(helper.render_thumbnail(yale_only_document, {})).to include(alt_text, placeholder_image)
       end
 
-      it 'returns image when logged in' do
-        user = FactoryBot.create(:user)
+      it 'returns image when logged in with valid netid' do
+        user = FactoryBot.create(:user, netid: 'net_id')
         sign_in(user) # sign_in so user_signed_in? works in method
 
         expect(helper.render_thumbnail(yale_only_document, {})).to match("<img [^>]* src=\"http://localhost:8182/iiif/2/1234822/full/#{thumbnail_size}/0/default.jpg\" />")
       end
 
-      it 'has lazy loading for the thumbnail image' do
+      it 'user cannot access YCO without a netid' do
         user = FactoryBot.create(:user)
+        sign_in(user)
+        expect(helper.render_thumbnail(yale_only_document, {})).to match("<img alt=\"Access Available on YALE network only due to copyright or other restrictions. OFF-SITE? Log in with NetID\" src=\"/assets/placeholder_restricted-4d0037c54ed3900f4feaf705e801f4c980164e45ee556f60065c39b4bd4af345.png\" />")
+      end
+
+      it 'has lazy loading for the thumbnail image' do
+        user = FactoryBot.create(:user, netid: 'net_id')
         sign_in(user)
 
         expect(helper.render_thumbnail(yale_only_document, {})).to match("<img[^>]* loading=\"lazy\"")

--- a/spec/requests/annotation_request_spec.rb
+++ b/spec/requests/annotation_request_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 # WebMock.allow_net_connect!
 RSpec.describe 'AnnotationsController', type: :request, clean: true, js: true do
-  let(:user) { FactoryBot.create(:user) }
+  let(:user) { FactoryBot.create(:user, netid: "net_id") }
   let(:public_work) do
     {
       "id": "2034600",

--- a/spec/requests/download_original_spec.rb
+++ b/spec/requests/download_original_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 
 RSpec.describe "Download Original", type: :request, clean: true do
   let(:imgtiff) { 'image/tiff' }
-  let(:user) { FactoryBot.create(:user) }
+  let(:user) { FactoryBot.create(:user, netid: "net_id") }
   let(:public_work) { WORK_WITH_PUBLIC_VISIBILITY.merge({ "child_oids_ssim": ["5555555"] }) }
   let(:yale_work) do
     {

--- a/spec/requests/iiif_request_spec.rb
+++ b/spec/requests/iiif_request_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 RSpec.describe "Iiifs", type: :request do
   let(:thumbnail_size) { "!1200,630" }
 
-  let(:user) { FactoryBot.create(:user) }
+  let(:user) { FactoryBot.create(:user, netid: "net_id") }
   let(:public_work) { WORK_WITH_PUBLIC_VISIBILITY.merge({ "child_oids_ssim": ["5555555"] }) }
   let(:yale_work) do
     {

--- a/spec/requests/manifests_request_spec.rb
+++ b/spec/requests/manifests_request_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 # WebMock.allow_net_connect!
 
 RSpec.describe 'Manifests', type: :request, clean: true do
-  let(:user) { FactoryBot.create(:user) }
+  let(:user) { FactoryBot.create(:user, netid: "net_id") }
   let(:public_work) { WORK_WITH_PUBLIC_VISIBILITY }
   let(:redirected_work) { WORK_REDIRECTED }
   let(:yale_work) do


### PR DESCRIPTION
## Summary  
Accessing YCO objects now requires a netid