### PR TITLE
Add etag to tiff response to prevent rack:ETag from buffering the response

### DIFF
--- a/app/controllers/pdfs_controller.rb
+++ b/app/controllers/pdfs_controller.rb
@@ -2,7 +2,7 @@
 
 # Takes a request for a manifest/oid and stream the JSON for that oid from S3
 class PdfsController < ApplicationController
-  include ActionController::Streaming
+  include ActionController::Live
   include Blacklight::Catalog
   include CheckAuthorization
 
@@ -22,6 +22,7 @@ class PdfsController < ApplicationController
     log_download
     response.set_header('Content-Type', 'application/pdf')
     response.set_header('X-Robots-Tag', 'noindex')
+    response.set_header('ETag', S3Service.etag(pdf_pairtree_path, ENV['S3_SOURCE_BUCKET_NAME']))
     client = Aws::S3::Client.new
     client.get_object(bucket: ENV['S3_SOURCE_BUCKET_NAME'], key: pdf_pairtree_path) do |chunk|
       response.stream.write(chunk)

--- a/app/services/s3_service.rb
+++ b/app/services/s3_service.rb
@@ -16,4 +16,10 @@ class S3Service
     object = Aws::S3::Object.new(bucket_name: bucket, key: remote_path)
     object.exists?
   end
+
+  def self.etag(remote_path, bucket)
+    object = Aws::S3::Object.new(bucket_name: bucket, key: remote_path)
+    return nil unless object.exists?
+    object.etag
+  end
 end

--- a/spec/requests/pdfs_request_spec.rb
+++ b/spec/requests/pdfs_request_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe 'PdfController', type: :request do
       solr = Blacklight.default_index.connection
       solr.add([public_work, yale_work, no_visibility_work, pubic_work_with_no_pdf, redirected_work])
       solr.commit
+      allow(S3Service).to receive(:etag).and_return("TEST")
       allow(User).to receive(:on_campus?).and_return(false)
     end
 
@@ -91,6 +92,9 @@ RSpec.describe 'PdfController', type: :request do
     before do
       stub_request(:get, 'https://yul-test-samples.s3.amazonaws.com/pdfs/02/20/202.pdf')
         .to_return(status: 404, body: 'not found')
+      stub_request(:head, 'https://yul-test-samples.s3.amazonaws.com/pdfs/02/20/202.pdf')
+        .to_return(status: 404, body: 'not found')
+      allow(S3Service).to receive(:etag).and_return("TEST")
     end
 
     around do |example|


### PR DESCRIPTION
I did some tests by adding a test endpoint to the controller:
`download_original_controller.rb`:
```
before_action :check_authorization, except: [:staged, :test_stream]
...
def test_stream
  response.headers['Content-Type'] = 'text/html'
  response.headers['ETag'] = '0'
  25.times {
    puts("SENT ONE")
    response.stream.write "<p>#{Time.now}</p>\n"
    sleep 1
  }
ensure
  response.stream.close
end
```
`routes.rb`:
```
get '/download/test_streaming', to: 'download_original#test_stream'
```

I tested by running rails in the container to take nginx out of the picture:
```
rails s -p 9999
```
Then testing it from the container with:
```
curl localhost:9999/download/test_streaming
```

There were two issues:
1. `include ActionController::Live` instead of `include ActionController::Streaming` for this type of streaming
1.  rack generates ETags by default, which requires it to buffer the entire response. Adding an ETag to the header prevents that.  So, this PR adds the ETag from S3 to the header for the tiff. See: https://github.com/rack/rack/issues/1619

This PR also updates the PDF download to use the same pattern: ActionController::Live and set etag header.

(Adding `config.middleware.delete Rack::ETag` to `application.rb` also worked, but it would disable etags for all requests.)
