### PR TITLE
Updates to requests page

### DIFF
--- a/app/views/permission_requests/index.html.erb
+++ b/app/views/permission_requests/index.html.erb
@@ -2,7 +2,6 @@
 
 <div id="permission-requests-page" class="col-md-12">
   <h2 id='permission-requests-page-heading'><%= t('blacklight.permission_requests.title') %></h2>
-  <button id="back-to-bookmarks"><a href=<%= bookmarks_path %>><%= t('blacklight.permission_requests.bookmark_button') %></a></button>
 
   <%- if current_or_guest_user.blank? -%>
 

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -31,5 +31,5 @@ en:
       bookmark_button: 'BACK TO BOOKMARKS'
       need_login: 'Please log in to view your requests'
       no_requests: 'No requests found'
-      title: 'Digital Access Requests'
+      title: 'Access Requests'
       page_title: 'User Digital Access Requests'

--- a/spec/system/open_with_permission/user_requests_table_page_spec.rb
+++ b/spec/system/open_with_permission/user_requests_table_page_spec.rb
@@ -161,8 +161,6 @@ RSpec.describe "Open with Permission", type: :system do
         # access expires column displays N/A for Pending or Denied requests
         expect(page).to have_content('N/A', count: 3)
         expect(page).to have_content('11/02/34').twice
-        # has a button that goes to /bookmarks
-        expect(page).to have_link 'BACK TO BOOKMARKS', href: bookmarks_path
       end
 
       it 'can search as expected' do

--- a/spec/system/open_with_permission/user_requests_table_page_spec.rb
+++ b/spec/system/open_with_permission/user_requests_table_page_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe "Open with Permission", type: :system do
       it 'can display as expected' do
         expect(page).to have_http_status(:success)
         # Header is present
-        expect(page).to have_content 'Digital Access Requests'
+        expect(page).to have_content 'Access Requests'
         # table has 5 columns: title, call number, request date, status, access expires
         expect(page).to have_content 'Title'
         expect(page).to have_content 'Call Number'


### PR DESCRIPTION
## Summary  
Removes "Back to Bookmarks" button and updated "Digital Access Requests" to "Access Requests".  
  
## Screenshot:  
<img width="1792" alt="image" src="https://github.com/yalelibrary/yul-dc-blacklight/assets/24666568/04374b21-d77e-40fc-aaff-adf72af52964">
