### PR TITLE
Fallback for nil terms

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -642,7 +642,9 @@ class CatalogController < ApplicationController
     @response, @document = search_service.fetch(params[:oid])
     if current_user && @document['visibility_ssi'] == 'Open with Permission'
       @permission_set_terms = retrieve_permission_set_terms
-      if user_owp_permissions['permission_set_terms_agreed']&.include?(@permission_set_terms['id'])
+      if @permission_set_terms.nil?
+        redirect_back(fallback_location: "#{ENV['BLACKLIGHT_HOST']}/catalog/#{params[:oid]}", notice: "We are unable to complete your access request at this time. For more information about this object, click the ‘Feedback’ link located at the bottom of this page and fill out the form. We will get back to you as soon as possible.")
+      elsif user_owp_permissions['permission_set_terms_agreed']&.include?(@permission_set_terms['id'])
         render 'catalog/request_form'
       else
         render 'catalog/terms_and_conditions'

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -638,6 +638,7 @@ class CatalogController < ApplicationController
   end
   # rubocop:enable Metrics/PerceivedComplexity
 
+  # rubocop:disable Layout/LineLength
   def request_form
     @response, @document = search_service.fetch(params[:oid])
     if current_user && @document['visibility_ssi'] == 'Open with Permission'
@@ -653,6 +654,7 @@ class CatalogController < ApplicationController
       redirect_back(fallback_location: "#{ENV['BLACKLIGHT_HOST']}/catalog/#{params[:oid]}", notice: "Please log in to request access to these materials.")
     end
   end
+  # rubocop:enable Layout/LineLength
 
   def request_confirmation
     @response, @document = search_service.fetch(params[:oid])

--- a/app/helpers/access_helper.rb
+++ b/app/helpers/access_helper.rb
@@ -67,7 +67,7 @@ module AccessHelper
     # for local debugging - http://yul-dc-management-1:3001/management or http://yul-dc_management_1:3001/management
     url = URI.parse("#{ENV['MANAGEMENT_HOST']}/api/permission_sets/#{@document[:id]}/terms")
     response = Net::HTTP.get(url)
-    JSON.parse(response)
+    JSON.parse(response) unless response.nil?
   end
 
   def client_can_view_metadata?(document)


### PR DESCRIPTION
## Summary  
Blacklight will fallback to object showpage when missing terms and conditions 
  
## Screenshot  
<img width="1771" alt="image" src="https://github.com/yalelibrary/yul-dc-blacklight/assets/24666568/02298521-2540-4dda-abb8-1e03f01a5046">
