### PR TITLE
Adjusts table sorting

### DIFF
--- a/app/assets/stylesheets/customOverrides/permission_requests.scss
+++ b/app/assets/stylesheets/customOverrides/permission_requests.scss
@@ -40,7 +40,7 @@ DEFAULT MOBILE STYLING
   background-position-y: center;
   background-position-x: left;
   display: block;
-  width: .5rem;
+  width: .75rem;
   height: 1.7rem !important;
   background-repeat: no-repeat;
   background-size: .5rem;

--- a/app/views/permission_requests/index.html.erb
+++ b/app/views/permission_requests/index.html.erb
@@ -26,7 +26,7 @@
           <th scope='col' onclick="sortTable(3)">
             <p>Status <i class="double-arrow"></i></p>
           </th>
-          <th scope='col' onclick="sortTable(4)">
+          <th scope='col' onclick="sortDate(4)">
             <p>Access Expires <i class="double-arrow"></i></p>
           </th>
         </tr>


### PR DESCRIPTION
# Summary
The Access Until column was not sorting chronologically.  This PR adjusts the sorting to use date based sorting.  This also adjusts the double arrow to no longer be cut off in some media screen sizes.

# Related Ticket
[#2921](https://github.com/yalelibrary/YUL-DC/issues/2921)

# Screenshots

<img width="1070" alt="image" src="https://github.com/user-attachments/assets/18f56a6c-aed1-45f6-b082-9c15a20dced4">

