### PR TITLE
Fix continue button link

### DIFF
--- a/app/assets/stylesheets/customOverrides/show_page.scss
+++ b/app/assets/stylesheets/customOverrides/show_page.scss
@@ -305,11 +305,23 @@ dt.blacklight-ancestordisplaystrings_tesim.metadata-block__label-key {
   margin-right: 190px;
 }
 
-.request-form-submit, .request-continue {
+.request-form-submit {
   color: white;
   background-color: $light_blue; 
   border-radius: 8px;
   height: 38px;
+}
+
+.request-continue {
+  color: white;
+  background-color: $light_blue; 
+  border-radius: 8px;
+  padding: 5px;
+}
+
+.request-continue:hover {
+  text-decoration: none !important;
+  color: white !important;
 }
 
 .terms-heading {

--- a/app/views/catalog/request_confirmation.html.erb
+++ b/app/views/catalog/request_confirmation.html.erb
@@ -67,6 +67,6 @@
     <%= "<b>Email:</b> #{current_user.email}".html_safe %><br />
     <%= "<b>Full Name:</b> #{@user_full_name}".html_safe %><br />
     <%= "<b>Reason for request:</b> #{@user_note}".html_safe %><br />
-    <button type="button" class="request-continue" onclick="javascript:history.go(-2)">Continue</button>
+    <%= link_to "Continue", "/catalog/#{@document[:id]}", class: "request-continue" %>
   </div>
 </div>


### PR DESCRIPTION
# Summary
Prior implementation used a javascript history trick to redirect back to the show page but this change will replace the JS with a standard link_to and will prevent the request loop.

# Related Ticket
[#2656](https://github.com/yalelibrary/YUL-DC/issues/2656)