### PR TITLE
Adds bookmark functionality

### DIFF
--- a/app/assets/stylesheets/customOverrides/index_gallery.scss
+++ b/app/assets/stylesheets/customOverrides/index_gallery.scss
@@ -12,6 +12,11 @@ DEFAULT MOBILE STYLING
   margin-bottom: 50px;
 }
 
+#documents.gallery.row.row-cols-2.row-cols-md-3{
+  margin-left: 0;
+  margin-top: 30px;
+}
+
 .document.col .caption .documentHeader {
   padding-left: 15px !important;
 }

--- a/app/assets/stylesheets/customOverrides/search_result.scss
+++ b/app/assets/stylesheets/customOverrides/search_result.scss
@@ -305,3 +305,40 @@ DEFAULT MOBILE STYLING
     }
   }
 }
+/********************************************************
+BOOKMARK STYLING
+********************************************************/
+
+// This is to prevent the bookmark-toggle css below to not have an effect on the gallery view checkboxes.
+.gallery .bookmark-toggle {
+  padding-left: 0px;
+}
+
+// List item search results bookmark styling
+.index_title.document-title-heading.title_tesim {
+  display: flex;
+}
+
+.index-document-functions { 
+  padding-left: 175px;
+}
+
+.bookmark-toggle {
+  font-size: 17px;
+}
+
+@media screen and (max-width: 1650px) {
+  .index-document-functions {
+    padding-left: 90px;
+  }
+}
+@media screen and (max-width: 1530px) {
+  .index-document-functions {
+    padding-left: 0px;
+  }
+}
+@media screen and (max-width: 1380px) {
+  .index-document-functions {
+    margin-left: -105px;
+  }
+}

--- a/app/assets/stylesheets/customOverrides/show_page.scss
+++ b/app/assets/stylesheets/customOverrides/show_page.scss
@@ -173,7 +173,7 @@ dt.blacklight-ancestordisplaystrings_tesim.metadata-block__label-key {
   text-transform: uppercase;
 }
 
-.link-card-header{
+.link-card-header {
   display: none;
 }
 
@@ -218,15 +218,26 @@ dt.blacklight-ancestordisplaystrings_tesim.metadata-block__label-key {
 
 //Title on Single Items and Search Result pages
 //Replace Yale Roman with Yale Display when its available.
-.show-header {
-  font-family: $yale_new_roman, 'Times New Roman', Times, serif !important;
-  font-size: 1.5rem;
-  color: $yale_blue;
+.show-header-container {
   padding-bottom: 1.5%;
   padding-top: 1.5%;
   width: 82%;
   left: 8%;
   position: relative;
+}
+
+.show-header {
+  font-family: $yale_new_roman, 'Times New Roman', Times, serif !important;
+  font-size: 1.5rem;
+  color: $yale_blue;
+  width: 80%;
+}
+
+.show-bookmark {
+  width: 2%;
+  position: absolute;
+  right: 6.5%;
+  top: 18%;
 }
 
 .universal-viewer-iframe {
@@ -466,7 +477,7 @@ p.yale-restricted-work-text{
     align-content: center;
   }
 
-  .show-header,
+  .show-header-container,
   .yale-restricted-work-text {
     width: 92%;
   }
@@ -567,7 +578,7 @@ p.yale-restricted-work-text{
     align-content: center;
   }
 
-  .show-header,
+  .show-header-container,
   .yale-restricted-work-text {
     width: 97%;
     left: 19%;
@@ -674,7 +685,7 @@ p.yale-restricted-work-text{
     align-content: center;
   }
 
-  .show-header,
+  .show-header-container,
   .yale-restricted-work-text {
     width: 96%;
   }

--- a/app/assets/stylesheets/customOverrides/sort_widget.scss
+++ b/app/assets/stylesheets/customOverrides/sort_widget.scss
@@ -58,6 +58,11 @@ DEFAULT MOBILE STYLING
   font-size: 16px;
 }
 
+.clear-bookmarks {
+  background-color: #767676;
+  color: white !important;
+}
+
 .view-type-group > .btn-outline-secondary:first-child {
   margin-right: 8px;
 }

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -73,15 +73,13 @@ class CatalogController < ApplicationController
     # config.index.display_type_field = 'format'
     config.index.thumbnail_method = :render_thumbnail
 
-    # Remove bookmark functionality from the research page
-    # config.add_results_document_tool(:bookmark, partial: 'bookmark_control', if: :render_bookmarks_control?)
+    config.add_results_document_tool(:bookmark, partial: 'bookmark_control', if: :render_bookmarks_control?)
 
     config.add_results_collection_tool(:sort_widget)
     config.add_results_collection_tool(:per_page_widget)
     config.add_results_collection_tool(:view_type_group)
 
-    # Remove bookmark functionality from the item page
-    # config.add_show_tools_partial(:bookmark, partial: 'bookmark_control', if: :render_bookmarks_control?)
+    config.add_show_tools_partial(:bookmark, partial: 'bookmark_control', if: :render_bookmarks_control?)
     # config.add_show_tools_partial(:email, callback: :email_action, validator: :validate_email_params)
     # config.add_show_tools_partial(:sms, if: :render_sms_action?, callback: :sms_action, validator: :validate_sms_params)
     config.add_show_tools_partial(:citation)

--- a/app/views/bookmarks/_clear_bookmarks_widget.html.erb
+++ b/app/views/bookmarks/_clear_bookmarks_widget.html.erb
@@ -1,0 +1,1 @@
+  <%= link_to t('blacklight.bookmarks.clear.action_title'), clear_bookmarks_path, :method => :delete, :data => { :confirm => t('blacklight.bookmarks.clear.action_confirm') }, :class => 'clear-bookmarks btn' %>

--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -1,0 +1,20 @@
+<% @page_title = t('blacklight.bookmarks.page_title', :application_name => application_name) %>
+
+<div id="content" class="col-md-12">
+  <h2 class='page-heading'><%= t('blacklight.bookmarks.title') %></h2>
+
+  <%- if current_or_guest_user.blank? -%>
+
+    <h3 class='section-heading'><%= t('blacklight.bookmarks.need_login') %></h3>
+
+  <%- elsif @response.documents.blank? -%>
+
+    <h3 class='section-heading'><%= t('blacklight.bookmarks.no_bookmarks') %></h3>
+  <% else %>
+    <%= render 'sort_and_per_page' %>
+    <%= render partial: 'tools', locals: { document_list: @response.documents } %>
+    <h3 class='section-heading sr-only visually-hidden'><%= t('blacklight.bookmarks.list_title') %></h3>
+    <%= render_document_index @response.documents %>
+    <%= render 'results_pagination' %>
+  <% end %>
+</div>

--- a/app/views/catalog/_index_header.html.erb
+++ b/app/views/catalog/_index_header.html.erb
@@ -23,12 +23,8 @@
   unless title_class == :none
   end
 
-  original_url = request.original_url
-  parsed_url = Addressable::URI.parse(original_url)
-  view = parsed_url.query_values['view']
 -%>
-
-<div class='documentHeader row'>
+<header class='documentHeader row'>
   <h3 class='index_title document-title-heading <%= title_class %>'>
     <% if !gallery_view? %>
       <span class='counter_no_show' ><%= counter %> </span>
@@ -36,5 +32,6 @@
     <div class='document-title'>
       <%= link_to_document document, document.highlight_field('title_tesim').try(:[],0) || document['title_tesim'], counter:document_counter %>
     </div>
+    <%= render_index_doc_actions document, wrapping_class: "index-document-functions col-sm-3 col-lg-2" %>
   </h3>
-</div>
+</header>

--- a/app/views/catalog/_show_header.html.erb
+++ b/app/views/catalog/_show_header.html.erb
@@ -1,1 +1,10 @@
-<h1 itemprop="name" class="show-header"><%= sep_title_show_page %></h1>
+<div class="show-header-container">
+  <h1 itemprop="name" class="show-header"><%= sep_title_show_page %></h1>
+  <%= render_show_doc_actions @document do |config, inner| %>
+      <% if config.key.to_s == 'bookmark' %>
+          <div class="show-<%= config.key %>">
+              <%= inner %>
+          </div>
+      <% end %>
+  <% end %>
+</div>

--- a/app/views/catalog/_show_tools.html.erb
+++ b/app/views/catalog/_show_tools.html.erb
@@ -6,9 +6,11 @@
 
         <ul class="list-group list-group-flush">
             <%= render_show_doc_actions @document do |config, inner| %>
-                <li class="list-group-item <%= config.key %>">
-                    <%= inner %>
-                </li>
+                <% if config.key.to_s == 'citation' %>
+                    <li class="list-group-item <%= config.key %>">
+                        <%= inner %>
+                    </li>
+                <% end %>
             <% end %>
 
             <% oid = @document.id %>

--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -27,8 +27,10 @@
     <%= link_to t('blacklight.skip_links.main_content'), '#main-container', class: 'element-invisible element-focusable rounded-bottom py-2 px-3', data: { turbolinks: 'false' } %>
     <%= content_for(:skip_links) %>
   </nav>
-  <%= render partial: 'shared/header_navbar' %>
-  <%= render partial: 'shared/search_bar' %>
+  <header>
+    <%= render partial: 'shared/header_navbar' %>
+    <%= render partial: 'shared/search_bar' %>
+  </header>
 
   <main id="main-container" class="<%= container_classes %>" role="main" aria-label="<%= t('blacklight.main.aria.main_container') %>">
     <%= content_for(:container_header) %>

--- a/app/views/shared/_user_util_links.html.erb
+++ b/app/views/shared/_user_util_links.html.erb
@@ -1,4 +1,9 @@
 <ul class="navbar-nav">
+
+  <li class="nav-item">
+    <%= link_to 'Bookmarks', '/bookmarks', class: 'nav-link' %>
+  </li>
+
   <% if has_user_authentication_provider? %>
     <% if current_user %>
       <li class="nav-item">

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -7,6 +7,10 @@ en:
       next: 'NEXT'
   blacklight:
     application_name: 'Yale University Library'
+    bookmarks:
+      clear:
+        action_title: 'Clear All Bookmarks'
+        action_confirm: Are you sure you want to clear all bookmarks? You cannot undo this action.
     sidebar:
       links: Links
       manifest: Manifest Link

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_09_26_201727) do
+ActiveRecord::Schema.define(version: 2024_01_15_173008) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
   factory :user do
     uid { FFaker::Internet.user_name }
     sub { "123" }
-    provider { "cas" }
+    netid { "az123" }
+    provider { "openid" }
   end
 end

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -183,7 +183,7 @@ RSpec.describe BlacklightHelper, helper: true, style: true do
 
       # rubocop:disable Layout/LineLength
       it 'user cannot access YCO without a netid' do
-        user = FactoryBot.create(:user)
+        user = FactoryBot.create(:user, netid: nil)
         sign_in(user)
         expect(helper.render_thumbnail(yale_only_document, {})).to match("<img alt=\"Access Available on YALE network only due to copyright or other restrictions. OFF-SITE? Log in with NetID\" src=\"/assets/placeholder_restricted-4d0037c54ed3900f4feaf705e801f4c980164e45ee556f60065c39b4bd4af345.png\" />")
       end

--- a/spec/system/access_restrictions_spec.rb
+++ b/spec/system/access_restrictions_spec.rb
@@ -12,8 +12,6 @@ RSpec.describe "access restrictions", type: :system, clean: true do
   # "[Map of China]. [yale-only copy]"
   let(:yale_work) { WORK_WITH_YALE_ONLY_VISIBILITY }
 
-  let(:cas) { WORK_WITH_YALE_ONLY_VISIBILITY }
-
   before do
     solr = Blacklight.default_index.connection
     solr.add(public_work)
@@ -119,8 +117,8 @@ RSpec.describe "access restrictions", type: :system, clean: true do
       expect(page.html).to match(/universal-viewer-iframe/)
     end
 
-    it 'manifest, mirador, and pdf links are disabled' do
-      visit '/catalog/2055095'
+    it 'manifest, mirador, and pdf links are NOT disabled' do
+      visit solr_document_path(public_work[:id])
       expect(page).to have_link 'Manifest Link'
       expect(page).to have_link 'View in Mirador'
       expect(page).to have_link 'Download as PDF'

--- a/spec/system/header_spec.rb
+++ b/spec/system/header_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe 'header', type: :system do
   end
 
   it 'has expected links on the main header' do
+    expect(page).to have_link('Bookmarks', href: '/bookmarks')
     expect(page).to have_link('Ask Yale Library', href: 'http://ask.library.yale.edu/')
     expect(page).to have_link('Reserve Rooms', href: 'https://schedule.yale.edu/')
     expect(page).to have_link('Places to Study', href: 'https://web.library.yale.edu/places/to-study')

--- a/spec/user_views_accessible_welcome_page_spec.rb
+++ b/spec/user_views_accessible_welcome_page_spec.rb
@@ -5,8 +5,14 @@ require 'axe/rspec'
 
 feature 'welcome', js: true do
   context 'landing page is accessible' do
-    it 'prototype working axe gem on landing page' do
+    it 'with axe gem' do
       visit "/"
+      expect(page).to be_accessible
+    end
+  end
+  context 'bookmarks page is accessible' do
+    it 'with axe gem' do
+      visit "/bookmarks"
       expect(page).to be_accessible
     end
   end


### PR DESCRIPTION
# Summary
Adds the bookmark functionality and moves the bookmark check box to the show page header instead of the tools section at the bottom of the page.

# Related Ticket
[#2663](https://github.com/yalelibrary/YUL-DC/issues/2663)

# Screenshot

![image](https://github.com/yalelibrary/yul-dc-blacklight/assets/36549923/5f36e6a2-ad9a-4222-9321-dc3508f83302)
