### PR TITLE
Full Text label wording 

### DIFF
--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -449,7 +449,7 @@ module BlacklightHelper
   end
 
   def fulltext_snippet_separation(options = {})
-    return unless client_can_view_digital?(options[:document])
+    return "Available with permission" unless client_can_view_digital?(options[:document])
     # Some snippets come back with new lines embedded without them. We don't want that.
     # We do however want new lines after a snippet, to show separation
     # the "tr" below has to use double quotes, otherwise it will remove the character 'n', instead of new line notations

--- a/spec/system/fulltext_search_spec.rb
+++ b/spec/system/fulltext_search_spec.rb
@@ -152,12 +152,14 @@ RSpec.describe 'Fulltext search', type: :system, clean: true, js: true do
       login_as owp_user_no_access
       visit '/catalog?search_field=fulltext_tesim&fulltext_search=2&q=full'
       expect(page).not_to have_content 'full text OwP'
+      expect(page).to have_content('Available with permission')
     end
     it 'cannot view YCO full text search results' do
       allow(User).to receive(:on_campus?).and_return(false)
       visit '/catalog?search_field=fulltext_tesim&fulltext_search=2&q=full'
       expect(page).not_to have_content 'full text Yale only'
       expect(page).to have_content 'full text public'
+      expect(page).to have_content('Available with permission')
     end
   end
 end


### PR DESCRIPTION
## Summary  
Full Text items being viewed by unauthorized users will see a "Available with permission" next to the Full Text label:  
  
## Screenshot:  
Without permission:  
<img width="1266" alt="image" src="https://github.com/yalelibrary/yul-dc-blacklight/assets/24666568/47c95671-f07b-4334-8f96-4b808bd00a4c">
  
With permission:  
<img width="1283" alt="image" src="https://github.com/yalelibrary/yul-dc-blacklight/assets/24666568/e878e584-ab79-48a2-bbde-1f3c412fd877">
