### PR TITLE
Staged Download auth

### DIFF
--- a/app/controllers/download_original_controller.rb
+++ b/app/controllers/download_original_controller.rb
@@ -58,7 +58,7 @@ class DownloadOriginalController < ApplicationController
 
   def stage_download
     Rails.logger.info("TIFF with id [#{child_oid}] not found - staging for download.")
-    url = URI.parse("http://yul-dc-management-1:3001/management/api/download/stage/child/#{child_oid}")
+    url = URI.parse("#{ENV['MANAGEMENT_HOST']}/api/download/stage/child/#{child_oid}")
     req = Net::HTTP::Get.new(url.path)
     con = Net::HTTP.new(url.host, url.port)
     con.start { |http| http.request(req) }

--- a/app/controllers/download_original_controller.rb
+++ b/app/controllers/download_original_controller.rb
@@ -6,7 +6,7 @@ class DownloadOriginalController < ApplicationController
   include Blacklight::Catalog
   include CheckAuthorization
 
-  before_action :check_authorization, except: [:staged]
+  before_action :check_authorization
 
   def tiff
     if S3Service.exists_in_s3(tiff_pairtree_path)
@@ -58,7 +58,7 @@ class DownloadOriginalController < ApplicationController
 
   def stage_download
     Rails.logger.info("TIFF with id [#{child_oid}] not found - staging for download.")
-    url = URI.parse("#{ENV['MANAGEMENT_HOST']}/api/download/stage/child/#{child_oid}")
+    url = URI.parse("http://yul-dc-management-1:3001/management/api/download/stage/child/#{child_oid}")
     req = Net::HTTP::Get.new(url.path)
     con = Net::HTTP.new(url.host, url.port)
     con.start { |http| http.request(req) }

--- a/spec/requests/download_original_spec.rb
+++ b/spec/requests/download_original_spec.rb
@@ -168,12 +168,24 @@ RSpec.describe "Download Original", type: :request, clean: true do
       get "/download/tiff/#{yale_work[:child_oids_ssim].first}"
       expect(response).to have_http_status(:unauthorized) # 401
     end
+    it 'does not stage the download if set to YCO' do
+      get "/download/tiff/#{yale_work[:child_oids_ssim].first}/staged"
+      expect(response).to have_http_status(:unauthorized) # 401
+    end
     it 'does not display if set to OWP' do
       get "/download/tiff/#{owp_work_without_permission[:child_oids_ssim].first}"
       expect(response).to have_http_status(:unauthorized) # 401
     end
+    it 'does not stage the download if set to OWP' do
+      get "/download/tiff/#{owp_work_without_permission[:child_oids_ssim].first}/staged"
+      expect(response).to have_http_status(:unauthorized) # 401
+    end
     it 'does not display if set to private' do
       get "/download/tiff/#{private_work[:child_oids_ssim].first}"
+      expect(response).to have_http_status(:not_found) # 404
+    end
+    it 'does not stage the download if set to private' do
+      get "/download/tiff/#{private_work[:child_oids_ssim].first}/staged"
       expect(response).to have_http_status(:not_found) # 404
     end
   end


### PR DESCRIPTION
## Summary  
Enables our standard auth for staged downloads.  
Users receive an 'unauthorized' message if attempting to download tiff via direct url