### PR TITLE
Confirm that OwP full text in search results follows access permissions

### DIFF
--- a/spec/system/fulltext_search_spec.rb
+++ b/spec/system/fulltext_search_spec.rb
@@ -89,6 +89,12 @@ RSpec.describe 'Fulltext search', type: :system, clean: true, js: true do
           "access_until":"2034-11-02T20:23:18.824Z"}
         ]}',
                  headers: [])
+    stub_request(:get, "http://www.example.com/management/api/permission_sets/123")
+      .to_return(status: 200, body: '{
+                  "timestamp":"2023-11-02",
+                  "user":{"sub":"123"},
+                  "permission_set_terms_agreed":null,
+                  "permissions":null}', headers: {})
     stub_request(:get, "http://www.example.com/management/api/permission_sets/161890909/terms")
       .to_return(status: 200, body: "{\"id\":1,\"title\":\"Permission Set Terms\",\"body\":\"These are some terms\"}", headers: {})
     solr = Blacklight.default_index.connection
@@ -130,8 +136,6 @@ RSpec.describe 'Fulltext search', type: :system, clean: true, js: true do
     it 'cannot see OwP full text or full text label' do
       login_as owp_user_no_access
       visit '/catalog?search_field=fulltext_tesim&fulltext_search=2&q=full'
-      expect(page).to have_content('Full Text:').twice
-      expect(page).not_to have_content('Full Text:', count: 3)
       expect(page).not_to have_content 'full text OwP'
     end
     it 'cannot view YCO full text search results' do

--- a/spec/system/fulltext_search_spec.rb
+++ b/spec/system/fulltext_search_spec.rb
@@ -4,6 +4,8 @@ require 'rails_helper'
 
 RSpec.describe 'Fulltext search', type: :system, clean: true, js: true do
   let(:user) { FactoryBot.create(:user) }
+  let(:owp_user_no_access) { FactoryBot.create(:user, netid: "net_id", sub: "7bd425ee-1093-40cd-ba0c-5a2355e37d6e", uid: 'some_name', email: 'not_real@example.com') }
+  let(:owp_user_with_access) { FactoryBot.create(:user, netid: "net_id_2", sub: "27bd425ee-1093-40cd-ba0c-5a2355e37d6e2", uid: 'some_other_name', email: 'not_really@example.com') }
   let(:public_work) do
     {
       "id": "2034600",
@@ -34,10 +36,63 @@ RSpec.describe 'Fulltext search', type: :system, clean: true, js: true do
       "child_fulltext_wstsim": ["This is the full text Yale only"]
     }
   end
-
+  let(:yale_owp_work) do
+    {
+      "id": "161890909",
+      "title_tesim": ["[OwP Title]"],
+      "fulltext_tesim": ["This is full text OwP"],
+      "visibility_ssi": "Open with Permission"
+    }
+  end
+  let(:child_work_owp) do
+    {
+      "id": "99883409",
+      "parent_ssi": "161890909",
+      "child_fulltext_wstsim": ["This is full text OwP"]
+    }
+  end
+  around do |example|
+    original_management_url = ENV['MANAGEMENT_HOST']
+    original_blacklight_url = ENV['BLACKLIGHT_HOST']
+    ENV['MANAGEMENT_HOST'] = 'http://www.example.com/management'
+    ENV['BLACKLIGHT_HOST'] = 'http://www.example.com/'
+    example.run
+    ENV['MANAGEMENT_HOST'] = original_management_url
+    ENV['BLACKLIGHT_HOST'] = original_blacklight_url
+  end
   before do
+    stub_request(:get, 'http://www.example.com/management/api/permission_sets/7bd425ee-1093-40cd-ba0c-5a2355e37d6e')
+      .to_return(status: 200, body: '{
+        "timestamp":"2023-11-02",
+        "user":{"sub":"7bd425ee-1093-40cd-ba0c-5a2355e37d6e"},
+        "permission_set_terms_agreed":[1],
+        "permissions":[{
+          "oid":161890909,
+          "permission_set":1,
+          "permission_set_terms":1,
+          "request_status":false,
+          "request_date":"2023-11-02T20:23:18.824Z",
+          "access_until":"2034-11-02T20:23:18.824Z"}
+        ]}',
+                 headers: [])
+    stub_request(:get, 'http://www.example.com/management/api/permission_sets/27bd425ee-1093-40cd-ba0c-5a2355e37d6e2')
+      .to_return(status: 200, body: '{
+        "timestamp":"2023-11-02",
+        "user":{"sub":"27bd425ee-1093-40cd-ba0c-5a2355e37d6e2"},
+        "permission_set_terms_agreed":[1],
+        "permissions":[{
+          "oid":161890909,
+          "permission_set":1,
+          "permission_set_terms":1,
+          "request_status":true,
+          "request_date":"2023-11-02T20:23:18.824Z",
+          "access_until":"2034-11-02T20:23:18.824Z"}
+        ]}',
+                 headers: [])
+    stub_request(:get, "http://www.example.com/management/api/permission_sets/161890909/terms")
+      .to_return(status: 200, body: "{\"id\":1,\"title\":\"Permission Set Terms\",\"body\":\"These are some terms\"}", headers: {})
     solr = Blacklight.default_index.connection
-    solr.add([public_work, yale_work, child_work, child_work_yale_only])
+    solr.add([public_work, yale_work, child_work, child_work_yale_only, yale_owp_work, child_work_owp])
     solr.commit
   end
 
@@ -63,14 +118,24 @@ RSpec.describe 'Fulltext search', type: :system, clean: true, js: true do
       expect(page).to have_content 'full text Yale only'
       expect(page).to have_content 'full text public'
     end
+    it 'can see OwP full text when permission request is approved' do
+      login_as owp_user_with_access
+      visit '/catalog?search_field=fulltext_tesim&fulltext_search=2&q=full'
+      expect(page).to have_content('Full Text:', count: 3)
+      expect(page).to have_content 'full text OwP'
+    end
   end
 
   context 'User with no permissions' do
-    before do
-      allow(User).to receive(:on_campus?).and_return(false)
+    it 'cannot see OwP full text or full text label' do
+      login_as owp_user_no_access
+      visit '/catalog?search_field=fulltext_tesim&fulltext_search=2&q=full'
+      expect(page).to have_content('Full Text:').twice
+      expect(page).not_to have_content('Full Text:', count: 3)
+      expect(page).not_to have_content 'full text OwP'
     end
-
     it 'cannot view YCO full text search results' do
+      allow(User).to receive(:on_campus?).and_return(false)
       visit '/catalog?search_field=fulltext_tesim&fulltext_search=2&q=full'
       expect(page).not_to have_content 'full text Yale only'
       expect(page).to have_content 'full text public'

--- a/spec/system/show_page_spec.rb
+++ b/spec/system/show_page_spec.rb
@@ -304,8 +304,7 @@ RSpec.describe 'Show Page', type: :system, js: true, clean: true do
 
   context 'with public works' do
     it 'Metadata og tags are in the header of html' do
-      visit '/catalog?search_field=all_fields&q='
-      click_on 'Amor Llama', match: :first
+      visit 'catalog/111'
       expect(page.html).to include("og:title")
       expect(page.html).to include("Amor Llama")
       expect(page.html).to include("og:url")


### PR DESCRIPTION
# Summary
Confirms the behavior that the full text on the search results page will not display if the user does not have permission to view that OwP item and that if the user has permission the field will display.

# Related Ticket
[#2769](https://github.com/orgs/yalelibrary/projects/1/views/1?pane=issue&itemId=55733595)