### PR TITLE
Confirmation Page bug

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -666,12 +666,14 @@ class CatalogController < ApplicationController
     @response, @document = search_service.fetch(params[:oid])
     if current_user && @document['visibility_ssi'] == 'Open with Permission'
       @render_confirmation = false
-      user_owp_permissions['permissions']&.each do |permission|
+      permissions = user_owp_permissions['permissions']
+      permissions&.each do |permission|
         if permission['oid'].to_s == params['oid']
+          active_request = permissions.first
           @render_confirmation = true
-          @user_full_name = permission['user_full_name']
-          @user_note = permission['user_note']
-          @request_status = permission['request_status']
+          @user_full_name = active_request['user_full_name']
+          @user_note = active_request['user_note']
+          @request_status = active_request['request_status']
         end
       end
       if @render_confirmation

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -667,9 +667,11 @@ class CatalogController < ApplicationController
     if current_user && @document['visibility_ssi'] == 'Open with Permission'
       @render_confirmation = false
       permissions = user_owp_permissions['permissions']
+      requests = []
       permissions&.each do |permission|
         if permission['oid'].to_s == params['oid']
-          active_request = permissions.first
+          requests << permission
+          active_request = requests.first
           @render_confirmation = true
           @user_full_name = active_request['user_full_name']
           @user_note = active_request['user_note']

--- a/spec/system/open_with_permission/permission_request_confirmation_page_spec.rb
+++ b/spec/system/open_with_permission/permission_request_confirmation_page_spec.rb
@@ -34,6 +34,16 @@ RSpec.describe "Permission Requests", type: :system do
         "user":{"sub":"7bd425ee-1093-40cd-ba0c-5a2355e37d6e"},
         "permission_set_terms_agreed":[],
         "permissions":[{
+          "oid":1718909,
+          "permission_set":1,
+          "permission_set_terms":1,
+          "request_status":"Pending",
+          "request_date":"2023-11-02T20:23:18.824Z",
+          "access_until":null,
+          "user_note": "lorem ipsum",
+          "user_full_name": "Request Full Name"
+        },
+        {
           "oid":1618909,
           "permission_set":1,
           "permission_set_terms":1,
@@ -41,17 +51,7 @@ RSpec.describe "Permission Requests", type: :system do
           "request_date":"2023-11-02T20:23:18.824Z",
           "access_until":"2034-11-02T20:23:18.824Z",
           "user_note": "permission.user_note",
-          "user_full_name": "request_user.name"},
-          {
-            "oid":1718909,
-            "permission_set":1,
-            "permission_set_terms":1,
-            "request_status":"Pending",
-            "request_date":"2023-11-02T20:23:18.824Z",
-            "access_until":null,
-            "user_note": "lorem ipsum",
-            "user_full_name": "Request Full Name"
-          }
+          "user_full_name": "request_user.name"}
         ]}',
                  headers: [])
     stub_request(:post, 'http://www.example.com/management/api/permission_requests')


### PR DESCRIPTION
## Summary  
Previous confirmation page was displaying request form details from prior requests. This PR will display the active request details to the confirmation page