### PR TITLE
Update config and styles for gallery view

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,7 +157,7 @@ GEM
     blacklight_dynamic_sitemap (1.0.0)
       blacklight (> 7.0)
       rails
-    blacklight_range_limit (8.4.0)
+    blacklight_range_limit (8.5.0)
       blacklight (>= 7.25.2, < 9)
       deprecation
       view_component (>= 2.54, < 4)
@@ -530,7 +530,7 @@ GEM
     unf_ext (0.0.9.1)
     unicode-display_width (2.5.0)
     uri (0.13.0)
-    view_component (3.10.0)
+    view_component (2.83.0)
       activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)

--- a/app/assets/stylesheets/customOverrides/index_gallery.scss
+++ b/app/assets/stylesheets/customOverrides/index_gallery.scss
@@ -2,8 +2,7 @@
 DEFAULT MOBILE STYLING
 ********************************************************/
 
-.caption,
-.caption > .documentHeader {
+.documents-gallery > .documentHeader {
   width: 200px;
 }
 
@@ -12,11 +11,7 @@ DEFAULT MOBILE STYLING
   margin-bottom: 50px;
 }
 
-.document.col .caption .documentHeader {
-  padding-left: 15px !important;
-}
-
-.caption .document-title {
+.document-title-heading {
   font-size: 14px;
   font-family: $mallory_mp_medium, $mallory_medium, Arial, Helvetica, sans-serif;
   padding-left: 0;
@@ -25,11 +20,11 @@ DEFAULT MOBILE STYLING
   margin-top: 14px;
 }
 
-.document-title > a {
+.document-title-heading > a {
   color: $light_blue;
 }
 
-#documents .thumbnail > a {
+.documents-gallery .thumbnail-container > a {
   width: 200px;
   display: block;
 }
@@ -39,9 +34,12 @@ DEFAULT MOBILE STYLING
   flex: 0 0 100%;
 }
 
+.documents-gallery .document-metadata, .document-counter {
+  display: none;
+}
 
 @media screen and (min-width: $small_device) {
-  #documents .thumbnail > a {
+  .documents-gallery .thumbnail-container > a {
     height: 200px;
   }
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -39,7 +39,7 @@ class CatalogController < ApplicationController
     config.advanced_search[:form_solr_parameters] ||= {}
 
     ## Gallery View
-    config.view.gallery.partials = [:index_header]
+    config.view.gallery.document_component = Blacklight::Gallery::DocumentComponent
     config.show.tile_source_field = :content_metadata_image_iiif_info_ssm
     config.show.partials.insert(1, :openseadragon)
     config.http_method = :post

--- a/spec/system/search_result_spec.rb
+++ b/spec/system/search_result_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe 'search result', type: :system, clean: true do
     end
 
     it 'does not show the index number' do
-      expect(page).not_to have_selector '#documents > .document.col:first-child span'
+      expect(page).not_to have_selector('.document-counter span', visible: true)
     end
 
     it 'has a no index meta tag in header' do
@@ -95,7 +95,7 @@ RSpec.describe 'search result', type: :system, clean: true do
     end
 
     it 'does not show the index number' do
-      expect(page).not_to have_selector '#documents > .document.col:first-child span'
+      expect(page).not_to have_selector('.document-counter span', visible: true)
     end
   end
 


### PR DESCRIPTION
# Summary
The upgrade work included a update to the blacklight gallery gem.  The update to the gem introduced a [breaking change](https://github.com/projectblacklight/blacklight-gallery/releases/tag/v3.0.1) but the configuration has been updated and now thumbnails and titles are displaying as they were prior to the upgrade work.

# Related Ticket
[#2755](https://github.com/yalelibrary/YUL-DC/issues/2755)

# Screenshot
![image](https://github.com/yalelibrary/yul-dc-blacklight/assets/36549923/30df80a0-03c5-43f0-824a-2e7119687e99)
