### PR TITLE
Adjust Saved Items Styles

### DIFF
--- a/app/assets/stylesheets/customOverrides/saved_items.scss
+++ b/app/assets/stylesheets/customOverrides/saved_items.scss
@@ -11,7 +11,7 @@ DEFAULT MOBILE STYLING
 }
 
 .bookmark-toggle, .toggle-bookmark, .bookmarksTools {
-  font-family: $mallory_medium Arial, Helvetica, sans-serif
+  font-family: $mallory_medium, Arial, Helvetica, sans-serif
 }
 
 .bookmarksTools .btn {

--- a/app/assets/stylesheets/customOverrides/saved_items.scss
+++ b/app/assets/stylesheets/customOverrides/saved_items.scss
@@ -1,0 +1,19 @@
+/********************************************************
+DEFAULT MOBILE STYLING
+********************************************************/
+
+.blacklight-bookmarks {
+  font-family: YaleDisplay-Roman, "Times New Roman", Times, serif;
+}
+
+.blacklight-bookmarks .page-heading {
+  color: $yale_blue;
+}
+
+.bookmark-toggle, .toggle-bookmark, .bookmarksTools {
+  font-family: $mallory_medium Arial, Helvetica, sans-serif
+}
+
+.bookmarksTools .btn {
+  padding: 0.5rem 0.75rem .375rem .75rem;
+}


### PR DESCRIPTION
# Summary
Purpose of ticket 2906 was to update the header on the Saved Items page.  During development additional mismatched font issues were discovered so this PR will also update the Saved Items toggle and button fonts to match the styling of the site.

# Related Ticket
[#2906](https://github.com/yalelibrary/YUL-DC/issues/2906)

# Screenshots

<details>


## Before

<img width="569" alt="image" src="https://github.com/user-attachments/assets/1ff8ec43-98fb-4887-8153-47fcdf1db7d7">

<img width="569" alt="image" src="https://github.com/user-attachments/assets/4f24755b-b667-4dfe-a68a-baae529ffd80">

<img width="567" alt="image" src="https://github.com/user-attachments/assets/54e80f47-2bb2-46a0-b2ed-ab3fe6c09d83">


## After

<img width="570" alt="image" src="https://github.com/user-attachments/assets/f75eb6f9-2dc6-4214-9d06-45b3a1744378">

<img width="570" alt="image" src="https://github.com/user-attachments/assets/55ba13e5-61cd-4e5c-a32a-3a51897dfd9b">

<img width="565" alt="image" src="https://github.com/user-attachments/assets/f008c988-fda4-4541-97b8-169fb0434c8c">


</details>