### PR TITLE
adds provenance to showpage

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -230,6 +230,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'publisher_ssim', label: 'Publisher', metadata: 'description'
     config.add_show_field 'abstract_tesim', label: 'Abstract', metadata: 'description', helper_method: :join_as_paragraphs
     config.add_show_field 'description_tesim', label: 'Description', metadata: 'description', helper_method: :sanitize_join_with_br
+    config.add_show_field 'provenanceUncontrolled_tesi', label: 'Provenance', metadata: 'description'
     config.add_show_field 'extent_ssim', label: 'Extent', metadata: 'description', helper_method: :join_with_br
     config.add_show_field 'extentOfDigitization_ssim', label: 'Extent of Digitization', metadata: 'description', helper_method: :format_digitization
     config.add_show_field 'digitization_note_tesi', label: 'Digitization Note', metadata: 'description'


### PR DESCRIPTION
Adds "Provenance" to object showpages:  
<img width="1218" alt="image" src="https://github.com/yalelibrary/yul-dc-blacklight/assets/24666568/332d4f20-03b4-4521-9228-715440976b94">
