### PR TITLE
Expands tests for various users

### DIFF
--- a/app/helpers/access_helper.rb
+++ b/app/helpers/access_helper.rb
@@ -101,7 +101,7 @@ module AccessHelper
     return nil if current_user.nil?
     # #{ENV['MANAGEMENT_HOST']}
     # for local debugging - http://yul-dc-management-1:3001/management or http://yul-dc_management_1:3001/management
-    url = URI.parse("#{ENV['MANAGEMENT_HOST']}/api/permission_sets/#{document}/#{current_user.netid}")
+    url = URI.parse("#{ENV['MANAGEMENT_HOST']}/api/permission_sets/#{document}/#{current_user.uid}")
     response = Net::HTTP.get_response(url, { 'Authorization' => "Bearer #{ENV['OWP_AUTH_TOKEN']}" })
     JSON.parse(response.body)
   end

--- a/app/helpers/access_helper.rb
+++ b/app/helpers/access_helper.rb
@@ -92,7 +92,7 @@ module AccessHelper
     return nil if current_user.nil?
     # #{ENV['MANAGEMENT_HOST']}
     # for local debugging - http://yul-dc-management-1:3001/management or http://yul-dc_management_1:3001/management
-    url = URI.parse("#{ENV['MANAGEMENT_HOST']}/api/permission_sets/#{document.id}/#{current_user.netid}")
+    url = URI.parse("#{ENV['MANAGEMENT_HOST']}/api/permission_sets/#{document.id}/#{current_user.uid}")
     response = Net::HTTP.get_response(url, { 'Authorization' => "Bearer #{ENV['OWP_AUTH_TOKEN']}" })
     JSON.parse(response.body)
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -7,7 +7,6 @@ FactoryBot.define do
   factory :user do
     uid { FFaker::Internet.user_name }
     sub { "123" }
-    netid { "az123" }
     provider { "openid" }
   end
 end

--- a/spec/requests/download_original_spec.rb
+++ b/spec/requests/download_original_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 
 RSpec.describe "Download Original", type: :request, clean: true do
   let(:imgtiff) { 'image/tiff' }
-  let(:yale_user) { FactoryBot.create(:user, netid: "net_id") }
-  let(:non_yale_user) { FactoryBot.create(:user) }
+  let(:yale_user) { FactoryBot.create(:user, netid: 'net_id', sub: '7bd425ee-1093-40cd-ba0c-5a2355e37d6e', uid: 'sun345') }
+  let(:non_yale_user) { FactoryBot.create(:user, sub: '7bd425ee-1093-40cd-ba0c-5a2355e37d6f', uid: 'moon678') }
   let(:public_work) { WORK_WITH_PUBLIC_VISIBILITY.merge({ "child_oids_ssim": ["5555555"] }) }
   let(:yale_work) do
     {
@@ -12,6 +12,22 @@ RSpec.describe "Download Original", type: :request, clean: true do
       "title_tesim": ["[Map of China]. [yale-only copy]"],
       "visibility_ssi": "Yale Community Only",
       "child_oids_ssim": ["11111"]
+    }
+  end
+  let(:owp_work_without_permission) do
+    {
+      "id": "1818909",
+      "title_tesim": ["[Map of Australia]. [owp-only copy]"],
+      "visibility_ssi": "Open with Permission",
+      "child_oids_ssim": ["44444"]
+    }
+  end
+  let(:owp_work_with_permission) do
+    {
+      "id": "1918909",
+      "title_tesim": ["Fictional Work"],
+      "visibility_ssi": "Open with Permission",
+      "child_oids_ssim": ["66666"]
     }
   end
   let(:private_work) do
@@ -28,6 +44,14 @@ RSpec.describe "Download Original", type: :request, clean: true do
       "title_tesim": ["Fictional Work"],
       "visibility_ssi": "Public",
       "child_oids_ssim": ["3333333"]
+    }
+  end
+  let(:not_available_yet_owp) do
+    {
+      "id": "2345678999",
+      "title_tesim": ["Fiction Work"],
+      "visibility_ssi": "Open with Permission",
+      "child_oids_ssim": ["77777"]
     }
   end
 
@@ -56,6 +80,16 @@ RSpec.describe "Download Original", type: :request, clean: true do
       .to_return(status: 404)
     stub_request(:head, 'https://yul-test-samples.s3.amazonaws.com/download/tiff/33/33/33/33/3333333.tif')
       .to_return(status: 404)
+    stub_request(:head, 'https://yul-test-samples.s3.amazonaws.com/download/tiff/44/44/44/44444.tif')
+      .to_return(status: 200, body: '')
+    stub_request(:get, 'https://yul-test-samples.s3.amazonaws.com/download/tiff/66/66/66/66666.tif')
+      .to_return(status: 200, body: '')
+    stub_request(:head, 'https://yul-test-samples.s3.amazonaws.com/download/tiff/66/66/66/66666.tif')
+      .to_return(status: 200, body: '')
+    stub_request(:get, 'https://yul-test-samples.s3.amazonaws.com/download/tiff/77/77/77/77777.tif')
+      .to_return(status: 404)
+    stub_request(:head, 'https://yul-test-samples.s3.amazonaws.com/download/tiff/77/77/77/77777.tif')
+      .to_return(status: 404)
     stub_request(:get, "http://www.example.com/management/api/download/stage/child/3333333")
       .with(
         headers: {
@@ -65,8 +99,67 @@ RSpec.describe "Download Original", type: :request, clean: true do
         }
       )
       .to_return(status: 200, body: '', headers: {})
+    stub_request(:get, "http://www.example.com/management/api/download/stage/child/77777")
+      .with(
+        headers: {
+          'Accept' => '*/*',
+          'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'User-Agent' => 'Ruby'
+        }
+      )
+      .to_return(status: 200, body: '', headers: {})
+    stub_request(:get, 'http://www.example.com/management/api/permission_sets/7bd425ee-1093-40cd-ba0c-5a2355e37d6e')
+      .to_return(status: 200, body: '{
+        "timestamp":"2023-11-02",
+        "user":{"sub":"7bd425ee-1093-40cd-ba0c-5a2355e37d6e"},
+        "permission_set_terms_agreed":[1],
+        "permissions":[{
+          "oid":1918909,
+          "permission_set":1,
+          "permission_set_terms":1,
+          "request_status":"Approved",
+          "request_date":"2023-11-02T20:23:18.824Z",
+          "access_until":"2034-11-02T20:23:18.824Z",
+          "user_note": "permission.user_note",
+          "user_full_name": "request_user.name"}]}')
+    stub_request(:get, "http://www.example.com/management/api/permission_sets/1818909/sun345")
+      .to_return(status: 200, body: '{ "is_admin_or_approver?": "false" }')
+    stub_request(:get, "http://www.example.com/management/api/permission_sets/1918909/sun345")
+      .to_return(status: 200, body: '{ "is_admin_or_approver?": "false" }')
+    stub_request(:get, "http://www.example.com/management/api/permission_sets/2345678999/sun345")
+      .to_return(status: 200, body: '{ "is_admin_or_approver?": "false" }')
+    stub_request(:get, 'http://www.example.com/management/api/permission_sets/7bd425ee-1093-40cd-ba0c-5a2355e37d6f')
+      .to_return(status: 200, body: '{
+        "timestamp":"2023-11-02",
+        "user":{"sub":"7bd425ee-1093-40cd-ba0c-5a2355e37d6f"},
+        "permission_set_terms_agreed":[1],
+        "permissions":[{
+          "oid":1918909,
+          "permission_set":1,
+          "permission_set_terms":1,
+          "request_status":"Approved",
+          "request_date":"2023-11-02T20:23:18.824Z",
+          "access_until":"2034-11-02T20:23:18.824Z",
+          "user_note": "permission.user_note",
+          "user_full_name": "request_user.name"},
+          {
+          "oid":2345678999,
+          "permission_set":1,
+          "permission_set_terms":1,
+          "request_status":"Approved",
+          "request_date":"2023-11-02T20:23:18.824Z",
+          "access_until":"2034-11-02T20:23:18.824Z",
+          "user_note": "permission.user_note",
+          "user_full_name": "request_user.name"}
+          ]}')
+    stub_request(:get, "http://www.example.com/management/api/permission_sets/1818909/moon678")
+      .to_return(status: 200, body: '{ "is_admin_or_approver?": "false" }')
+    stub_request(:get, "http://www.example.com/management/api/permission_sets/1918909/moon678")
+      .to_return(status: 200, body: '{ "is_admin_or_approver?": "false" }')
+    stub_request(:get, "http://www.example.com/management/api/permission_sets/2345678999/moon678")
+      .to_return(status: 200, body: '{ "is_admin_or_approver?": "false" }')
     solr = Blacklight.default_index.connection
-    solr.add([public_work, yale_work, private_work, not_available_yet])
+    solr.add([public_work, yale_work, owp_work_with_permission, owp_work_without_permission, private_work, not_available_yet, not_available_yet_owp])
     solr.commit
     allow(User).to receive(:on_campus?).and_return(false)
   end
@@ -79,6 +172,10 @@ RSpec.describe "Download Original", type: :request, clean: true do
     end
     it 'does not display if set to YCO' do
       get "/download/tiff/#{yale_work[:child_oids_ssim].first}"
+      expect(response).to have_http_status(:unauthorized) # 401
+    end
+    it 'does not display if set to OWP' do
+      get "/download/tiff/#{owp_work_without_permission[:child_oids_ssim].first}"
       expect(response).to have_http_status(:unauthorized) # 401
     end
     it 'does not display if set to private' do
@@ -102,16 +199,29 @@ RSpec.describe "Download Original", type: :request, clean: true do
         expect(response).to have_http_status(:success) # 200
         expect(response.content_type).to eq imgtiff
       end
+      it 'display if set to OWP with permission' do
+        get "/download/tiff/#{owp_work_with_permission[:child_oids_ssim].first}"
+        expect(response).to have_http_status(:success) # 200
+        expect(response.content_type).to eq imgtiff
+      end
+      it 'does not display if set to OWP without permission' do
+        get "/download/tiff/#{owp_work_without_permission[:child_oids_ssim].first}"
+        expect(response).to have_http_status(:unauthorized) # 401
+      end
       it 'does not display if set to private' do
         get "/download/tiff/#{private_work[:child_oids_ssim].first}"
         expect(response).to have_http_status(:not_found) # 404
       end
     end
     context 'when file is not present on S3' do
-      it 'presents user with try again message' do
+      it 'stages tiff for download when user has viewing access' do
         get "/download/tiff/#{not_available_yet[:child_oids_ssim].first}"
         expect(response).to have_http_status(:see_other) # 303
         expect(response.redirect_url).to eq 'http://www.example.com/download/tiff/3333333/staged'
+      end
+      it 'does not stage tiff for download when user does not have viewing access' do
+        get "/download/tiff/#{not_available_yet_owp[:child_oids_ssim].first}"
+        expect(response).to have_http_status(:unauthorized) # 401
       end
     end
     context 'when child object does not exist' do
@@ -136,9 +246,25 @@ RSpec.describe "Download Original", type: :request, clean: true do
         get "/download/tiff/#{yale_work[:child_oids_ssim].first}"
         expect(response).to have_http_status(:unauthorized) # 401
       end
+      it 'display if set to OWP with permission' do
+        get "/download/tiff/#{owp_work_with_permission[:child_oids_ssim].first}"
+        expect(response).to have_http_status(:success) # 200
+        expect(response.content_type).to eq imgtiff
+      end
+      it 'does not display if set to OWP without permission' do
+        get "/download/tiff/#{owp_work_without_permission[:child_oids_ssim].first}"
+        expect(response).to have_http_status(:unauthorized) # 401
+      end
       it 'does not display if set to private' do
         get "/download/tiff/#{private_work[:child_oids_ssim].first}"
         expect(response).to have_http_status(:not_found) # 404
+      end
+    end
+    context 'when file is not present on S3' do
+      it 'stages tiff for download' do
+        get "/download/tiff/#{not_available_yet_owp[:child_oids_ssim].first}"
+        expect(response).to have_http_status(:see_other) # 303
+        expect(response.redirect_url).to eq 'http://www.example.com/download/tiff/77777/staged'
       end
     end
   end

--- a/spec/requests/open_with_permission/create_permission_requests_request_spec.rb
+++ b/spec/requests/open_with_permission/create_permission_requests_request_spec.rb
@@ -2,7 +2,8 @@
 require 'rails_helper'
 
 RSpec.describe "Permission Requests", type: :request, clean: true do
-  let(:user) { FactoryBot.create(:user, netid: "net_id", sub: "7bd425ee-1093-40cd-ba0c-5a2355e37d6e", uid: 'some_name', email: 'not_real@example.com') }
+  let(:yale_user) { FactoryBot.create(:user, netid: "net_id", sub: "7bd425ee-1093-40cd-ba0c-5a2355e37d6e", uid: 'some_name', email: 'not_real@example.com') }
+  let(:non_yale_user) { FactoryBot.create(:user, sub: "7bd425ee-1093-40cd-ba0c-5a2355e37d6f", uid: 'som456', email: 'not_real_either@example.com') }
   let(:owp_work_with_permission) do
     {
       "id": "1618909",
@@ -64,15 +65,40 @@ RSpec.describe "Permission Requests", type: :request, clean: true do
             "user_full_name": "Request Full Name"}
         ]}',
                  headers: valid_header)
+    stub_request(:get, 'http://www.example.com/management/api/permission_sets/7bd425ee-1093-40cd-ba0c-5a2355e37d6f')
+      .to_return(status: 200, body: '{
+        "timestamp":"2023-11-02",
+        "user":{"sub":"7bd425ee-1093-40cd-ba0c-5a2355e37d6f"},
+        "permission_set_terms_agreed":[],
+        "permissions":[{
+          "oid":1618909,
+          "permission_set":1,
+          "permission_set_terms":1,
+          "request_status":"Approved",
+          "request_date":"2023-11-02T20:23:18.824Z",
+          "access_until":"2034-11-02T20:23:18.824Z",
+          "user_note": "permission.user_note",
+          "user_full_name": "request_user.name"},
+          {
+            "oid":1718909,
+            "permission_set":1,
+            "permission_set_terms":1,
+            "request_status":null,
+            "request_date":"2023-11-02T20:23:18.824Z",
+            "access_until":null,
+            "user_note": "lorem ipsum",
+            "user_full_name": "Request Full Name"}
+        ]}',
+                 headers: valid_header)
     solr = Blacklight.default_index.connection
     solr.add([owp_work_with_permission, owp_work_without_permission])
     solr.commit
     allow(User).to receive(:on_campus?).and_return(false)
-    sign_in user
   end
 
-  context 'with an authenticated user' do
+  context 'with an authenticated yale user' do
     before do
+      sign_in yale_user
       stub_request(:post, 'http://www.example.com/management/api/permission_requests')
         .with(body: {
                 "oid" => "1718909",
@@ -84,7 +110,33 @@ RSpec.describe "Permission Requests", type: :request, clean: true do
               },
               headers: valid_header)
         .to_return(status: 201, body: '{ "title": "New request created"}', headers: valid_header)
-      stub_request(:post, 'http://www.example.com/catalog/1718909/request_form')
+    end
+    it 'will create a new permission request and redirect to the confirmation page' do
+      post '/catalog/1718909/request_form', params: {
+        'oid': '1718909',
+        'permission_request': {
+          'user_full_name': 'Request Full Name',
+          'user_note': 'lorem ipsum'
+        }
+      }, headers: valid_header
+      expect(response).to have_http_status(:redirect)
+      expect(response.redirect_url).to eq('http://www.example.com/catalog/1718909/request_confirmation')
+    end
+  end
+
+  context 'with an authenticated non yale user' do
+    before do
+      sign_in non_yale_user
+      stub_request(:post, 'http://www.example.com/management/api/permission_requests')
+        .with(body: {
+                "oid" => "1718909",
+                "user_email" => "not_real_either@example.com",
+                "user_full_name" => "Request Full Name",
+                "user_netid" => nil,
+                "user_note" => "lorem ipsum",
+                "user_sub" => "7bd425ee-1093-40cd-ba0c-5a2355e37d6f"
+              },
+              headers: valid_header)
         .to_return(status: 201, body: '{ "title": "New request created"}', headers: valid_header)
     end
     it 'will create a new permission request and redirect to the confirmation page' do
@@ -102,7 +154,6 @@ RSpec.describe "Permission Requests", type: :request, clean: true do
 
   context 'with a NOT authenticated user' do
     it 'will redirect to the show page' do
-      sign_out user
       post '/catalog/1718909/request_form', params: {
         'oid': '1718909',
         'permission_request': {

--- a/spec/requests/open_with_permission/create_permission_requests_request_spec.rb
+++ b/spec/requests/open_with_permission/create_permission_requests_request_spec.rb
@@ -99,6 +99,10 @@ RSpec.describe "Permission Requests", type: :request, clean: true do
   context 'with an authenticated yale user' do
     before do
       sign_in yale_user
+      stub_request(:post, 'http://www.example.com/management/agreement_term')
+        .with(body: { "oid" => "1718909", "permission_set_terms_id" => "1", "user_email" => "not_real@example.com", "user_full_name" => "new", "user_netid" => "net_id",
+                      "user_sub" => "7bd425ee-1093-40cd-ba0c-5a2355e37d6e" }, headers: valid_header)
+        .to_return(status: 200)
       stub_request(:post, 'http://www.example.com/management/api/permission_requests')
         .with(body: {
                 "oid" => "1718909",
@@ -110,6 +114,18 @@ RSpec.describe "Permission Requests", type: :request, clean: true do
               },
               headers: valid_header)
         .to_return(status: 201, body: '{ "title": "New request created"}', headers: valid_header)
+    end
+    it 'can accept terms and redirect to request form' do
+      post '/catalog/1718909/terms_and_conditions', params: {
+        'oid': '1718909',
+        'user_email': yale_user.email,
+        'user_netid': yale_user.netid,
+        'user_sub': yale_user.sub,
+        'user_full_name': "new",
+        'permission_set_terms_id': 1
+      }, headers: valid_header
+      expect(response).to have_http_status(:redirect)
+      expect(response.redirect_url).to eq('http://www.example.com/catalog/1718909/request_form')
     end
     it 'will create a new permission request and redirect to the confirmation page' do
       post '/catalog/1718909/request_form', params: {
@@ -127,6 +143,10 @@ RSpec.describe "Permission Requests", type: :request, clean: true do
   context 'with an authenticated non yale user' do
     before do
       sign_in non_yale_user
+      stub_request(:post, 'http://www.example.com/management/agreement_term')
+        .with(body: { "oid" => "1718909", "permission_set_terms_id" => "1", "user_email" => "not_real_either@example.com", "user_full_name" => "new", "user_netid" => nil,
+                      "user_sub" => "7bd425ee-1093-40cd-ba0c-5a2355e37d6f" }, headers: valid_header)
+        .to_return(status: 200)
       stub_request(:post, 'http://www.example.com/management/api/permission_requests')
         .with(body: {
                 "oid" => "1718909",
@@ -138,6 +158,18 @@ RSpec.describe "Permission Requests", type: :request, clean: true do
               },
               headers: valid_header)
         .to_return(status: 201, body: '{ "title": "New request created"}', headers: valid_header)
+    end
+    it 'can accept terms and redirect to request form' do
+      post '/catalog/1718909/terms_and_conditions', params: {
+        'oid': '1718909',
+        'user_email': non_yale_user.email,
+        'user_netid': non_yale_user.netid,
+        'user_sub': non_yale_user.sub,
+        'user_full_name': "new",
+        'permission_set_terms_id': 1
+      }, headers: valid_header
+      expect(response).to have_http_status(:redirect)
+      expect(response.redirect_url).to eq('http://www.example.com/catalog/1718909/request_form')
     end
     it 'will create a new permission request and redirect to the confirmation page' do
       post '/catalog/1718909/request_form', params: {
@@ -153,7 +185,12 @@ RSpec.describe "Permission Requests", type: :request, clean: true do
   end
 
   context 'with a NOT authenticated user' do
-    it 'will redirect to the show page' do
+    it 'will not accept terms and will redirect to show page' do
+      post '/catalog/1718909/terms_and_conditions'
+      expect(response).to have_http_status(:redirect)
+      expect(response.redirect_url).to eq('http://www.example.com/catalog/1718909')
+    end
+    it 'sending request form will redirect to the show page not confirmation page' do
       post '/catalog/1718909/request_form', params: {
         'oid': '1718909',
         'permission_request': {

--- a/spec/requests/open_with_permission/owp_object_show_page_request_spec.rb
+++ b/spec/requests/open_with_permission/owp_object_show_page_request_spec.rb
@@ -86,17 +86,17 @@ RSpec.describe "Open with Permission", type: :request, clean: true do
           }
         ]}',
                  headers: valid_header)
-    stub_request(:get, "http://www.example.com/management/api/permission_sets/1618909/#{user.netid}")
+    stub_request(:get, "http://www.example.com/management/api/permission_sets/1618909/#{user.uid}")
       .to_return(status: 200, body: '{
         "is_admin_or_approver?":"true"
         }',
                  headers: valid_header)
-    stub_request(:get, "http://www.example.com/management/api/permission_sets/1618909/#{admin_approver_user.netid}")
+    stub_request(:get, "http://www.example.com/management/api/permission_sets/1618909/#{admin_approver_user.uid}")
       .to_return(status: 200, body: '{
         "is_admin_or_approver?":"true"
         }',
                  headers: valid_header)
-    stub_request(:get, "http://www.example.com/management/api/permission_sets/1718909/#{non_approved_user.netid}")
+    stub_request(:get, "http://www.example.com/management/api/permission_sets/1718909/#{non_approved_user.uid}")
       .to_return(status: 200, body: '{
         "is_admin_or_approver?":"false"
         }',

--- a/spec/requests/open_with_permission/owp_object_show_page_request_spec.rb
+++ b/spec/requests/open_with_permission/owp_object_show_page_request_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 
 RSpec.describe "Open with Permission", type: :request, clean: true do
   let(:user) { FactoryBot.create(:user, netid: "net_id1", sub: "7bd425ee-1093-40cd-ba0c-5a2355e37d6e", uid: 'user_uid', email: 'not_real@example.com') }
+  let(:non_yale_user) { FactoryBot.create(:user, sub: "7bd425ee-1093-40cd-ba0c-5a2355e37d6g", uid: 'uid456', email: 'not_real_either@example.com') }
   let(:admin_approver_user) { FactoryBot.create(:user, netid: "net_id2", sub: "7bd425ee-1093-40cd-ba0c-5a2355e37d6d", uid: 'unique_uid', email: 'not_real@example.com') }
   let(:non_approved_user) { FactoryBot.create(:user, netid: "net_id3", sub: "7bd425ee-1093-40cd-ba0c-5a2355e37d6f", uid: 'some_name', email: 'not_real@example.com') }
   let(:owp_work_with_permission) do
@@ -45,6 +46,28 @@ RSpec.describe "Open with Permission", type: :request, clean: true do
       .to_return(status: 200, body: '{
         "timestamp":"2023-11-02",
         "user":{"sub":"7bd425ee-1093-40cd-ba0c-5a2355e37d6e"},
+        "permission_set_terms_agreed":[1],
+        "permissions":[{
+          "oid":1618909,
+          "permission_set":1,
+          "permission_set_terms":1,
+          "request_status":"Approved",
+          "request_date":"2023-11-02T20:23:18.824Z",
+          "access_until":"2034-11-02T20:23:18.824Z"},
+          {
+            "oid":1718909,
+            "permission_set":1,
+            "permission_set_terms":1,
+            "request_status":null,
+            "request_date":"2023-11-02T20:23:18.824Z",
+            "access_until":null
+          }
+        ]}',
+                 headers: valid_header)
+    stub_request(:get, 'http://www.example.com/management/api/permission_sets/7bd425ee-1093-40cd-ba0c-5a2355e37d6g')
+      .to_return(status: 200, body: '{
+        "timestamp":"2023-11-02",
+        "user":{"sub":"7bd425ee-1093-40cd-ba0c-5a2355e37d6g"},
         "permission_set_terms_agreed":[1],
         "permissions":[{
           "oid":1618909,
@@ -173,6 +196,21 @@ RSpec.describe "Open with Permission", type: :request, clean: true do
       expect(response.body).to include('Map of India')
       expect(response.body).to include(user.uid.to_s)
       expect(response.body).to include(user.email.to_s)
+      expect(response.body).to include('input required="required" type="text" name="permission_request[user_full_name]" id="permission_request_user_full_name"')
+      expect(response.body).to include('textarea rows="3" required="required" name="permission_request[user_note]" id="permission_request_user_note"')
+      expect(response.body).to include('CANCEL')
+      expect(response.body).to include('SUBMIT REQUEST')
+    end
+  end
+
+  context 'as an authenticated non yale user on the request form page' do
+    it 'displays metadata, username, email, input fields, and buttons if user has accepted the terms and conditions' do
+      sign_in non_yale_user
+      get "/catalog/1718909/request_form"
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include('Map of India')
+      expect(response.body).to include(non_yale_user.uid.to_s)
+      expect(response.body).to include(non_yale_user.email.to_s)
       expect(response.body).to include('input required="required" type="text" name="permission_request[user_full_name]" id="permission_request_user_full_name"')
       expect(response.body).to include('textarea rows="3" required="required" name="permission_request[user_note]" id="permission_request_user_note"')
       expect(response.body).to include('CANCEL')

--- a/spec/requests/pdfs_request_spec.rb
+++ b/spec/requests/pdfs_request_spec.rb
@@ -4,6 +4,8 @@ require 'rails_helper'
 
 # WebMock.allow_net_connect!
 RSpec.describe 'PdfController', type: :request do
+  let(:yale_user) { FactoryBot.create(:user, netid: 'netid', sub: '7bd425ee-1093-40cd-ba0c-5a2355e37d6e', uid: 'sun345') }
+  let(:non_yale_user) { FactoryBot.create(:user, sub: '7bd425ee-1093-40cd-ba0c-5a2355e37d6f', uid: 'moon678') }
   let(:public_work) do
     {
       "id": "2034600",
@@ -25,6 +27,13 @@ RSpec.describe 'PdfController', type: :request do
       "visibility_ssi": "Yale Community Only"
     }
   end
+  let(:owp_work) do
+    {
+      "id": "1818909",
+      "title_tesim": ["[Map of Australia]. [owp-only copy]"],
+      "visibility_ssi": "Open with Permission"
+    }
+  end
   let(:no_visibility_work) do
     {
       "id": "1234567",
@@ -39,51 +48,162 @@ RSpec.describe 'PdfController', type: :request do
         .to_return(status: 200, body: File.open(File.join('spec', 'fixtures', '2034600.pdf')).read)
       stub_request(:get, 'https://yul-test-samples.s3.amazonaws.com/pdfs/09/16/18/90/1618909.pdf')
         .to_return(status: 200, body: File.open(File.join('spec', 'fixtures', '2034600.pdf')).read)
+      stub_request(:get, 'https://yul-test-samples.s3.amazonaws.com/pdfs/09/18/18/90/1818909.pdf')
+        .to_return(status: 200, body: File.open(File.join('spec', 'fixtures', '2034600.pdf')).read)
+      stub_request(:get, 'http://www.example.com/management/api/permission_sets/7bd425ee-1093-40cd-ba0c-5a2355e37d6e')
+        .to_return(status: 200, body: '{
+          "timestamp":"2023-11-02",
+          "user":{"sub":"7bd425ee-1093-40cd-ba0c-5a2355e37d6e"},
+          "permission_set_terms_agreed":[],
+          "permissions":[]}')
+      stub_request(:get, "http://www.example.com/management/api/permission_sets/1818909/sun345")
+        .to_return(status: 200, body: '{ "is_admin_or_approver?": "false" }')
+      stub_request(:get, "http://www.example.com/management/api/permission_sets/1818909/moon678")
+        .to_return(status: 200, body: '{ "is_admin_or_approver?": "false" }')
+      stub_request(:get, 'http://www.example.com/management/api/permission_sets/7bd425ee-1093-40cd-ba0c-5a2355e37d6f')
+        .to_return(status: 200, body: '{
+          "timestamp":"2023-11-02",
+          "user":{"sub":"7bd425ee-1093-40cd-ba0c-5a2355e37d6f"},
+          "permission_set_terms_agreed":[],
+          "permissions":[]}')
+
       solr = Blacklight.default_index.connection
-      solr.add([public_work, yale_work, no_visibility_work, pubic_work_with_no_pdf, redirected_work])
+      solr.add([public_work, yale_work, owp_work, no_visibility_work, pubic_work_with_no_pdf, redirected_work])
       solr.commit
       allow(S3Service).to receive(:etag).and_return("TEST")
       allow(User).to receive(:on_campus?).and_return(false)
     end
 
     around do |example|
+      original_management_url = ENV['MANAGEMENT_HOST']
+      original_token = ENV['OWP_AUTH_TOKEN']
       original_sample_bucket = ENV['S3_SOURCE_BUCKET_NAME']
+      ENV['MANAGEMENT_HOST'] = 'http://www.example.com/management'
+      ENV['OWP_AUTH_TOKEN'] = 'valid'
       ENV['S3_SOURCE_BUCKET_NAME'] = 'yul-test-samples'
       example.run
+      ENV['MANAGEMENT_HOST'] = original_management_url
+      ENV['OWP_AUTH_TOKEN'] = original_token
       ENV['S3_SOURCE_BUCKET_NAME'] = original_sample_bucket
     end
 
     describe 'GET /show' do
-      it 'returns a pdf document of the oid with public access' do
-        get '/pdfs/2034600.pdf'
-        expect(response).to have_http_status(:success)
-        expect(response.content_type).to eq 'application/pdf'
-        expect(response.body).to include 'PDF-1.4'
-        expect(response.headers['X-Robots-Tag']).to be('noindex')
+      context 'with unauthenticated user' do
+        context 'while not on campus' do
+          it 'returns a pdf document of the oid with public access' do
+            get '/pdfs/2034600.pdf'
+            expect(response).to have_http_status(:success)
+            expect(response.content_type).to eq 'application/pdf'
+            expect(response.body).to include 'PDF-1.4'
+            expect(response.headers['X-Robots-Tag']).to be('noindex')
+          end
+          it 'returns unauthorized for oid with no visibility' do
+            get '/pdfs/1234567.pdf'
+            expect(response).to have_http_status(:unauthorized)
+          end
+          it 'returns unauthorized for oid with Yale Only' do
+            get '/pdfs/1618909.pdf'
+            expect(response).to have_http_status(:unauthorized)
+          end
+          it 'returns unauthorized for oid with Open with Permission' do
+            get '/pdfs/1818909.pdf'
+            expect(response).to have_http_status(:unauthorized)
+          end
+          it 'returns not found for oid with Redirect' do
+            get '/pdfs/16685691.pdf'
+            expect(response).to have_http_status(:not_found)
+          end
+        end
+        context 'while on campus' do
+          before do
+            allow(User).to receive(:on_campus?).and_return(true)
+          end
+          it 'returns a pdf document of the oid with public access' do
+            get '/pdfs/2034600.pdf'
+            expect(response).to have_http_status(:success)
+            expect(response.content_type).to eq 'application/pdf'
+            expect(response.body).to include 'PDF-1.4'
+            expect(response.headers['X-Robots-Tag']).to be('noindex')
+          end
+          it 'returns unauthorized for oid with no visibility' do
+            get '/pdfs/1234567.pdf'
+            expect(response).to have_http_status(:unauthorized)
+          end
+          it 'returns pdf for oid with Yale Only' do
+            get '/pdfs/1618909.pdf'
+            expect(response).to have_http_status(:success)
+            expect(response.content_type).to eq 'application/pdf'
+            expect(response.body).to include 'PDF-1.4'
+          end
+          it 'returns unauthorized for oid with Open with Permission' do
+            get '/pdfs/1818909.pdf'
+            expect(response).to have_http_status(:unauthorized)
+          end
+          it 'returns not found for oid with Redirect' do
+            get '/pdfs/16685691.pdf'
+            expect(response).to have_http_status(:not_found)
+          end
+        end
       end
-      it 'returns not found for oid with no visibility' do
-        get '/pdfs/1234567.pdf'
-        expect(response).to have_http_status(:unauthorized)
-      end
-      it 'returns unauthorized for oid with Yale Only' do
-        get '/pdfs/1618909.pdf'
-        expect(response).to have_http_status(:unauthorized)
-      end
-      it 'returns not found for oid with Redirect' do
-        get '/pdfs/16685691.pdf'
-        expect(response).to have_http_status(:not_found)
-      end
-    end
 
-    describe 'GET /show while on campus' do
-      before do
-        allow(User).to receive(:on_campus?).and_return(true)
+      context 'with authenticated yale user' do
+        before do
+          sign_in yale_user
+        end
+        it 'returns a pdf document of the oid with public access' do
+          get '/pdfs/2034600.pdf'
+          expect(response).to have_http_status(:success)
+          expect(response.content_type).to eq 'application/pdf'
+          expect(response.body).to include 'PDF-1.4'
+          expect(response.headers['X-Robots-Tag']).to be('noindex')
+        end
+        it 'returns not found for oid with no visibility' do
+          get '/pdfs/1234567.pdf'
+          expect(response).to have_http_status(:unauthorized)
+        end
+        it 'returns pdf for oid with Yale Only' do
+          get '/pdfs/1618909.pdf'
+          expect(response).to have_http_status(:success)
+          expect(response.content_type).to eq 'application/pdf'
+          expect(response.body).to include 'PDF-1.4'
+        end
+        it 'returns unauthorized for oid with Open with Permission' do
+          get '/pdfs/1818909.pdf'
+          expect(response).to have_http_status(:unauthorized)
+        end
+        it 'returns not found for oid with Redirect' do
+          get '/pdfs/16685691.pdf'
+          expect(response).to have_http_status(:not_found)
+        end
       end
-      it 'returns pdf for oid with Yale Only' do
-        get '/pdfs/1618909.pdf'
-        expect(response).to have_http_status(:success)
-        expect(response.content_type).to eq 'application/pdf'
-        expect(response.body).to include 'PDF-1.4'
+
+      context 'with authenticated non yale user' do
+        before do
+          sign_in non_yale_user
+        end
+        it 'returns a pdf document of the oid with public access' do
+          get '/pdfs/2034600.pdf'
+          expect(response).to have_http_status(:success)
+          expect(response.content_type).to eq 'application/pdf'
+          expect(response.body).to include 'PDF-1.4'
+          expect(response.headers['X-Robots-Tag']).to be('noindex')
+        end
+        it 'returns not found for oid with no visibility' do
+          get '/pdfs/1234567.pdf'
+          expect(response).to have_http_status(:unauthorized)
+        end
+        it 'returns unauthorized for oid with Yale Only' do
+          get '/pdfs/1618909.pdf'
+          expect(response).to have_http_status(:unauthorized)
+        end
+        it 'returns unauthorized for oid with Open with Permission' do
+          get '/pdfs/1818909.pdf'
+          expect(response).to have_http_status(:unauthorized)
+        end
+        it 'returns not found for oid with Redirect' do
+          get '/pdfs/16685691.pdf'
+          expect(response).to have_http_status(:not_found)
+        end
       end
     end
   end

--- a/spec/system/fulltext_search_spec.rb
+++ b/spec/system/fulltext_search_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Fulltext search', type: :system, clean: true, js: true do
-  let(:user) { FactoryBot.create(:user) }
+  let(:user) { FactoryBot.create(:user, netid: "netid") }
   let(:owp_user_no_access) { FactoryBot.create(:user, netid: "net_id", sub: "7bd425ee-1093-40cd-ba0c-5a2355e37d6e", uid: 'some_name', email: 'not_real@example.com') }
   let(:owp_user_with_access) { FactoryBot.create(:user, netid: "net_id_2", sub: "27bd425ee-1093-40cd-ba0c-5a2355e37d6e2", uid: 'some_other_name', email: 'not_really@example.com') }
   let(:valid_header) do
@@ -101,17 +101,17 @@ RSpec.describe 'Fulltext search', type: :system, clean: true, js: true do
           "access_until":"2034-11-02T20:23:18.824Z"}
         ]}',
                  headers: valid_header)
-    stub_request(:get, "http://www.example.com/management/api/permission_sets/161890909/#{user.netid}")
+    stub_request(:get, "http://www.example.com/management/api/permission_sets/161890909/#{user.uid}")
       .to_return(status: 200, body: '{
         "is_admin_or_approver?":"false"
       }',
                  headers: valid_header)
-    stub_request(:get, "http://www.example.com/management/api/permission_sets/161890909/#{owp_user_with_access.netid}")
+    stub_request(:get, "http://www.example.com/management/api/permission_sets/161890909/#{owp_user_with_access.uid}")
       .to_return(status: 200, body: '{
         "is_admin_or_approver?":"false"
       }',
                  headers: valid_header)
-    stub_request(:get, "http://www.example.com/management/api/permission_sets/161890909/#{owp_user_no_access.netid}")
+    stub_request(:get, "http://www.example.com/management/api/permission_sets/161890909/#{owp_user_no_access.uid}")
       .to_return(status: 200, body: '{
         "is_admin_or_approver?":"false"
       }',

--- a/spec/system/open_with_permission/owp_agreement_term_spec.rb
+++ b/spec/system/open_with_permission/owp_agreement_term_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe "Open with Permission", type: :system do
+  let(:yale_user) { FactoryBot.create(:user, netid: "net_id1", sub: "7bd425ee-1093-40cd-ba0c-5a2355e37d6e", uid: 'user_uid', email: 'not_real@example.com') }
+  let(:non_yale_user) { FactoryBot.create(:user, sub: "7bd425ee-1093-40cd-ba0c-5a2355e37d6g", uid: 'uid456', email: 'not_real_either@example.com') }
+  let(:owp_work_without_permission) do
+    {
+      "id": "1718909",
+      "title_tesim": ["Map of India"],
+      "visibility_ssi": "Open with Permission",
+      "child_oids_ssim": ["222222"]
+    }
+  end
+  let(:valid_header) do
+    {
+      'Accept' => '*/*',
+      'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+      'Authorization' => 'Bearer valid',
+      'Content-Type' => 'application/x-www-form-urlencoded',
+      'User-Agent' => 'Ruby'
+    }
+  end
+
+  around do |example|
+    original_blacklight_url = ENV['BLACKLIGHT_HOST']
+    original_management_url = ENV['MANAGEMENT_HOST']
+    original_token = ENV['OWP_AUTH_TOKEN']
+    ENV['BLACKLIGHT_HOST'] = 'http://www.example.com'
+    ENV['MANAGEMENT_HOST'] = 'http://www.example.com/management'
+    ENV['OWP_AUTH_TOKEN'] = 'valid'
+    example.run
+    ENV['BLACKLIGHT_HOST'] = original_blacklight_url
+    ENV['MANAGEMENT_HOST'] = original_management_url
+    ENV['OWP_AUTH_TOKEN'] = original_token
+  end
+  before do
+    stub_request(:get, 'http://www.example.com/management/api/permission_sets/7bd425ee-1093-40cd-ba0c-5a2355e37d6e')
+      .to_return(status: 200, body: '{
+        "timestamp":"2023-11-02",
+        "user":{"sub":"7bd425ee-1093-40cd-ba0c-5a2355e37d6e"},
+        "permission_set_terms_agreed":[],
+        "permissions":[]}').then.to_return(status: 200, body: '{
+          "timestamp":"2023-11-02",
+          "user":{"sub":"7bd425ee-1093-40cd-ba0c-5a2355e37d6e"},
+          "permission_set_terms_agreed":[1],
+          "permissions":[]}')
+    stub_request(:get, 'http://www.example.com/management/api/permission_sets/7bd425ee-1093-40cd-ba0c-5a2355e37d6g')
+      .to_return(status: 200, body: '{
+        "timestamp":"2023-11-02",
+        "user":{"sub":"7bd425ee-1093-40cd-ba0c-5a2355e37d6e"},
+        "permission_set_terms_agreed":[],
+        "permissions":[]}').then.to_return(status: 200, body: '{
+                  "timestamp":"2023-11-02",
+                  "user":{"sub":"7bd425ee-1093-40cd-ba0c-5a2355e37d6g"},
+                  "permission_set_terms_agreed":[1],
+                  "permissions":[]}')
+    stub_request(:get, "http://www.example.com/management/api/permission_sets/1718909/terms")
+      .to_return(status: 200, body: "{\"id\":1,\"title\":\"Permission Set Terms\",\"body\":\"These are some terms\"}")
+    solr = Blacklight.default_index.connection
+    solr.add([owp_work_without_permission])
+    solr.commit
+    allow(User).to receive(:on_campus?).and_return(false)
+  end
+
+  context 'as an authenticated user on the request form page' do
+    before do
+      stub_request(:post, 'http://www.example.com/management/agreement_term')
+        .with(body: { "oid" => "1718909", "permission_set_terms_id" => "1", "user_email" => "not_real@example.com", "user_full_name" => "new", "user_netid" => "net_id1",
+                      "user_sub" => "7bd425ee-1093-40cd-ba0c-5a2355e37d6e" }, headers: valid_header)
+        .to_return(status: 200)
+      stub_request(:post, 'http://www.example.com/management/agreement_term')
+        .with(body: { "oid" => "1718909", "permission_set_terms_id" => "1", "user_email" => "not_real_either@example.com", "user_full_name" => "new", "user_netid" => nil,
+                      "user_sub" => "7bd425ee-1093-40cd-ba0c-5a2355e37d6g" }, headers: valid_header)
+        .to_return(status: 200)
+    end
+    context 'with yale user' do
+      it 'can display request form' do
+        login_as yale_user
+        visit "/catalog/1718909/request_form"
+        expect(page.body).to include('These are some terms')
+        click_on 'Agree'
+        expect(page).to have_http_status(:success)
+        expect(page.body).to include('SUBMIT')
+      end
+    end
+    context 'with non yale user' do
+      it 'can display request form' do
+        login_as non_yale_user
+        visit "/catalog/1718909/request_form"
+        expect(page.body).to include('These are some terms')
+        click_on 'Agree'
+        expect(page).to have_http_status(:success)
+        expect(page.body).to include('SUBMIT')
+      end
+    end
+  end
+
+  context 'as a not authenticated user on the request form page' do
+    it 'redirects to the show page' do
+      visit "/catalog/1718909/request_form"
+      expect(page).to have_http_status(:success)
+      expect(page.current_url).to eq('http://www.example.com/catalog/1718909')
+      expect(page.body).to include('The material in this folder is open for research use only with permission.')
+      expect(page.body).to include('Please log in')
+    end
+  end
+end

--- a/spec/system/open_with_permission/user_requests_table_page_spec.rb
+++ b/spec/system/open_with_permission/user_requests_table_page_spec.rb
@@ -2,7 +2,8 @@
 require 'rails_helper'
 
 RSpec.describe "Open with Permission", type: :system do
-  let(:user) { FactoryBot.create(:user, netid: "net_id", sub: "7bd425ee-1093-40cd-ba0c-5a2355e37d6e", uid: 'some_name', email: 'not_real@example.com') }
+  let(:yale_user) { FactoryBot.create(:user, netid: "net_id", sub: "7bd425ee-1093-40cd-ba0c-5a2355e37d6e", uid: 'some_name', email: 'not_real@example.com') }
+  let(:non_yale_user) { FactoryBot.create(:user, sub: "7bd425ee-1093-40cd-ba0c-5a2355e37d6f", uid: 'som789', email: 'not_real_either@example.com') }
   let(:owp_work_six_with_approved_permission) do
     {
       "id": "1618909",
@@ -117,6 +118,52 @@ RSpec.describe "Open with Permission", type: :system do
           }
         ]}',
                  headers: valid_header)
+    stub_request(:get, 'http://www.example.com/management/api/permission_sets/7bd425ee-1093-40cd-ba0c-5a2355e37d6f')
+      .to_return(status: 200, body: '{
+        "timestamp":"2023-11-02",
+        "user":{"sub":"7bd425ee-1093-40cd-ba0c-5a2355e37d6f"},
+        "permission_set_terms_agreed":[1],
+        "permissions":[{
+          "oid":1618909,
+          "permission_set":1,
+          "permission_set_terms":1,
+          "request_status":"Approved",
+          "request_date":"2023-11-02T20:23:18.824Z",
+          "access_until":"2034-11-02T20:23:18.824Z"},
+          {
+            "oid":1718909,
+            "permission_set":1,
+            "permission_set_terms":1,
+            "request_status":"Denied",
+            "request_date":"2024-11-02T20:23:18.824Z",
+            "access_until":null
+          },
+          {
+            "oid":1818909,
+            "permission_set":1,
+            "permission_set_terms":1,
+            "request_status":"Pending",
+            "request_date":"2025-11-02T20:23:18.824Z",
+            "access_until":null
+          },
+          {
+            "oid":1918909,
+            "permission_set":1,
+            "permission_set_terms":1,
+            "request_status":"Approved",
+            "request_date":"2026-11-02T20:23:18.824Z",
+            "access_until":"2034-11-02T20:23:18.824Z"
+          },
+          {
+            "oid":11018909,
+            "permission_set":1,
+            "permission_set_terms":1,
+            "request_status":"Denied",
+            "request_date":"2027-11-02T20:23:18.824Z",
+            "access_until":null
+          }
+        ]}',
+                 headers: valid_header)
     stub_request(:get, "http://www.example.com/management/api/permission_sets/1618909/terms")
       .to_return(status: 200, body: "{\"id\":1,\"title\":\"Permission Set Terms\",\"body\":\"These are some terms\"}", headers: valid_header)
     stub_request(:get, "http://www.example.com/management/api/permission_sets/1718909/terms")
@@ -140,9 +187,50 @@ RSpec.describe "Open with Permission", type: :system do
   end
 
   context 'as an authenticated user on the requests page' do
-    context 'with correct permission' do
+    context 'as a yale user' do
       before do
-        login_as user
+        login_as yale_user
+        visit '/permission_requests'
+      end
+
+      it 'can display as expected' do
+        expect(page).to have_http_status(:success)
+        # Header is present
+        expect(page).to have_content 'Access Requests'
+        # table has 5 columns: title, call number, request date, status, access expires
+        expect(page).to have_content 'Title'
+        expect(page).to have_content 'Call Number'
+        expect(page).to have_content 'Request Date'
+        expect(page).to have_content 'Status'
+        expect(page).to have_content 'Access Expires'
+        # has icons for sorting columns and they work
+        expect(page).to have_css '.double-arrow'
+        # title column displays owp object's title as a link
+        expect(page).to have_link 'Map of New Zealand', href: '/catalog/11018909'
+        # call number column displays owp object's call number
+        expect(page).to have_content '1234567890'
+        # request date column displays request date
+        expect(page).to have_content '11/02/27'
+        # status column displays request status
+        # status column displays Pending, Approved or Denied
+        expect(page).to have_content('Pending').once
+        expect(page).to have_content('Approved').twice
+        expect(page).to have_content('Denied').twice
+        # access expires column displays access until
+        # access expires column displays N/A for Pending or Denied requests
+        expect(page).to have_content('N/A', count: 3)
+        expect(page).to have_content('11/02/34').twice
+      end
+
+      it 'can search as expected' do
+        click_on 'Search'
+        expect(page.current_url).to eq 'http://web.library.yale.edu/gsearch'
+      end
+    end
+
+    context 'as a non yale user' do
+      before do
+        login_as non_yale_user
         visit '/permission_requests'
       end
 
@@ -184,7 +272,7 @@ RSpec.describe "Open with Permission", type: :system do
 
   context 'as a NOT authenticated user on the requests page' do
     it 'will redirect to homepage' do
-      logout user
+      # logout user
       visit '/permission_requests'
       expect(page.current_url).to eq ENV['BLACKLIGHT_HOST']
     end

--- a/spec/system/open_with_permission/user_requests_table_page_spec.rb
+++ b/spec/system/open_with_permission/user_requests_table_page_spec.rb
@@ -272,7 +272,6 @@ RSpec.describe "Open with Permission", type: :system do
 
   context 'as a NOT authenticated user on the requests page' do
     it 'will redirect to homepage' do
-      # logout user
       visit '/permission_requests'
       expect(page.current_url).to eq ENV['BLACKLIGHT_HOST']
     end

--- a/spec/system/show_page_spec.rb
+++ b/spec/system/show_page_spec.rb
@@ -471,7 +471,7 @@ RSpec.describe 'Show Page', type: :system, js: true, clean: true do
       login_as management_approver
     end
     # flappy - passes locally and sometimes in CI
-    it 'can access the object and view UV and metadata normally without approved status' do
+    xit 'can access the object and view UV and metadata normally without approved status' do
       visit 'catalog/12345'
       expect(page).not_to have_content "The material in this folder is open for research use only with permission. Researchers who wish to gain access or who have received permission to view this item, please log in to your account to request permission or to view the materials in this folder."
       expect(page).not_to have_content "You are currently logged in to your account. However, you do not have permission to view this folder. If you would like to request permission, please fill out this form."

--- a/spec/system/show_page_spec.rb
+++ b/spec/system/show_page_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 
 RSpec.describe 'Show Page', type: :system, js: true, clean: true do
   let(:user) { FactoryBot.create(:user) }
-  let(:management_approver) { FactoryBot.create(:user, netid: 'net_id2', sub: '1234') }
+  let(:management_approver) { FactoryBot.create(:user, netid: 'net_id2', sub: '1234', uid: 'sun345') }
   let(:request_user) { FactoryBot.create(:user, netid: "net_id", sub: "7bd425ee-1093-40cd-ba0c-5a2355e37d6e", uid: 'some_name', email: 'not_real@example.com') }
   let(:thumbnail_size_in_opengraph) { "!1200,630" }
   let(:thumbnail_size_in_solr) { "!200,200" }
@@ -200,17 +200,17 @@ RSpec.describe 'Show Page', type: :system, js: true, clean: true do
       .to_return(status: 200, body: File.open(File.join('spec', 'fixtures', '2041002.json')).read)
     stub_request(:get, 'http://www.example.com/management/api/permission_sets/123')
       .to_return(status: 200, body: '{"timestamp":"2023-11-02","user":{"sub":"123"},"permission_set_terms_agreed":[],"permissions":[{"oid":12345,"permission_set":1,"permission_set_terms":1,"request_status":"Approved","request_date":"2023-11-02T20:23:18.824Z","access_until":"2024-11-02T20:23:18.824Z"}]}', headers: valid_header)
-    stub_request(:get, "http://www.example.com/management/api/permission_sets/12345/#{user.netid}")
+    stub_request(:get, "http://www.example.com/management/api/permission_sets/12345/#{user.uid}")
       .to_return(status: 200, body: '{
         "is_admin_or_approver?":"false"
         }',
                  headers: valid_header)
-    stub_request(:get, "http://www.example.com/management/api/permission_sets/54321/#{user.netid}")
+    stub_request(:get, "http://www.example.com/management/api/permission_sets/54321/#{user.uid}")
       .to_return(status: 200, body: '{
         "is_admin_or_approver?":"false"
         }',
                  headers: valid_header)
-    stub_request(:get, "http://www.example.com/management/api/permission_sets/12345/#{management_approver.netid}")
+    stub_request(:get, "http://www.example.com/management/api/permission_sets/12345/#{management_approver.uid}")
       .to_return(status: 200, body: '{
         "is_admin_or_approver?":"true"
         }',
@@ -471,7 +471,7 @@ RSpec.describe 'Show Page', type: :system, js: true, clean: true do
       login_as management_approver
     end
     # flappy - passes locally and sometimes in CI
-    xit 'can access the object and view UV and metadata normally without approver_status' do
+    it 'can access the object and view UV and metadata normally without approved status' do
       visit 'catalog/12345'
       expect(page).not_to have_content "The material in this folder is open for research use only with permission. Researchers who wish to gain access or who have received permission to view this item, please log in to your account to request permission or to view the materials in this folder."
       expect(page).not_to have_content "You are currently logged in to your account. However, you do not have permission to view this folder. If you would like to request permission, please fill out this form."


### PR DESCRIPTION
# Summary
Ensures there is test coverage of restricted urls for authenticated yale and non yale, off campus, and unauthenticated users.

Also, updates a call to management to use a user's uid not netid for retrieving permissions - as management is expecting here - `yul-dc-management/app/controllers/api/permission_sets_controller.rb:42`.

# Related Ticket
[#2919](https://github.com/yalelibrary/YUL-DC/issues/2919)