### PR TITLE
Pin omniauth gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'honeybadger', '~> 4.0'
 gem 'iso-639'
 gem 'jbuilder', '~> 2.7'
 gem 'jquery-rails'
-gem 'omniauth'
+gem 'omniauth', '~> 1.9.2'
 gem 'omniauth-cas'
 # This addresses CVE-2015-9284 https://github.com/advisories/GHSA-ww4x-rwq6-qpgf
 gem 'omniauth-rails_csrf_protection', '~> 0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,7 +123,6 @@ GEM
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
-    base64 (0.2.0)
     bcrypt (3.1.20)
     bindex (0.8.1)
     bixby (5.0.2)
@@ -337,14 +336,13 @@ GEM
       builder (>= 3.1.0)
       faraday (< 3)
       faraday-follow_redirects (>= 0.3.0, < 2)
-    omniauth (2.1.2)
+    omniauth (1.9.2)
       hashie (>= 3.4.6)
-      rack (>= 2.2.3)
-      rack-protection
-    omniauth-cas (3.0.0.beta.1)
-      addressable (~> 2.8)
-      nokogiri (~> 1.12)
-      omniauth (~> 2.1)
+      rack (>= 1.6.2, < 3)
+    omniauth-cas (2.0.0)
+      addressable (~> 2.3)
+      nokogiri (~> 1.5)
+      omniauth (~> 1.2)
     omniauth-rails_csrf_protection (0.1.2)
       actionpack (>= 4.2)
       omniauth (>= 1.3.1)
@@ -365,9 +363,6 @@ GEM
       nio4r (~> 2.0)
     racc (1.7.3)
     rack (2.2.8)
-    rack-protection (3.2.0)
-      base64 (>= 0.1.0)
-      rack (~> 2.2, >= 2.2.4)
     rack-proxy (0.7.7)
       rack
     rack-test (2.1.0)
@@ -611,7 +606,7 @@ DEPENDENCIES
   jbuilder (~> 2.7)
   jquery-rails
   listen (~> 3.2)
-  omniauth
+  omniauth (~> 1.9.2)
   omniauth-cas
   omniauth-rails_csrf_protection (~> 0.1)
   openseadragon


### PR DESCRIPTION
# Summary
Experiencing log in issues with omniauth gem above version 1.9.2.  This PR pins the gem in place until troublshooting of the issue with newer versions of the gem is determined.

# Screenshot
![image](https://github.com/yalelibrary/yul-dc-blacklight/assets/36549923/0e2d1a1b-4428-4d9a-b3f8-7c701105ac6e)
