### PR TITLE
align metadata

### DIFF
--- a/app/assets/stylesheets/customOverrides/show_page.scss
+++ b/app/assets/stylesheets/customOverrides/show_page.scss
@@ -715,7 +715,6 @@ margin-bottom: 2%;  }
   }
 
   .item-page__metadata-wrapper {
-    width: auto;
     padding-left: 19%;
   }
 

--- a/app/assets/stylesheets/customOverrides/show_page.scss
+++ b/app/assets/stylesheets/customOverrides/show_page.scss
@@ -270,12 +270,12 @@ dt.blacklight-ancestordisplaystrings_tesim.metadata-block__label-key {
 
 .metadata-block__group dt {
   float: left;
-  width: 30%;
+  width: 25%;
 }
 
 .metadata-block__group dd {
   float: right;
-  width: 70%;
+  width: 75%;
 }
 
 .terms-form-cancel {
@@ -706,7 +706,7 @@ margin-bottom: 2%;  }
   }
 
   .single-item-show {
-    width: 880px;
+    width: 118%;
   }
 
   .text-container {
@@ -715,6 +715,7 @@ margin-bottom: 2%;  }
   }
 
   .item-page__metadata-wrapper {
+    width: auto;
     padding-left: 19%;
   }
 
@@ -726,6 +727,7 @@ margin-bottom: 2%;  }
   .tools-text-format{
     margin-left: -2.25%;
   }
+
   .show-tools.list-group{
     margin-left: -0.5%;
   }


### PR DESCRIPTION
## Summary  
Aligns metadata with the UV. The metadata will scale down automatically in line with the UV.  
  
## Screenshot:  
Regular 100%:  
<img width="1434" alt="image" src="https://github.com/user-attachments/assets/c40a7cbe-ee03-4c5a-8d43-a685b5513e81">
  
Zoomed out 67%:  
<img width="1336" alt="image" src="https://github.com/user-attachments/assets/9516cdb1-8524-4fb6-ac5a-99d1d9d74e68">
  
Smaller screen:  
<img width="995" alt="image" src="https://github.com/user-attachments/assets/177280ea-4e6d-4816-a02d-fc21070eea5f">
