### PR TITLE
increases metadata margin for mobile

### DIFF
--- a/app/assets/stylesheets/customOverrides/search_result.scss
+++ b/app/assets/stylesheets/customOverrides/search_result.scss
@@ -228,6 +228,12 @@ DEFAULT MOBILE STYLING
     }
   }
 
+  @media screen and (min-width: $mini_device) {
+    .dl-invert dd {
+      margin-left: 93px;
+    }
+  }
+
   @media screen and (min-width: $xlarge_device) {
     margin-left: 0;
 

--- a/app/assets/stylesheets/customOverrides/search_result.scss
+++ b/app/assets/stylesheets/customOverrides/search_result.scss
@@ -230,7 +230,7 @@ DEFAULT MOBILE STYLING
 
   @media screen and (min-width: $mini_device) {
     .dl-invert dd {
-      margin-left: 93px;
+      margin-left: 100px;
     }
   }
 


### PR DESCRIPTION
## Summary  
Metadata on mobile will no longer overlap.  
  
## Screenshot  
<img width="853" alt="image" src="https://github.com/yalelibrary/yul-dc-blacklight/assets/24666568/b7936b16-00ca-4ff2-8690-6e69deb60067">
