### PR TITLE
Adjust spacing to prevent text overlap and excessive line height

### DIFF
--- a/app/assets/stylesheets/customOverrides/landing.scss
+++ b/app/assets/stylesheets/customOverrides/landing.scss
@@ -175,7 +175,7 @@ DEFAULT MOBILE STYLING
 			position: relative;
 			overflow: hidden;
 			min-width: 343px;
-			min-height: 225px;
+			min-height: 275px;
 			width: 23%;
 			background-size: 100% 193px;
 			background-repeat: no-repeat;
@@ -249,12 +249,18 @@ DEFAULT MOBILE STYLING
 }
 
 
-#content-statement a {
+#content-statement { 
+	a {
 	margin-left: 0px !important;
-}
+	}
 
-#content-statement p {
-	width: 95%;
+	p {
+		width: 95%;
+	}
+
+	h2 {
+		line-height: 1.25;
+	}
 }
 
 @media screen and (min-width: $small_device) {
@@ -291,6 +297,10 @@ DEFAULT MOBILE STYLING
 	#content-statement {
 		margin-top: -5px;
 		margin-bottom: 50px;
+
+			h2 {
+				line-height: 1.5;
+			}
 	}
 }
 
@@ -336,7 +346,7 @@ DEFAULT MOBILE STYLING
 		width: 726px;
 
 		.highlight-link {
-			margin-left: 1%;
+			margin-left: 5%;
 			max-width: 261px;
 		}
 
@@ -359,7 +369,7 @@ DEFAULT MOBILE STYLING
 			}
 
 			.btn {
-				height: 250px;
+				height: 275px;
 			}
 		}
 
@@ -375,6 +385,10 @@ DEFAULT MOBILE STYLING
 	#content-statement {
 		margin-top: -50px;
 		margin-bottom: 50px;
+
+		h2 {
+			line-height: 1.75;
+		}
 	}
 	#coming-soon {
 		left: -4%;
@@ -443,7 +457,7 @@ DEFAULT MOBILE STYLING
 		width: auto;
 
 		a {
-			margin-bottom: -48%;
+			margin-bottom: -42%;
 		}
 
 		h2 {
@@ -456,7 +470,7 @@ DEFAULT MOBILE STYLING
 			.btn {
 				width: auto;
 				min-width: 205px;
-				height: 270px;
+				height: 290px;
 				background-size: 100% 127px;
 				top: 0;
 			}
@@ -476,12 +490,16 @@ DEFAULT MOBILE STYLING
 	}
 
 	#content-statement {
-		margin-top: -175px;
+		margin-top: -125px;
 		margin-bottom: 50px;
-	}
 
-	#content-statement p {
-		width: 98%;
+		p {
+			width: 98%;
+		}
+
+		h2 {
+			line-height: 2;
+		}
 	}
 }
 
@@ -573,11 +591,16 @@ DEFAULT MOBILE STYLING
 	#content-statement {
 		margin-top: -175px;
 		margin-bottom: 50px;
+		
+		p {
+			margin-left: -30px;
+		}
+
+		h2 {
+			line-height: 2.25;
+		}
 	}
 
-	#content-statement p {
-		margin-left: -30px;
-	}
 	#coming-soon {
 		left: -2%;
 	}


### PR DESCRIPTION
# Summary
On mobile screen the text for the harmful content statement header had too much of a gap.  In adjust this a few other changes were needed to ensure that text would not overlap or be hidden.

# Related Ticket
[#2584](https://github.com/yalelibrary/YUL-DC/issues/2584)

# Screenshots

<details>

### Desktop
![image](https://github.com/yalelibrary/yul-dc-blacklight/assets/36549923/4df17f2e-4c7a-49fc-acb1-5f86f91aaba5)


### Mobile
![image](https://github.com/yalelibrary/yul-dc-blacklight/assets/36549923/eff35b42-9a0e-4426-a416-678e0d576029)



</details>