### PR TITLE
Auth Message

### DIFF
--- a/app/assets/stylesheets/customOverrides/landing.scss
+++ b/app/assets/stylesheets/customOverrides/landing.scss
@@ -90,6 +90,9 @@ DEFAULT MOBILE STYLING
 	}
 }
 
+.landing_flash_messages {
+	margin-bottom: -15px;
+}
 
 #hero-search {
 	position: absolute;

--- a/app/views/application/landing.html.erb
+++ b/app/views/application/landing.html.erb
@@ -34,7 +34,7 @@
   <header>
     <%= render partial: 'shared/header_navbar' %>
 
-    <%= render partial: 'shared/flash_msg', layout: 'shared/flash_messages' %>
+    <%= render partial: 'shared/landing_flash_msg', layout: 'shared/flash_messages', class: 'landing-flash' %>
 
     <div id='hero'>
       <div class="intro">

--- a/app/views/shared/_landing_flash_msg.html.erb
+++ b/app/views/shared/_landing_flash_msg.html.erb
@@ -1,0 +1,5 @@
+<div class="landing_flash_messages">
+  <% [:success, :notice, :error, :alert].each do |type| %>
+    <%= render(Blacklight::System::FlashMessageComponent.with_collection(Array.wrap(flash[type]), type: type)) if flash[type] %>
+  <% end %>
+</div>

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -28,8 +28,8 @@ en:
       password_change:
         subject: "Password Changed"
     omniauth_callbacks:
-      failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
-      success: "Successfully authenticated from %{kind} account."
+      failure: "Could not authenticate you because \"%{reason}\"."
+      success: "Successfully logged in."
     passwords:
       no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
       send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."


### PR DESCRIPTION
## Summary  
Success auth message now displays, "Successfully logged in."  
  
Also removed the blank white bar under the flash message.  
  
## Screenshot:  
<img width="1788" alt="image" src="https://github.com/user-attachments/assets/ae2305d3-5548-4325-8b3a-6632320ae333">
