### PR TITLE
OwP Request/Confirmation Styling

### DIFF
--- a/app/assets/stylesheets/customOverrides/permission_request_form.scss
+++ b/app/assets/stylesheets/customOverrides/permission_request_form.scss
@@ -1,0 +1,58 @@
+.request-form-cancel {
+  color: white;
+  background-color: #767676;
+  margin-right: 190px;
+  margin-top: 5px;
+  height: 40px;
+  width: 100px;
+  font-size: 20px;
+}
+
+.request-form-submit {
+  color: #043669;
+  background-color: white;
+  border: 1px solid #cccccb;
+  height: 38px;
+}
+
+.request-continue {
+  color: #043669;
+  background-color: white;
+  border: 1px solid #cccccb;
+  padding: 5px;
+  margin-top: 5px;
+  height: 40px;
+  width: 135px;
+  font-size: 20px;
+}
+
+.submit-form-header {
+  font-family: YaleDisplay-Roman, "Times New Roman", Times, serif;
+  color: $yale_blue;
+  font-size: 30px;
+}
+
+.confirmation-form-header {
+  font-family: YaleDisplay-Roman, "Times New Roman", Times, serif;
+  color: $yale_blue;
+  font-size: 30px;
+}
+
+#permission_request_user_full_name {
+  width: 475px;
+}
+
+.request-user-note #permission_request_user_note {
+  width: 475px;
+}
+
+.request-form-submit {
+  margin-top: 5px;
+  height: 40px;
+  width: 180px;
+  font-size: 20px;
+}
+
+.request-form-metadata {
+  padding-top: 50px;
+}

--- a/app/assets/stylesheets/customOverrides/show_page.scss
+++ b/app/assets/stylesheets/customOverrides/show_page.scss
@@ -294,40 +294,9 @@ dt.blacklight-ancestordisplaystrings_tesim.metadata-block__label-key {
   width: 80px;
 }
 
-.request-form-cancel {
-  color: white;
-  background-color: red;
-  border-radius: 8px;
-  height: 36px;
-  margin-right: 190px;
-}
-
-.request-form-submit {
-  color: white;
-  background-color: $light_blue; 
-  border-radius: 8px;
-  height: 38px;
-}
-
-.request-continue {
-  color: white;
-  background-color: $light_blue; 
-  border-radius: 8px;
-  padding: 5px;
-}
-
-.request-continue:hover {
-  text-decoration: none !important;
-  color: white !important;
-}
-
 .terms-heading {
   color: #ad1c2a;
   font-family: 'YaleDisplay-Roman'
-}
-
-.request-form-metadata {
-  padding-top: 50px;
 }
 
 .terms-subheader {

--- a/app/views/catalog/request_confirmation.html.erb
+++ b/app/views/catalog/request_confirmation.html.erb
@@ -60,13 +60,13 @@
 </div>
 <br />
 <div>
-  <h3>Request Information</h3>
+  <h3 class="confirmation-form-header">Request Information</h3>
   <div class="confirmation-key">
     <%= "<b>Status:</b> #{@request_status}".html_safe %><br />
     <%= "<b>User ID:</b> #{current_user}".html_safe %><br />
     <%= "<b>Email:</b> #{current_user.email}".html_safe %><br />
     <%= "<b>Full Name:</b> #{@user_full_name}".html_safe %><br />
     <%= "<b>Reason for request:</b> #{@user_note}".html_safe %><br />
-    <%= link_to "Continue", "/catalog/#{@document[:id]}", class: "request-continue" %>
+    <%= link_to "CONTINUE", "/catalog/#{@document[:id]}", class: "request-continue btn" %>
   </div>
 </div>

--- a/app/views/catalog/request_form.html.erb
+++ b/app/views/catalog/request_form.html.erb
@@ -67,7 +67,7 @@
 </div>
 <br />
 <div class="submit_form">
-  <h3>Request Information</h3>
+  <h3 class="submit-form-header">Request Information</h3>
   <%= form_for :permission_request, remote: false do |f| %>
     <div class="request-key">
       <%= "<b>User ID:</b> #{current_user}".html_safe %><br />
@@ -75,6 +75,7 @@
     </div>
     <div class="request-name">
       <%= f.label 'Full Name:' %>
+      <br />
       <%= f.text_field :user_full_name, :required => true %>
     </div>
     <div class="request-label">
@@ -84,8 +85,8 @@
       <%= f.text_area :user_note, :rows => 3, :required => true %>
     </div>
     <div class="form_buttons">
-      <button type="button" class="request-form-cancel btn btn-danger" onclick="javascript:history.back()">Cancel</button>
-      <%= submit_tag "Submit Request", class: "request-form-submit" %>
+      <button type="button" class="request-form-cancel" onclick="javascript:history.back()">CANCEL</button>
+      <%= submit_tag "SUBMIT REQUEST", class: "request-form-submit" %>
     </div>
   <% end %>
 </div>

--- a/spec/requests/open_with_permission/owp_object_show_page_request_spec.rb
+++ b/spec/requests/open_with_permission/owp_object_show_page_request_spec.rb
@@ -163,8 +163,8 @@ RSpec.describe "Open with Permission", type: :request, clean: true do
       expect(response.body).to include(user.email.to_s)
       expect(response.body).to include('input required="required" type="text" name="permission_request[user_full_name]" id="permission_request_user_full_name"')
       expect(response.body).to include('textarea rows="3" required="required" name="permission_request[user_note]" id="permission_request_user_note"')
-      expect(response.body).to include('Cancel')
-      expect(response.body).to include('Submit Request')
+      expect(response.body).to include('CANCEL')
+      expect(response.body).to include('SUBMIT REQUEST')
     end
   end
 

--- a/spec/system/open_with_permission/permission_request_confirmation_page_spec.rb
+++ b/spec/system/open_with_permission/permission_request_confirmation_page_spec.rb
@@ -85,6 +85,6 @@ RSpec.describe "Permission Requests", type: :system do
     expect(page.body).to include "Pending"
     expect(page.body).to include "Request Full Name"
     expect(page.body).to include "lorem ipsum"
-    expect(page.body).to include "Continue"
+    expect(page.body).to include "CONTINUE"
   end
 end


### PR DESCRIPTION
## Summary  
New form styles for OwP Confirmation and Request forms.  
  
## Screenshots:  
Request Form:  
<img width="1132" alt="image" src="https://github.com/user-attachments/assets/e8ef91cd-3c33-4be3-a18e-922ca88949e8">
  
Confirmation Page:  
<img width="1120" alt="image" src="https://github.com/user-attachments/assets/dd95cd5f-e2c3-4a8e-9feb-7ea78339d8e5">
