### PR TITLE
Add terms and conditions to show page

### DIFF
--- a/app/assets/stylesheets/customOverrides/show_page.scss
+++ b/app/assets/stylesheets/customOverrides/show_page.scss
@@ -349,6 +349,23 @@ dt.blacklight-ancestordisplaystrings_tesim.metadata-block__label-key {
   width: 400px;
 }
 
+.blacklight-terms_hide_truncate_link, .blacklight-terms_show_truncate_link {
+  color: $dark_grey !important;
+}
+
+.blacklight-terms_hide_truncate_link:hover, .blacklight-terms_show_truncate_link:hover {
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.line-clamp-five {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  /* truncate to 5 lines */
+  -webkit-line-clamp: 5;
+}
+
 .blacklight-ancestortitles_tesim a{
   color: $light_blue;
 }

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -630,6 +630,7 @@ class CatalogController < ApplicationController
   def show
     super
     @search_params = session[:search_params]
+    @permission_set_terms = retrieve_permission_set_terms if @document["visibility_ssi"] == "Open with Permission"
     if @document["visibility_ssi"] == "Redirect" && @document["redirect_to_tesi"].present? && !request.original_url.include?("oai_dc_xml")
       redirect_to @document["redirect_to_tesi"]
     elsif @document["visibility_ssi"] == "Redirect" && @document["redirect_to_tesi"].present? && request.original_url.include?("oai_dc_xml")

--- a/app/views/catalog/_grouped_metadata.html.erb
+++ b/app/views/catalog/_grouped_metadata.html.erb
@@ -1,3 +1,47 @@
 <div id='doc_<%= @document.id.to_s.parameterize %>'>
   <%= render_document_partials @document, [:show] %>
 </div>
+
+<% if @permission_set_terms.present? %>
+  <script>
+    let rights = document.querySelector('dd.blacklight-rights_ssim');
+
+    function expandText() {
+      document.querySelector('dd.blacklight-terms').classList.remove('line-clamp-five')
+      document.querySelector('dt.blacklight-terms_show_truncate_link').classList.add('hidden');
+      document.querySelector('dd.blacklight-terms_show_truncate_link').classList.add('hidden');
+      document.querySelector('dt.blacklight-terms_hide_truncate_link').classList.remove('hidden');
+      document.querySelector('dd.blacklight-terms_hide_truncate_link').classList.remove('hidden');
+    }
+
+    function truncateText() {
+      document.querySelector('dd.blacklight-terms').classList.add('line-clamp-five')
+      document.querySelector('dt.blacklight-terms_show_truncate_link').classList.remove('hidden');
+      document.querySelector('dd.blacklight-terms_show_truncate_link').classList.remove('hidden');
+      document.querySelector('dt.blacklight-terms_hide_truncate_link').classList.add('hidden');
+      document.querySelector('dd.blacklight-terms_hide_truncate_link').classList.add('hidden');
+    }
+
+    rights.outerHTML += "<dt class='blacklight-terms metadata-block__label-key'>Terms & Conditions</dt><dd class='blacklight-terms metadata-block__label-value metadata-block__label-value--yul line-clamp-five'><%= @permission_set_terms['body'] %></dd><dt class='blacklight-terms_show_truncate_link'></dt><dd class='blacklight-terms_show_truncate_link metadata-block__label-value metadata-block__label-value--yul' onclick='expandText()'>Show Full Terms & Conditions</dd><dt class='blacklight-terms_hide_truncate_link'></dt><dd class='blacklight-terms_hide_truncate_link metadata-block__label-value metadata-block__label-value--yul' onclick='truncateText()'>Hide Full Terms & Conditions</dd>";
+
+    let terms = document.querySelector('dd.blacklight-terms');
+
+    if (terms.offsetHeight < terms.scrollHeight ||
+    terms.offsetWidth < terms.scrollWidth) {
+      // your element has overflow and truncated
+      // show read more / read less button
+      console.log('it is shorter than really is')
+      document.querySelector('dt.blacklight-terms_show_truncate_link').classList.remove('hidden');
+      document.querySelector('dd.blacklight-terms_show_truncate_link').classList.remove('hidden');
+      document.querySelector('dt.blacklight-terms_hide_truncate_link').classList.add('hidden');
+      document.querySelector('dd.blacklight-terms_hide_truncate_link').classList.add('hidden');
+    } else {
+      // your element doesn't overflow (not truncated)
+      console.log('it is short')
+      document.querySelector('dt.blacklight-terms_show_truncate_link').classList.add('hidden');
+      document.querySelector('dd.blacklight-terms_show_truncate_link').classList.add('hidden');
+      document.querySelector('dt.blacklight-terms_hide_truncate_link').classList.add('hidden');
+      document.querySelector('dd.blacklight-terms_hide_truncate_link').classList.add('hidden');
+    };
+  </script>
+<% end %>

--- a/app/views/catalog/_grouped_metadata.html.erb
+++ b/app/views/catalog/_grouped_metadata.html.erb
@@ -28,16 +28,13 @@
 
     if (terms.offsetHeight < terms.scrollHeight ||
     terms.offsetWidth < terms.scrollWidth) {
-      // your element has overflow and truncated
-      // show read more / read less button
-      console.log('it is shorter than really is')
+      // your element has overflow and is truncated
       document.querySelector('dt.blacklight-terms_show_truncate_link').classList.remove('hidden');
       document.querySelector('dd.blacklight-terms_show_truncate_link').classList.remove('hidden');
       document.querySelector('dt.blacklight-terms_hide_truncate_link').classList.add('hidden');
       document.querySelector('dd.blacklight-terms_hide_truncate_link').classList.add('hidden');
     } else {
       // your element doesn't overflow (not truncated)
-      console.log('it is short')
       document.querySelector('dt.blacklight-terms_show_truncate_link').classList.add('hidden');
       document.querySelector('dd.blacklight-terms_show_truncate_link').classList.add('hidden');
       document.querySelector('dt.blacklight-terms_hide_truncate_link').classList.add('hidden');


### PR DESCRIPTION
# Summary
Adds the terms and conditions for an open with permission object to the show page, just under the rights statement, with truncation toggle for long text.

# Related Ticket
[#2745](https://github.com/yalelibrary/YUL-DC/issues/2745)

# Screenshot
![image](https://github.com/yalelibrary/yul-dc-blacklight/assets/36549923/73218eff-bbb4-4238-a561-b311facf9701)
