### PR TITLE
Bookmark Dropdown Font

### DIFF
--- a/app/assets/stylesheets/customOverrides/saved_items.scss
+++ b/app/assets/stylesheets/customOverrides/saved_items.scss
@@ -2,10 +2,6 @@
 DEFAULT MOBILE STYLING
 ********************************************************/
 
-.blacklight-bookmarks {
-  font-family: YaleDisplay-Roman, "Times New Roman", Times, serif;
-}
-
 .blacklight-bookmarks .page-heading {
   color: $yale_blue;
 }


### PR DESCRIPTION
## Summary  
Removes font-family from bookmark dropdown.
  
## Screenshot:  
<img width="1665" alt="image" src="https://github.com/user-attachments/assets/1e147920-20e9-4f6b-80a5-14518dfe3d23" />
