### PR TITLE
Block image access for GPTBot in robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -8,6 +8,7 @@ User-agent: GPTBot
 Disallow: /pdfs/
 Disallow: /iiif/
 Disallow: /annotation/
-
+Disallow: /catalog/*/iiif_suggest
+Disallow: /catalog/*/iiif_search
 
 Sitemap: https://collections.library.yale.edu/sitemap

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -7,6 +7,7 @@ Disallow: /mirador/
 User-agent: GPTBot
 Disallow: /pdfs/
 Disallow: /iiif/
+Disallow: /annotation/
 
 
 Sitemap: https://collections.library.yale.edu/sitemap

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -4,4 +4,9 @@ Disallow: /manifests/
 Disallow: /pdfs/
 Disallow: /mirador/
 
+User-agent: GPTBot
+Disallow: /pdfs/
+Disallow: /iiif/
+
+
 Sitemap: https://collections.library.yale.edu/sitemap


### PR DESCRIPTION
Also include /pdfs/ which should be covered by the section above, but can't hurt.