### PR TITLE
Fixes misalignment of title

### DIFF
--- a/app/assets/stylesheets/customOverrides/search_result.scss
+++ b/app/assets/stylesheets/customOverrides/search_result.scss
@@ -322,29 +322,29 @@ BOOKMARK STYLING
 
 // List item search results bookmark styling
 .index_title.document-title-heading.title_tesim {
-  display: flex;
-}
-
-.index-document-functions { 
-  padding-left: 175px;
+  display: grid;
+  padding-left: 0px;
 }
 
 .bookmark-toggle {
   font-size: 17px;
 }
 
-@media screen and (max-width: 1650px) {
+@media screen and (min-width: $small_device) {
+  .index_title.document-title-heading.title_tesim {
+    display: flex;
+  }
+  .index-document-functions {
+    padding-left: 10px;
+  }
+}
+@media screen and (min-width: $medium_device) {
+  .index-document-functions {
+    padding-left: 45px;
+  }
+}
+@media screen and (min-width: $large_device) {
   .index-document-functions {
     padding-left: 90px;
-  }
-}
-@media screen and (max-width: 1530px) {
-  .index-document-functions {
-    padding-left: 0px;
-  }
-}
-@media screen and (max-width: 1380px) {
-  .index-document-functions {
-    margin-left: -105px;
   }
 }


### PR DESCRIPTION
# Summary
Bootstrap 5 upgrade included adding padding to rows.  This addresses the misalignment of the title section and fixes overlap on mobile view of 'Save Item' checkbox.

# Related Ticket
[#2936](https://github.com/yalelibrary/YUL-DC/issues/2936)

# Screenshots

<details>

# Title Alignment
## Before
<img width="1359" alt="image" src="https://github.com/user-attachments/assets/5659df75-fac4-49af-9287-2afab761141d" />


## After
<img width="1370" alt="image" src="https://github.com/user-attachments/assets/c5ddd739-14b2-4b0d-86da-57c1fac9df90" />


# Mobile View Overlap
## Before
<img width="449" alt="image" src="https://github.com/user-attachments/assets/4d9acd0d-c3d5-498a-afbe-037b34b827ba" />

## After

<img width="441" alt="image" src="https://github.com/user-attachments/assets/2f1c6837-740d-4a60-b291-4fb45f04ed13" />


</details>

