### PR TITLE
fixes search bug with owp admin/approver access

### DIFF
--- a/app/helpers/access_helper.rb
+++ b/app/helpers/access_helper.rb
@@ -12,7 +12,7 @@ module AccessHelper
     when 'Yale Community Only'
       return true if (current_user && current_user.netid.present?) || User.on_campus?(request.remote_ip)
     when 'Open with Permission'
-      return true if client_can_view_owp?(document)
+      return true if client_can_view_owp?(document) || admin_of_owp?(document)
     end
     false
   end
@@ -20,12 +20,6 @@ module AccessHelper
   def client_can_view_owp?(document)
     Rails.logger.warn("starting client can view digital check for #{request.env['HTTP_X_ORIGIN_URI']}")
     return true if object_owp?(document) && user_has_permission?(document)
-    false
-  end
-
-  def admin_or_approver_of_owp?(document)
-    Rails.logger.warn("starting client can view digital check for #{request.env['HTTP_X_ORIGIN_URI']}")
-    return true if object_owp?(document) && admin_of_owp?(document)
     false
   end
 

--- a/app/views/catalog/_show_main_content.html.erb
+++ b/app/views/catalog/_show_main_content.html.erb
@@ -13,11 +13,6 @@
       <%= render_document_partials @document, [:archival_context] %>
       <%= render_document_partials @document, [:uv] %>
       <%= render "grouped_metadata" %>
-    <% elsif client_can_view_owp?(@document) && current_user %>
-      <%= render_document_partials @document, [:show_header] %>
-      <%= render_document_partials @document, [:archival_context] %>
-      <%= render_document_partials @document, [:uv] %>
-      <%= render "grouped_metadata" %>
     <% elsif object_owp?(@document) && pending_request?(@document) && current_user %>
       <%= render_document_partials @document, [:show_header] %>
       <div class='text-container'>

--- a/spec/system/fulltext_search_spec.rb
+++ b/spec/system/fulltext_search_spec.rb
@@ -89,6 +89,16 @@ RSpec.describe 'Fulltext search', type: :system, clean: true, js: true do
           "access_until":"2034-11-02T20:23:18.824Z"}
         ]}',
                  headers: [])
+    stub_request(:get, "http://www.example.com/management/api/permission_sets/161890909/#{user.netid}")
+      .to_return(status: 200, body: '{
+        "is_admin_or_approver?":"false"
+      }',
+                  headers: [])
+    stub_request(:get, "http://www.example.com/management/api/permission_sets/161890909/#{owp_user_with_access.netid}")
+      .to_return(status: 200, body: '{
+        "is_admin_or_approver?":"false"
+      }',
+                  headers: [])
     stub_request(:get, "http://www.example.com/management/api/permission_sets/123")
       .to_return(status: 200, body: '{
                   "timestamp":"2023-11-02",

--- a/spec/system/fulltext_search_spec.rb
+++ b/spec/system/fulltext_search_spec.rb
@@ -99,6 +99,11 @@ RSpec.describe 'Fulltext search', type: :system, clean: true, js: true do
         "is_admin_or_approver?":"false"
       }',
                  headers: [])
+    stub_request(:get, "http://www.example.com/management/api/permission_sets/161890909/#{owp_user_no_access.netid}")
+      .to_return(status: 200, body: '{
+        "is_admin_or_approver?":"false"
+      }',
+                 headers: [])
     stub_request(:get, "http://www.example.com/management/api/permission_sets/123")
       .to_return(status: 200, body: '{
                   "timestamp":"2023-11-02",

--- a/spec/system/fulltext_search_spec.rb
+++ b/spec/system/fulltext_search_spec.rb
@@ -93,12 +93,12 @@ RSpec.describe 'Fulltext search', type: :system, clean: true, js: true do
       .to_return(status: 200, body: '{
         "is_admin_or_approver?":"false"
       }',
-                  headers: [])
+                 headers: [])
     stub_request(:get, "http://www.example.com/management/api/permission_sets/161890909/#{owp_user_with_access.netid}")
       .to_return(status: 200, body: '{
         "is_admin_or_approver?":"false"
       }',
-                  headers: [])
+                 headers: [])
     stub_request(:get, "http://www.example.com/management/api/permission_sets/123")
       .to_return(status: 200, body: '{
                   "timestamp":"2023-11-02",

--- a/spec/system/show_page_spec.rb
+++ b/spec/system/show_page_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 
 RSpec.describe 'Show Page', type: :system, js: true, clean: true do
   let(:user) { FactoryBot.create(:user) }
-  let(:management_approver) { FactoryBot.create(:user, netid: 'net_id2', sub: '1234')}
+  let(:management_approver) { FactoryBot.create(:user, netid: 'net_id2', sub: '1234') }
   let(:request_user) { FactoryBot.create(:user, netid: "net_id", sub: "7bd425ee-1093-40cd-ba0c-5a2355e37d6e", uid: 'some_name', email: 'not_real@example.com') }
   let(:thumbnail_size_in_opengraph) { "!1200,630" }
   let(:thumbnail_size_in_solr) { "!200,200" }
@@ -75,7 +75,7 @@ RSpec.describe 'Show Page', type: :system, js: true, clean: true do
           "request_date":"2023-11-02T20:23:18.824Z",
           "access_until":"2034-11-02T20:23:18.824Z"}
         ]}',
-                headers: [])
+                 headers: [])
     stub_request(:get, "http://www.example.com/management/api/permission_sets/12345/terms")
       .to_return(status: 200, body: "{\"id\":1,\"title\":\"Permission Set Terms\",\"body\":\"These are some terms\"}", headers: {})
     stub_request(:get, 'http://www.example.com/management/api/permission_sets/7bd425ee-1093-40cd-ba0c-5a2355e37d6e')

--- a/spec/system/show_page_spec.rb
+++ b/spec/system/show_page_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 
 RSpec.describe 'Show Page', type: :system, js: true, clean: true do
   let(:user) { FactoryBot.create(:user) }
+  let(:management_approver) { FactoryBot.create(:user, netid: 'net_id2', sub: '1234')}
   let(:request_user) { FactoryBot.create(:user, netid: "net_id", sub: "7bd425ee-1093-40cd-ba0c-5a2355e37d6e", uid: 'some_name', email: 'not_real@example.com') }
   let(:thumbnail_size_in_opengraph) { "!1200,630" }
   let(:thumbnail_size_in_solr) { "!200,200" }
@@ -32,6 +33,21 @@ RSpec.describe 'Show Page', type: :system, js: true, clean: true do
       .to_return(status: 200, body: File.open(File.join('spec', 'fixtures', '2041002.json')).read)
     stub_request(:get, 'http://www.example.com/management/api/permission_sets/123')
       .to_return(status: 200, body: '{"timestamp":"2023-11-02","user":{"sub":"123"},"permission_set_terms_agreed":[],"permissions":[{"oid":12345,"permission_set":1,"permission_set_terms":1,"request_status":true,"request_date":"2023-11-02T20:23:18.824Z","access_until":"2024-11-02T20:23:18.824Z"}]}', headers: [])
+    stub_request(:get, "http://www.example.com/management/api/permission_sets/12345/#{user.netid}")
+      .to_return(status: 200, body: '{
+        "is_admin_or_approver?":"false"
+        }',
+                 headers: [])
+    stub_request(:get, "http://www.example.com/management/api/permission_sets/54321/#{user.netid}")
+      .to_return(status: 200, body: '{
+        "is_admin_or_approver?":"false"
+        }',
+                 headers: [])
+    stub_request(:get, "http://www.example.com/management/api/permission_sets/12345/#{management_approver.netid}")
+      .to_return(status: 200, body: '{
+        "is_admin_or_approver?":"true"
+        }',
+                 headers: [])
     stub_request(:get, 'http://www.example.com/management/api/permission_sets/7bd425ee-1093-40cd-ba0c-5a2355e37d6e')
       .to_return(status: 200, body: '{
         "timestamp":"2023-11-02",
@@ -46,6 +62,20 @@ RSpec.describe 'Show Page', type: :system, js: true, clean: true do
           "access_until":"2034-11-02T20:23:18.824Z"}
         ]}',
                  headers: [])
+    stub_request(:get, 'http://www.example.com/management/api/permission_sets/1234')
+      .to_return(status: 200, body: '{
+        "timestamp":"2023-11-02",
+        "user":{"sub":"1234"},
+        "permission_set_terms_agreed":[],
+        "permissions":[{
+          "oid":12345,
+          "permission_set":1,
+          "permission_set_terms":1,
+          "request_status":false,
+          "request_date":"2023-11-02T20:23:18.824Z",
+          "access_until":"2034-11-02T20:23:18.824Z"}
+        ]}',
+                headers: [])
     stub_request(:get, "http://www.example.com/management/api/permission_sets/12345/terms")
       .to_return(status: 200, body: "{\"id\":1,\"title\":\"Permission Set Terms\",\"body\":\"These are some terms\"}", headers: {})
     stub_request(:get, 'http://www.example.com/management/api/permission_sets/7bd425ee-1093-40cd-ba0c-5a2355e37d6e')
@@ -374,10 +404,24 @@ RSpec.describe 'Show Page', type: :system, js: true, clean: true do
       visit 'catalog/12345'
       expect(page).not_to have_content "The material in this folder is open for research use only with permission. Researchers who wish to gain access or who have received permission to view this item, please log in to your account to request permission or to view the materials in this folder."
       expect(page).not_to have_content "You are currently logged in to your account. However, you do not have permission to view this folder. If you would like to request permission, please fill out this form."
+      expect(page).to have_css('.uv-container')
     end
     it 'displays login message when accessing an OwP object without access' do
       visit 'catalog/54321'
       expect(page).to have_content "You are currently logged in to your account. However, you do not have permission to view this folder. If you would like to request permission, please fill out this form."
+      expect(page).not_to have_css('.uv-container')
+    end
+  end
+
+  context "Open with Permission objects and signed in as a management approver/admin" do
+    before do
+      login_as management_approver
+    end
+    it 'can access the object and view UV and metadata normally without approver_status' do
+      visit 'catalog/12345'
+      expect(page).not_to have_content "The material in this folder is open for research use only with permission. Researchers who wish to gain access or who have received permission to view this item, please log in to your account to request permission or to view the materials in this folder."
+      expect(page).not_to have_content "You are currently logged in to your account. However, you do not have permission to view this folder. If you would like to request permission, please fill out this form."
+      expect(page).to have_css('.uv-container')
     end
   end
 


### PR DESCRIPTION
## Summary  
Original PR was reverted due to search bug in Blacklight. This PR resolves the search bug. OwP items/thumbnails are accessible and visible to Permission Set Admins/Approvers