### PR TITLE
Only yale users have netids

### DIFF
--- a/app/helpers/access_helper.rb
+++ b/app/helpers/access_helper.rb
@@ -67,7 +67,9 @@ module AccessHelper
                      retrieve_admin_credentials(document)
                    end
     allowance = false
-    allowance = true if @credentials&['is_admin_or_approver?'] == "true"
+    if @credentials
+      allowance = true if @credentials['is_admin_or_approver?'] == "true"
+    end
     allowance
   end
 

--- a/app/helpers/access_helper.rb
+++ b/app/helpers/access_helper.rb
@@ -89,19 +89,19 @@ module AccessHelper
   end
 
   def retrieve_admin_credentials(document)
-    return nil if current_user.nil?
+    return nil if current_user.nil? || current_user&.netid.nil?
     # #{ENV['MANAGEMENT_HOST']}
     # for local debugging - http://yul-dc-management-1:3001/management or http://yul-dc_management_1:3001/management
-    url = URI.parse("#{ENV['MANAGEMENT_HOST']}/api/permission_sets/#{document.id}/#{current_user.uid}")
+    url = URI.parse("#{ENV['MANAGEMENT_HOST']}/api/permission_sets/#{document.id}/#{current_user.netid}")
     response = Net::HTTP.get_response(url, { 'Authorization' => "Bearer #{ENV['OWP_AUTH_TOKEN']}" })
     JSON.parse(response.body)
   end
 
   def retrieve_admin_fulltext_credentials(document)
-    return nil if current_user.nil?
+    return nil if current_user.nil? || current_user&.netid.nil?
     # #{ENV['MANAGEMENT_HOST']}
     # for local debugging - http://yul-dc-management-1:3001/management or http://yul-dc_management_1:3001/management
-    url = URI.parse("#{ENV['MANAGEMENT_HOST']}/api/permission_sets/#{document}/#{current_user.uid}")
+    url = URI.parse("#{ENV['MANAGEMENT_HOST']}/api/permission_sets/#{document}/#{current_user.netid}")
     response = Net::HTTP.get_response(url, { 'Authorization' => "Bearer #{ENV['OWP_AUTH_TOKEN']}" })
     JSON.parse(response.body)
   end

--- a/app/helpers/access_helper.rb
+++ b/app/helpers/access_helper.rb
@@ -67,7 +67,7 @@ module AccessHelper
                      retrieve_admin_credentials(document)
                    end
     allowance = false
-    allowance = true if @credentials['is_admin_or_approver?'] == "true"
+    allowance = true if @credentials&['is_admin_or_approver?'] == "true"
     allowance
   end
 

--- a/spec/requests/download_original_spec.rb
+++ b/spec/requests/download_original_spec.rb
@@ -122,11 +122,11 @@ RSpec.describe "Download Original", type: :request, clean: true do
           "access_until":"2034-11-02T20:23:18.824Z",
           "user_note": "permission.user_note",
           "user_full_name": "request_user.name"}]}')
-    stub_request(:get, "http://www.example.com/management/api/permission_sets/1818909/sun345")
+    stub_request(:get, "http://www.example.com/management/api/permission_sets/1818909/net_id")
       .to_return(status: 200, body: '{ "is_admin_or_approver?": "false" }')
-    stub_request(:get, "http://www.example.com/management/api/permission_sets/1918909/sun345")
+    stub_request(:get, "http://www.example.com/management/api/permission_sets/1918909/net_id")
       .to_return(status: 200, body: '{ "is_admin_or_approver?": "false" }')
-    stub_request(:get, "http://www.example.com/management/api/permission_sets/2345678999/sun345")
+    stub_request(:get, "http://www.example.com/management/api/permission_sets/2345678999/net_id")
       .to_return(status: 200, body: '{ "is_admin_or_approver?": "false" }')
     stub_request(:get, 'http://www.example.com/management/api/permission_sets/7bd425ee-1093-40cd-ba0c-5a2355e37d6f')
       .to_return(status: 200, body: '{
@@ -152,12 +152,6 @@ RSpec.describe "Download Original", type: :request, clean: true do
           "user_note": "permission.user_note",
           "user_full_name": "request_user.name"}
           ]}')
-    stub_request(:get, "http://www.example.com/management/api/permission_sets/1818909/moon678")
-      .to_return(status: 200, body: '{ "is_admin_or_approver?": "false" }')
-    stub_request(:get, "http://www.example.com/management/api/permission_sets/1918909/moon678")
-      .to_return(status: 200, body: '{ "is_admin_or_approver?": "false" }')
-    stub_request(:get, "http://www.example.com/management/api/permission_sets/2345678999/moon678")
-      .to_return(status: 200, body: '{ "is_admin_or_approver?": "false" }')
     solr = Blacklight.default_index.connection
     solr.add([public_work, yale_work, owp_work_with_permission, owp_work_without_permission, private_work, not_available_yet, not_available_yet_owp])
     solr.commit

--- a/spec/requests/open_with_permission/owp_object_show_page_request_spec.rb
+++ b/spec/requests/open_with_permission/owp_object_show_page_request_spec.rb
@@ -86,17 +86,17 @@ RSpec.describe "Open with Permission", type: :request, clean: true do
           }
         ]}',
                  headers: valid_header)
-    stub_request(:get, "http://www.example.com/management/api/permission_sets/1618909/#{user.uid}")
+    stub_request(:get, "http://www.example.com/management/api/permission_sets/1618909/#{user.netid}")
       .to_return(status: 200, body: '{
         "is_admin_or_approver?":"true"
         }',
                  headers: valid_header)
-    stub_request(:get, "http://www.example.com/management/api/permission_sets/1618909/#{admin_approver_user.uid}")
+    stub_request(:get, "http://www.example.com/management/api/permission_sets/1618909/#{admin_approver_user.netid}")
       .to_return(status: 200, body: '{
         "is_admin_or_approver?":"true"
         }',
                  headers: valid_header)
-    stub_request(:get, "http://www.example.com/management/api/permission_sets/1718909/#{non_approved_user.uid}")
+    stub_request(:get, "http://www.example.com/management/api/permission_sets/1718909/#{non_approved_user.netid}")
       .to_return(status: 200, body: '{
         "is_admin_or_approver?":"false"
         }',

--- a/spec/requests/pdfs_request_spec.rb
+++ b/spec/requests/pdfs_request_spec.rb
@@ -56,9 +56,7 @@ RSpec.describe 'PdfController', type: :request do
           "user":{"sub":"7bd425ee-1093-40cd-ba0c-5a2355e37d6e"},
           "permission_set_terms_agreed":[],
           "permissions":[]}')
-      stub_request(:get, "http://www.example.com/management/api/permission_sets/1818909/sun345")
-        .to_return(status: 200, body: '{ "is_admin_or_approver?": "false" }')
-      stub_request(:get, "http://www.example.com/management/api/permission_sets/1818909/moon678")
+      stub_request(:get, "http://www.example.com/management/api/permission_sets/1818909/netid")
         .to_return(status: 200, body: '{ "is_admin_or_approver?": "false" }')
       stub_request(:get, 'http://www.example.com/management/api/permission_sets/7bd425ee-1093-40cd-ba0c-5a2355e37d6f')
         .to_return(status: 200, body: '{

--- a/spec/system/fulltext_search_spec.rb
+++ b/spec/system/fulltext_search_spec.rb
@@ -101,17 +101,17 @@ RSpec.describe 'Fulltext search', type: :system, clean: true, js: true do
           "access_until":"2034-11-02T20:23:18.824Z"}
         ]}',
                  headers: valid_header)
-    stub_request(:get, "http://www.example.com/management/api/permission_sets/161890909/#{user.uid}")
+    stub_request(:get, "http://www.example.com/management/api/permission_sets/161890909/#{user.netid}")
       .to_return(status: 200, body: '{
         "is_admin_or_approver?":"false"
       }',
                  headers: valid_header)
-    stub_request(:get, "http://www.example.com/management/api/permission_sets/161890909/#{owp_user_with_access.uid}")
+    stub_request(:get, "http://www.example.com/management/api/permission_sets/161890909/#{owp_user_with_access.netid}")
       .to_return(status: 200, body: '{
         "is_admin_or_approver?":"false"
       }',
                  headers: valid_header)
-    stub_request(:get, "http://www.example.com/management/api/permission_sets/161890909/#{owp_user_no_access.uid}")
+    stub_request(:get, "http://www.example.com/management/api/permission_sets/161890909/#{owp_user_no_access.netid}")
       .to_return(status: 200, body: '{
         "is_admin_or_approver?":"false"
       }',

--- a/spec/system/show_page_spec.rb
+++ b/spec/system/show_page_spec.rb
@@ -120,6 +120,7 @@ RSpec.describe 'Show Page', type: :system, js: true, clean: true do
       genre_ssim: 'Artifacts',
       resourceType_ssim: 'Books, Journals & Pamphlets',
       has_fulltext_ssi: 'No',
+      child_oids_ssim: [444],
       creator_ssim: ['Andy Graves']
     }
   end
@@ -143,10 +144,12 @@ RSpec.describe 'Show Page', type: :system, js: true, clean: true do
       title_tesim: ['Rhett Lecheire'],
       format: 'text',
       language_ssim: 'fr',
+      parent_ssi: "222",
       visibility_ssi: 'Public',
       genre_ssim: 'Animation',
       resourceType_ssim: 'Archives or Manuscripts',
-      creator_ssim: ['Paulo Coelho']
+      creator_ssim: ['Paulo Coelho'],
+      has_fulltext_ssi: 'No'
     }
   end
 

--- a/spec/system/show_page_spec.rb
+++ b/spec/system/show_page_spec.rb
@@ -200,17 +200,17 @@ RSpec.describe 'Show Page', type: :system, js: true, clean: true do
       .to_return(status: 200, body: File.open(File.join('spec', 'fixtures', '2041002.json')).read)
     stub_request(:get, 'http://www.example.com/management/api/permission_sets/123')
       .to_return(status: 200, body: '{"timestamp":"2023-11-02","user":{"sub":"123"},"permission_set_terms_agreed":[],"permissions":[{"oid":12345,"permission_set":1,"permission_set_terms":1,"request_status":"Approved","request_date":"2023-11-02T20:23:18.824Z","access_until":"2024-11-02T20:23:18.824Z"}]}', headers: valid_header)
-    stub_request(:get, "http://www.example.com/management/api/permission_sets/12345/#{user.uid}")
+    stub_request(:get, "http://www.example.com/management/api/permission_sets/12345/#{user.netid}")
       .to_return(status: 200, body: '{
         "is_admin_or_approver?":"false"
         }',
                  headers: valid_header)
-    stub_request(:get, "http://www.example.com/management/api/permission_sets/54321/#{user.uid}")
+    stub_request(:get, "http://www.example.com/management/api/permission_sets/54321/#{user.netid}")
       .to_return(status: 200, body: '{
         "is_admin_or_approver?":"false"
         }',
                  headers: valid_header)
-    stub_request(:get, "http://www.example.com/management/api/permission_sets/12345/#{management_approver.uid}")
+    stub_request(:get, "http://www.example.com/management/api/permission_sets/12345/#{management_approver.netid}")
       .to_return(status: 200, body: '{
         "is_admin_or_approver?":"true"
         }',


### PR DESCRIPTION
# Summary
Fixes switch from netid to uid back to netid.  Only yale users will have netids and non yale users will not have permissions to manage owp works.

