### PR TITLE
Feedback Footer Link

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -20,7 +20,7 @@
             <a href="https://guides.library.yale.edu/about/policies/access" target="_blank" rel="noopener">Terms</a>
           </li>
           <!--<% url = request.path() %>-->
-          <% url = request.original_url %>
+          <% url = request.original_url.gsub("&", "%26") %>
           <li>
             <%= link_to(:"Feedback", "http://web.library.yale.edu/form/findit-feedback?findITURL=#{url}", :target => '_blank' ) %>
           </li>


### PR DESCRIPTION
Feedback footer link now works after replacing "&" with "%26"