### PR TITLE
Adds space so metadata label will wrap on small screens

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -249,7 +249,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'repository_ssi', label: 'Repository', metadata: 'collection_information'
     config.add_show_field 'callNumber_ssim', label: 'Call Number', metadata: 'collection_information', link_to_facet: true
     config.add_show_field 'sourceTitle_tesim', label: 'Collection Title', metadata: 'collection_information'
-    config.add_show_field 'sourceCreator_tesim', label: 'Collection/Other Creator', metadata: 'collection_information'
+    config.add_show_field 'sourceCreator_tesim', label: 'Collection / Other Creator', metadata: 'collection_information'
     config.add_show_field 'sourceCreated_tesim', label: 'Collection Created', metadata: 'collection_information'
     config.add_show_field 'sourceDate_tesim', label: 'Collection Date', metadata: 'collection_information'
     config.add_show_field 'sourceNote_tesim', label: 'Collection Note', metadata: 'collection_information'


### PR DESCRIPTION
# Summary
In testing the object had more metadata which revealed that one of the metadata labels did not have spaces around a `/` and this prevented the label from wrapping on small screens.  This PR adds those spaces to allow wrapping.

# Related Ticket 
[#2872](https://github.com/yalelibrary/YUL-DC/issues/2872)

# Screenshot
### Before
![image](https://github.com/yalelibrary/yul-dc-blacklight/assets/36549923/73cb90c5-af9f-4b8b-a299-dfd594a7c75e)

### Intended Wrapping Behavior
![image](https://github.com/yalelibrary/yul-dc-blacklight/assets/36549923/aee0a684-07b1-4adf-9496-e7692363406b)

