### PR TITLE
Reposition bookmark toggle

### DIFF
--- a/app/assets/stylesheets/customOverrides/index_gallery.scss
+++ b/app/assets/stylesheets/customOverrides/index_gallery.scss
@@ -44,8 +44,25 @@ DEFAULT MOBILE STYLING
   display: none;
 }
 
+.row-cols-2 > * {
+  max-width: 100%;
+  flex: 0 0 100%;
+}
+
 @media screen and (min-width: $small_device) {
   .documents-gallery .thumbnail-container > a {
     height: 200px;
+  }
+
+  .row-cols-2 > * {
+    max-width: 50%;
+    flex: 0 0 50%;
+  }
+}
+
+@media screen and (min-width: $xlarge_device) {
+  .row-cols-2 > * {
+    max-width: 33%;
+    flex: 0 0 33%;
   }
 }

--- a/app/assets/stylesheets/customOverrides/index_gallery.scss
+++ b/app/assets/stylesheets/customOverrides/index_gallery.scss
@@ -15,9 +15,11 @@ DEFAULT MOBILE STYLING
 }
 
 .documents-gallery .index-document-functions {
+  position: relative;
   top: 0;
-  position: absolute;
-  left: -160px;
+  flex: auto;
+  width: 100%;
+  padding-left: 0px;
 }
 
 .documents-gallery .document-title-heading {
@@ -26,7 +28,7 @@ DEFAULT MOBILE STYLING
   padding-left: 0;
   padding-bottom: 0;
   width: 200px;
-  margin-top: 14px;
+  margin-top: 22px;
 }
 
 .document-title-heading > a {
@@ -38,11 +40,6 @@ DEFAULT MOBILE STYLING
   display: block;
 }
 
-.row-cols-2 > * {
-  max-width: 100%;
-  flex: 0 0 100%;
-}
-
 .documents-gallery .document-metadata, .document-counter {
   display: none;
 }
@@ -50,18 +47,5 @@ DEFAULT MOBILE STYLING
 @media screen and (min-width: $small_device) {
   .documents-gallery .thumbnail-container > a {
     height: 200px;
-  }
-
-  .row-cols-2 > * {
-    max-width: 50%;
-    flex: 0 0 50%;
-  }
-}
-
-
-@media screen and (min-width: $xlarge_device) {
-  .row-cols-2 > * {
-    max-width: 33%;
-    flex: 0 0 33%;
   }
 }

--- a/app/assets/stylesheets/customOverrides/search_result.scss
+++ b/app/assets/stylesheets/customOverrides/search_result.scss
@@ -334,17 +334,17 @@ BOOKMARK STYLING
   .index_title.document-title-heading.title_tesim {
     display: flex;
   }
-  .documents-list .index-document-functions {
+  .index-document-functions {
     padding-left: 10px;
   }
 }
 @media screen and (min-width: $medium_device) {
-  .documents-list .index-document-functions {
+  .index-document-functions {
     padding-left: 45px;
   }
 }
 @media screen and (min-width: $large_device) {
-  .documents-list .index-document-functions {
+  .index-document-functions {
     padding-left: 90px;
   }
 }

--- a/app/assets/stylesheets/customOverrides/search_result.scss
+++ b/app/assets/stylesheets/customOverrides/search_result.scss
@@ -334,17 +334,17 @@ BOOKMARK STYLING
   .index_title.document-title-heading.title_tesim {
     display: flex;
   }
-  .index-document-functions {
+  .documents-list .index-document-functions {
     padding-left: 10px;
   }
 }
 @media screen and (min-width: $medium_device) {
-  .index-document-functions {
+  .documents-list .index-document-functions {
     padding-left: 45px;
   }
 }
 @media screen and (min-width: $large_device) {
-  .index-document-functions {
+  .documents-list .index-document-functions {
     padding-left: 90px;
   }
 }


### PR DESCRIPTION
# Summary
Absolute position for bookmark toggle moved the item off the visible screen for the user after the bootstrap upgrade.  This changes the toggle's positioning for visibility at all screen sizes.

# Related Ticket
[#2936](https://github.com/yalelibrary/YUL-DC/issues/2936)

# Screenshots

<details>

<img width="444" alt="image" src="https://github.com/user-attachments/assets/0e48aa02-fefd-4073-84e6-464dbc14566a" />


<img width="821" alt="image" src="https://github.com/user-attachments/assets/bb27f756-9081-46d0-95c3-a7243cc59501" />

<img width="1091" alt="image" src="https://github.com/user-attachments/assets/6f0d12e0-0784-41d9-80af-5e383d61db3b" />

<img width="1380" alt="image" src="https://github.com/user-attachments/assets/cba8b014-0ec9-46e0-83de-0d260ea04da3" />


</details>