### PR TITLE
Updates logic for unauthorized OwP request

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -631,9 +631,7 @@ class CatalogController < ApplicationController
     super
     @search_params = session[:search_params]
     @permission_set_terms = retrieve_permission_set_terms if @document["visibility_ssi"] == "Open with Permission"
-    if @permission_set_terms == 'unauthorized'
-      render json: { error: 'unauthorized' }.to_json, status: :unauthorized
-    elsif @document["visibility_ssi"] == "Redirect" && @document["redirect_to_tesi"].present? && !request.original_url.include?("oai_dc_xml")
+    if @document["visibility_ssi"] == "Redirect" && @document["redirect_to_tesi"].present? && !request.original_url.include?("oai_dc_xml")
       redirect_to @document["redirect_to_tesi"]
     elsif @document["visibility_ssi"] == "Redirect" && @document["redirect_to_tesi"].present? && request.original_url.include?("oai_dc_xml")
       not_found
@@ -651,9 +649,7 @@ class CatalogController < ApplicationController
     @response, @document = search_service.fetch(params[:oid])
     if current_user && @document['visibility_ssi'] == 'Open with Permission'
       @permission_set_terms = retrieve_permission_set_terms
-      if @permission_set_terms == 'unauthorized'
-        render json: { error: 'unauthorized' }.to_json, status: :unauthorized
-      elsif @permission_set_terms.nil?
+      if @permission_set_terms.nil?
         redirect_back(fallback_location: "#{ENV['BLACKLIGHT_HOST']}/catalog/#{params[:oid]}", notice: "We are unable to complete your access request at this time. For more information about this object, click the ‘Feedback’ link located at the bottom of this page and fill out the form. We will get back to you as soon as possible.")
       elsif user_owp_permissions['permission_set_terms_agreed']&.include?(@permission_set_terms['id'])
         render 'catalog/request_form'
@@ -670,7 +666,7 @@ class CatalogController < ApplicationController
   # rubocop:disable Metrics/PerceivedComplexity
   def request_confirmation
     @response, @document = search_service.fetch(params[:oid])
-    if current_user && @document['visibility_ssi'] == 'Open with Permission' && user_owp_permissions != 'unauthorized'
+    if current_user && @document['visibility_ssi'] == 'Open with Permission'
       @render_confirmation = false
       permissions = user_owp_permissions['permissions']
       requests = []

--- a/app/controllers/permission_requests_controller.rb
+++ b/app/controllers/permission_requests_controller.rb
@@ -14,9 +14,9 @@ class PermissionRequestsController < ApplicationController
       redirect_to((ENV['BLACKLIGHT_HOST']).to_s, notice: 'Please log in to gain access to this page.')
       return false
     end
-    if user_owp_permissions == 'unauthorized'
+    if user_owp_permissions.nil?
       redirect_to((ENV['BLACKLIGHT_HOST']).to_s, notice: 'Access Requests unavailable at this time.')
-      return false
+      false
     else
       # retrive permission requests for user
       user_owp_permissions['permissions']&.each do |permission|
@@ -34,8 +34,8 @@ class PermissionRequestsController < ApplicationController
         }
         @table_data << request_details
       end
+      @table_data
     end
-    @table_data
   end
 
   def create_readable_access_until(permission_request)

--- a/app/helpers/access_helper.rb
+++ b/app/helpers/access_helper.rb
@@ -35,7 +35,7 @@ module AccessHelper
   def pending_request?(document)
     parent_oid = document[:id]
     pending = false
-    return unless current_user
+    return unless current_user && user_owp_permissions != 'unauthorized'
     user_owp_permissions['permissions']&.each do |permission|
       pending = true if (permission['oid'].to_s == parent_oid) && !permission['request_date'].nil? && (permission['request_status'] == "Pending")
     end

--- a/app/helpers/access_helper.rb
+++ b/app/helpers/access_helper.rb
@@ -35,7 +35,7 @@ module AccessHelper
   def pending_request?(document)
     parent_oid = document[:id]
     pending = false
-    return unless current_user && user_owp_permissions != 'unauthorized'
+    return unless current_user
     user_owp_permissions['permissions']&.each do |permission|
       pending = true if (permission['oid'].to_s == parent_oid) && !permission['request_date'].nil? && (permission['request_status'] == "Pending")
     end
@@ -47,7 +47,7 @@ module AccessHelper
   def user_has_permission?(document)
     return unless current_user
     parent_oid = params[:oid].presence || document[:id]
-    return false if parent_oid.nil? || user_owp_permissions == 'unauthorized'
+    return false if parent_oid.nil?
     allowance = false
     user_owp_permissions['permissions']&.each do |permission|
       if (permission['oid'].to_s == parent_oid) && (permission['access_until'].nil? || Time.zone.parse(permission['access_until']) > Time.zone.today) && (permission['request_status'] == "Approved")
@@ -67,7 +67,6 @@ module AccessHelper
                      retrieve_admin_credentials(document)
                    end
     allowance = false
-    allowance = false if @credentials == 'unauthorized'
     allowance = true if @credentials['is_admin_or_approver?'] == "true"
     allowance
   end
@@ -76,8 +75,7 @@ module AccessHelper
     return nil if current_user.nil?
     # for local debugging - http://yul-dc-management-1:3001/management or http://yul-dc_management_1:3001/management
     url = URI.parse("#{ENV['MANAGEMENT_HOST']}/api/permission_sets/#{current_user.sub}")
-    response = Net::HTTP.get_response(url, { 'authorization' => "Bearer #{ENV['OWP_AUTH_TOKEN']}" })
-    return 'unauthorized' unless owp_auth_token_valid?(response)
+    response = Net::HTTP.get_response(url, { 'Authorization' => "Bearer #{ENV['OWP_AUTH_TOKEN']}" })
     JSON.parse(response.body)
   end
 
@@ -86,8 +84,7 @@ module AccessHelper
     # #{ENV['MANAGEMENT_HOST']}
     # for local debugging - http://yul-dc-management-1:3001/management or http://yul-dc_management_1:3001/management
     url = URI.parse("#{ENV['MANAGEMENT_HOST']}/api/permission_sets/#{@document[:id]}/terms")
-    response = Net::HTTP.get_response(url, { 'authorization' => "Bearer #{ENV['OWP_AUTH_TOKEN']}" })
-    return 'unauthorized' unless owp_auth_token_valid?(response)
+    response = Net::HTTP.get_response(url, { 'Authorization' => "Bearer #{ENV['OWP_AUTH_TOKEN']}" })
     JSON.parse(response.body) unless response.nil?
   end
 
@@ -96,8 +93,7 @@ module AccessHelper
     # #{ENV['MANAGEMENT_HOST']}
     # for local debugging - http://yul-dc-management-1:3001/management or http://yul-dc_management_1:3001/management
     url = URI.parse("#{ENV['MANAGEMENT_HOST']}/api/permission_sets/#{document.id}/#{current_user.netid}")
-    response = Net::HTTP.get_response(url, { 'authorization' => "Bearer #{ENV['OWP_AUTH_TOKEN']}" })
-    return 'unauthorized' unless owp_auth_token_valid?(response)
+    response = Net::HTTP.get_response(url, { 'Authorization' => "Bearer #{ENV['OWP_AUTH_TOKEN']}" })
     JSON.parse(response.body)
   end
 
@@ -106,17 +102,8 @@ module AccessHelper
     # #{ENV['MANAGEMENT_HOST']}
     # for local debugging - http://yul-dc-management-1:3001/management or http://yul-dc_management_1:3001/management
     url = URI.parse("#{ENV['MANAGEMENT_HOST']}/api/permission_sets/#{document}/#{current_user.netid}")
-    response = Net::HTTP.get_response(url, { 'authorization' => "Bearer #{ENV['OWP_AUTH_TOKEN']}" })
-    return 'unauthorized' unless owp_auth_token_valid?(response)
+    response = Net::HTTP.get_response(url, { 'Authorization' => "Bearer #{ENV['OWP_AUTH_TOKEN']}" })
     JSON.parse(response.body)
-  end
-
-  def owp_auth_token_valid?(response)
-    if ENV['OWP_AUTH_TOKEN'].blank? || ENV['OWP_AUTH_TOKEN'].nil?
-      false
-    else
-      response.header.to_json.include?((ENV['OWP_AUTH_TOKEN']).to_s)
-    end
   end
 
   def client_can_view_metadata?(document)


### PR DESCRIPTION
# Summary
Blacklight will not expect the owp auth header back from management and in case no permission requests are found this PR also adds another guard for this.

# Related Ticket
[#2877](https://github.com/yalelibrary/YUL-DC/issues/2877)

