### PR TITLE
Mark flappy specs as pending

### DIFF
--- a/spec/system/show_page_spec.rb
+++ b/spec/system/show_page_spec.rb
@@ -170,7 +170,8 @@ RSpec.describe 'Show Page', type: :system, js: true, clean: true do
       expect(page).to have_css('.fulltext-button')
       expect(page).to have_content('Show Full Text')
     end
-    it 'Metadata og tags are in the header of html' do
+    # flappy
+    xit 'Metadata og tags are in the header of html' do
       expect(page.html).to include("og:title")
       expect(page.html).to include("Amor Llama")
       expect(page.html).to include("og:url")
@@ -239,7 +240,8 @@ RSpec.describe 'Show Page', type: :system, js: true, clean: true do
   end
 
   context 'Full text button' do
-    it 'does not have a full text button without full text available' do
+    # flappy
+    xit 'does not have a full text button without full text available' do
       visit '/catalog?search_field=all_fields&q='
       click_on 'HandsomeDan Bulldog', match: :first
 

--- a/spec/system/sort_in_search_spec.rb
+++ b/spec/system/sort_in_search_spec.rb
@@ -170,7 +170,8 @@ RSpec.describe 'Search results should be sorted', type: :system, js: :true, clea
   end
 
   context 'sorts by collection with correct facets' do
-    it 'does not have sort by collection by default' do
+    # flappy
+    xit 'does not have sort by collection by default' do
       visit "/catalog?f[collection_title_ssi][]=Test"
       content = find(:css, '#content')
       expect(content).to have_content("HandsomeDan Bulldog\nCreator:\nAndy Graves\nRhett Lecheire\nCreator:\nPaulo Coelho").or have_content("1.\nHandsomeDan Bulldog\nCreator:\nAndy Graves\n2.\nRhett Lecheire\nCreator:\nPaulo Coelho")


### PR DESCRIPTION
# Summary
A few tests are behaving inconsistently in CI so they have been marked as pending because they do pass locally and in CI but the number of reruns it takes to pass is too high.

# Related Ticket
[#2852](https://github.com/yalelibrary/YUL-DC/issues/2852)

# Screenshot

<details>

![image](https://github.com/yalelibrary/yul-dc-blacklight/assets/36549923/d74ef197-448b-4a75-9340-d148ff49f000)

</details>