### PR TITLE
Add Customized CSP

### DIFF
--- a/app/controllers/mirador_controller.rb
+++ b/app/controllers/mirador_controller.rb
@@ -2,6 +2,15 @@
 class MiradorController < ApplicationController
   include BlacklightHelper
 
+  # Allows Mirador to use inline JS to open viewer in new tab
+  content_security_policy(only: :show) do |policy|
+    policy.script_src_attr  :self, :unsafe_inline, 'siteimproveanalytics.com www.googletagmanager.com'
+    policy.script_src_elem  :self, :unsafe_inline, 'siteimproveanalytics.com www.googletagmanager.com'    # policy.style_src :self, :unsafe_inline
+    policy.style_src_attr :self, :unsafe_inline
+    policy.style_src_elem :self, :unsafe_inline
+  end
+
+
   def show
     @oid = number_or_nil params[:oid]
     @manifest = @oid ? manifest_url(@oid) : nil

--- a/app/controllers/mirador_controller.rb
+++ b/app/controllers/mirador_controller.rb
@@ -10,7 +10,6 @@ class MiradorController < ApplicationController
     policy.style_src_elem :self, :unsafe_inline
   end
 
-
   def show
     @oid = number_or_nil params[:oid]
     @manifest = @oid ? manifest_url(@oid) : nil

--- a/app/views/application/landing.html.erb
+++ b/app/views/application/landing.html.erb
@@ -129,7 +129,7 @@
   </body>
 <% end %>
 
-<script nonce="<%= content_security_policy_nonce %>">
+<script>
 
 $(document).ready(function() {
     const images = [

--- a/app/views/catalog/_grouped_metadata.html.erb
+++ b/app/views/catalog/_grouped_metadata.html.erb
@@ -3,7 +3,7 @@
 </div>
 
 <% if @permission_set_terms.present? %>
-  <script nonce="<%= content_security_policy_nonce %>">
+  <script>
     let rights = document.querySelector('dd.blacklight-rights_ssim');
 
     function expandText() {

--- a/app/views/catalog/_schema_org_metadata.html.erb
+++ b/app/views/catalog/_schema_org_metadata.html.erb
@@ -1,3 +1,3 @@
-<script type="application/ld+json" nonce="<%= content_security_policy_nonce %>">
+<script type="application/ld+json">
   <%= raw metadata.to_json %>
 </script>

--- a/app/views/catalog/_uv.html.erb
+++ b/app/views/catalog/_uv.html.erb
@@ -23,7 +23,7 @@
 <div id='uv-pages'></div>
 <div id='parent-oid'><%= @document.id %></div>
 
-<script nonce="<%= content_security_policy_nonce %>">
+<script>
   $(document).ready(function(){
     window.addEventListener('message', (event) => {
       if (event.origin.match('<%= request.protocol %><%= request.host %>')) {

--- a/app/views/mirador/show.html.erb
+++ b/app/views/mirador/show.html.erb
@@ -4,13 +4,13 @@
   <%= render partial: 'shared/ga_header' %>
   <title>Yale Digital Collections Mirador Viewer</title>
   <meta name="robots" content="noindex"/>
-  <script src="/mirador.js" nonce="<%= content_security_policy_nonce %>"></script>
+  <script src="/mirador.js"></script>
 </head>
 <body>
   <%= render partial: 'shared/ga_body' %>
 <div id="my-mirador"/>
 
-<script type="text/javascript" nonce="<%= content_security_policy_nonce %>">
+<script type="text/javascript">
   let dc_mirador_config = {
       "id": "my-mirador"
   }

--- a/app/views/permission_requests/index.html.erb
+++ b/app/views/permission_requests/index.html.erb
@@ -46,7 +46,7 @@
   <% end %>
 </div>
 
-<script nonce="<%= content_security_policy_nonce %>">
+<script>
   function sortTable(n) {
     var table, rows, switching, i, x, y, shouldSwitch, dir, switchcount = 0;
     table = document.getElementById("permission-requests-table");

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -53,7 +53,7 @@
     </div>
   </div>
 </div>
-<aside nonce="<%= content_security_policy_nonce %>">
+<aside>
   <div class="branch-name">
     Branch:<span title="SHA:<%=GIT_SHA%>"><%=ENV['BLACKLIGHT_VERSION']||GIT_BRANCH%></span>,Deployed:<%=DEPLOYED_AT%>
   </div>

--- a/app/views/shared/_ga_header.html.erb
+++ b/app/views/shared/_ga_header.html.erb
@@ -1,5 +1,5 @@
 <!-- Google Tag Manager -->
-<script nonce="<%= request.content_security_policy_nonce %>">
+<script>
 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,20 +4,20 @@
 # Define an application-wide content security policy.
 # See the Securing Rails Applications Guide for more information:
 # https://guides.rubyonrails.org/security.html#content-security-policy-header
-if ENV["RAILS_ENV"] == 'production' || ENV["RAILS_ENV"] == 'staging'
+# if ENV["RAILS_ENV"] == 'production' || ENV["RAILS_ENV"] == 'staging'
   Rails.application.configure do
     config.content_security_policy do |policy|
       policy.default_src :self, :https
       policy.font_src    :self, 'static.library.yale.edu'
       policy.img_src     :self, :https, :data, "#{ENV['IIIF_IMAGE_BASE_URL']}/"
       policy.object_src  :none
-      policy.script_src  :self, :unsafe_inline, 'siteimproveanalytics.com www.googletagmanager.com'
-      policy.script_src_attr  :self, :unsafe_inline, 'www.googletagmanager.com'
-      policy.script_src_elem  :self, :unsafe_inline, 'siteimproveanalytics.com www.googletagmanager.com'
-      policy.style_src :self, :unsafe_inline
-      policy.style_src_attr :self, :unsafe_inline
-      policy.style_src_elem :self, :unsafe_inline, "#{ENV['IIIF_IMAGE_BASE_URL']}/"
-      policy.connect_src :self, "banner.library.yale.edu www.google-analytics.com #{ENV['IIIF_IMAGE_BASE_URL']}/"
+      policy.script_src  :self, 'siteimproveanalytics.com www.googletagmanager.com'
+      policy.script_src_attr  :self, 'www.googletagmanager.com'
+      policy.script_src_elem  :self, 'siteimproveanalytics.com www.googletagmanager.com'
+      policy.style_src :self
+      policy.style_src_attr :self
+      policy.style_src_elem :self, "#{ENV['IIIF_IMAGE_BASE_URL']}/"
+      policy.connect_src :self, "banner.library.yale.edu www.google-analytics.com region1.google-analytics.com #{ENV['IIIF_IMAGE_BASE_URL']}/"
 
       # Specify URI for violation reports
       unless ENV['CLUSTER_NAME'] == 'local'
@@ -34,4 +34,4 @@ if ENV["RAILS_ENV"] == 'production' || ENV["RAILS_ENV"] == 'staging'
     # Report violations without enforcing the policy.
     # config.content_security_policy_report_only = true
   end
-end
+# end

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -14,8 +14,8 @@ if ENV["RAILS_ENV"] == 'production' || ENV["RAILS_ENV"] == 'staging'
       policy.script_src  :self, 'siteimproveanalytics.com www.googletagmanager.com'
       policy.script_src_attr  :self, :unsafe_inline, 'www.googletagmanager.com'
       policy.script_src_elem  :self, :unsafe_inline, 'siteimproveanalytics.com www.googletagmanager.com'
-      policy.style_src :self
-      policy.style_src_attr :self
+      policy.style_src :self, :unsafe_inline
+      policy.style_src_attr :self, :unsafe_inline
       policy.style_src_elem :self, "#{ENV['IIIF_IMAGE_BASE_URL']}/"
       policy.connect_src :self, "banner.library.yale.edu www.google-analytics.com region1.google-analytics.com #{ENV['IIIF_IMAGE_BASE_URL']}/"
 

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,7 +4,7 @@
 # Define an application-wide content security policy.
 # See the Securing Rails Applications Guide for more information:
 # https://guides.rubyonrails.org/security.html#content-security-policy-header
-# if ENV["RAILS_ENV"] == 'production' || ENV["RAILS_ENV"] == 'staging'
+if ENV["RAILS_ENV"] == 'production' || ENV["RAILS_ENV"] == 'staging'
   Rails.application.configure do
     config.content_security_policy do |policy|
       policy.default_src :self, :https
@@ -12,8 +12,8 @@
       policy.img_src     :self, :https, :data, "#{ENV['IIIF_IMAGE_BASE_URL']}/"
       policy.object_src  :none
       policy.script_src  :self, 'siteimproveanalytics.com www.googletagmanager.com'
-      policy.script_src_attr  :self, 'www.googletagmanager.com'
-      policy.script_src_elem  :self, 'siteimproveanalytics.com www.googletagmanager.com'
+      policy.script_src_attr  :self, :unsafe_inline, 'www.googletagmanager.com'
+      policy.script_src_elem  :self, :unsafe_inline, 'siteimproveanalytics.com www.googletagmanager.com'
       policy.style_src :self
       policy.style_src_attr :self
       policy.style_src_elem :self, "#{ENV['IIIF_IMAGE_BASE_URL']}/"
@@ -34,4 +34,4 @@
     # Report violations without enforcing the policy.
     # config.content_security_policy_report_only = true
   end
-# end
+end


### PR DESCRIPTION
# Summary
Remove some of the broad rules from general content security policy and add customized CSP for controllers that require exceptions to operate successfully.

# Related Ticket 
[#2977](https://github.com/yalelibrary/YUL-DC/issues/2977)