### PR TITLE
Fixes overlapping links, metadata, and titles

### DIFF
--- a/app/assets/stylesheets/customOverrides/show_page.scss
+++ b/app/assets/stylesheets/customOverrides/show_page.scss
@@ -22,7 +22,6 @@ dd.blacklight-containergrouping_tesim.metadata-block__label-value.metadata-block
   flex: available;
   flex: -moz-available;
   position: relative;
-  left: -0.50%;
   min-width: 5%;
   max-width: 30%;
 }
@@ -96,11 +95,9 @@ dt.blacklight-ancestordisplaystrings_tesim.metadata-block__label-key {
   font-family: $mallory_bold;
   font-size: 14px;
   background-color: $lighter_grey;
-  margin: 0;
-  padding-left: 3%;
+  margin: 0px 0px 15px 0px;
+  padding: 2%;
   width: 100%;
-  height: 37px;
-  padding-top: 2%!important;
   #popup_window {
     padding-left: 1.5%;
     padding-bottom: 0.75%;
@@ -114,11 +111,10 @@ dt.blacklight-ancestordisplaystrings_tesim.metadata-block__label-key {
 .showpage_no_label_tag.blacklight-findingaid_ssim {
   font-family: $mallory_bold;
   font-size: 14px;
-  padding-bottom: 2%;
-  padding-left: 3%;
+  padding: 2%;
   background-color: $lighter_grey;
+  margin: 0px 0px 15px 0px;
   width: 100%;
-  padding-top: 0;
   #popup_window{
     padding-left: 1.5%;
     padding-bottom: 0.75%
@@ -253,6 +249,7 @@ dt.blacklight-ancestordisplaystrings_tesim.metadata-block__label-key {
   color: $medium_grey;
   font-family: $mallory_medium, Arial, Helvetica, sans-serif !important;
   font-weight: 500;
+  padding-left: 25px;
 }
 
 .metadata-block__group {
@@ -471,13 +468,6 @@ p.yale-restricted-work-text{
   .aSpace_tree li {
     left: 0;
   }
-
-  .showpage_no_label_tag.blacklight-archivespaceuri_ssi {
-    height: 42px;
-  }
-  dd.blacklight-containergrouping_tesim.metadata-block__label-value.metadata-block__label-value--yul {
-    left: -0.85%;
-  }
 }
 
 
@@ -570,7 +560,6 @@ p.yale-restricted-work-text{
   }
 
   .showpage_no_label_tag,.blacklight-findingaid_ssim{
-    padding-bottom: 2%;
     padding-left: 2%;
   }
 
@@ -582,9 +571,6 @@ p.yale-restricted-work-text{
       padding-left: 1.5%;
       padding-bottom: 0.75%;
     }
-  }
-  dd.blacklight-containergrouping_tesim.metadata-block__label-value.metadata-block__label-value--yul {
-    left: -0.5%;
   }
 }
 
@@ -645,9 +631,5 @@ p.yale-restricted-work-text{
   .aSpace_tree {
     margin-top: 2%;
     margin-left: -3%;
-  }
-
-  .showpage_no_label_tag.blacklight-archivespaceuri_ssi {
-    height: 50px;
   }
 }

--- a/app/assets/stylesheets/customOverrides/subheader_users.scss
+++ b/app/assets/stylesheets/customOverrides/subheader_users.scss
@@ -3,9 +3,7 @@ DEFAULT MOBILE STYLING
 ********************************************************/
 
 .user-subheader {
-  margin-left: 15px;
-  margin-right: 15px;
-  margin-bottom: 10px;
+  margin: 25px 15px 10px 15px;
   display: flex;
   border-bottom: .5px solid $light_grey;
   padding-bottom: 6px;


### PR DESCRIPTION
# Summary
Metadata overlapped it's title on Safari browsers 275px wide or less and this PR fixes that issue in Safari along with the overlap of ASpace links and the 'Digital Collections' overlapping the full text search radio button that was occurring in all browsers at 450px and below.

# Related Ticket
[#2872](https://github.com/yalelibrary/YUL-DC/issues/2872)

# Screenshot

<details>

## After
![image](https://github.com/yalelibrary/yul-dc-blacklight/assets/36549923/35b55f63-b4e2-4a4c-8a86-776dbf63f826)
 
![image](https://github.com/yalelibrary/yul-dc-blacklight/assets/36549923/9f02b660-980e-466a-b309-e457ab866966)


## Before
![image](https://github.com/yalelibrary/yul-dc-blacklight/assets/36549923/6cda0c7e-8c3c-4c11-a28f-55ddcb67f279)

![image](https://github.com/yalelibrary/yul-dc-blacklight/assets/36549923/f752dfee-0c43-4c68-b7cf-71cf5648308b)


</details>