### PR TITLE
Styles links

### DIFF
--- a/app/assets/stylesheets/customOverrides/constraints.scss
+++ b/app/assets/stylesheets/customOverrides/constraints.scss
@@ -32,6 +32,8 @@ DEFAULT MOBILE STYLING
   background-color: $lighter_grey;
   margin-left: 0;
   overflow-wrap: break-word;
+  justify-content: space-between;
+  align-items: center;
 }
 
 
@@ -115,12 +117,6 @@ DEFAULT MOBILE STYLING
 @media screen and (min-width: $small_device) {
   .constraints-group{
     width: 62%;
-  }
-
-  .catalog_startOverLink {
-    position: absolute;
-    right: 0;
-    bottom: 1px;
   }
 }
 

--- a/app/assets/stylesheets/customOverrides/pagination.scss
+++ b/app/assets/stylesheets/customOverrides/pagination.scss
@@ -100,7 +100,7 @@ DEFAULT MOBILE STYLING
   .record-padding {
     position: relative;
   }
-  
+
   .page-item .page-link[aria-label="Go to previous page"] {
     position: absolute;
     left: 0;
@@ -109,5 +109,29 @@ DEFAULT MOBILE STYLING
   .page-item .page-link[aria-label="Go to next page"] {
     position: absolute;
     right: 0;
+  }
+}
+
+@media screen and (min-width: $medium_device) {
+  .page-links-show {
+    position: absolute;
+    right: 0;
+    width: 30%;
+  }
+}
+
+@media screen and (min-width: $large_device) {
+  .page-links-show {
+    position: absolute;
+    right: 0;
+    width: 20%;
+  }
+}
+
+@media screen and (min-width: $xlarge_device) {
+  .page-links-show {
+    position: absolute;
+    right: 0;
+    width: 15%;
   }
 }

--- a/app/assets/stylesheets/customOverrides/pagination.scss
+++ b/app/assets/stylesheets/customOverrides/pagination.scss
@@ -12,12 +12,16 @@ DEFAULT MOBILE STYLING
   font-family: $mallory_mp_medium, $mallory_medium, Arial, Helvetica, sans-serif;
   font-size: 12px;
   color: $light_blue;
+  text-decoration: none;
+}
+
+#sortAndPerPage .page-links a:hover, #sortAndPerPage .page-links a:focus, #sortAndPerPage .page-links a:active {
+  text-decoration: underline;
 }
 
 #sortAndPerPage .page-entries {
   color: $medium_grey;
 }
-
 
 // Pagination at the bottom of the page
 

--- a/app/assets/stylesheets/customOverrides/pagination.scss
+++ b/app/assets/stylesheets/customOverrides/pagination.scss
@@ -127,11 +127,3 @@ DEFAULT MOBILE STYLING
     width: 20%;
   }
 }
-
-@media screen and (min-width: $xlarge_device) {
-  .page-links-show {
-    position: absolute;
-    right: 0;
-    width: 15%;
-  }
-}

--- a/app/assets/stylesheets/customOverrides/search_result.scss
+++ b/app/assets/stylesheets/customOverrides/search_result.scss
@@ -6,6 +6,14 @@ DEFAULT MOBILE STYLING
    display: none;
   }
 
+  a {
+    text-decoration: none;
+  }
+
+  a:hover, a:focus, a:active {
+    text-decoration: underline;
+  }
+
   .document-title > a {
     color: $light_blue;
     max-width: 420px;

--- a/app/assets/stylesheets/customOverrides/show_page.scss
+++ b/app/assets/stylesheets/customOverrides/show_page.scss
@@ -143,16 +143,16 @@ dt.blacklight-ancestordisplaystrings_tesim.metadata-block__label-key {
   padding: 0 0 0 0;
 }
 
-.constraints-container {
+.show-document .constraints-container {
   margin-left: 1%;
-  justify-self: center;
+  align-items: center;
   display: flex;
   z-index: 1;
   position: relative;
 }
 
 .show-buttons {
-  justify-self: center;
+  align-items: center;
 }
 
 .show-links {
@@ -477,10 +477,10 @@ p.yale-restricted-work-text{
 }
 
 @media screen and (min-width: $medium_device) {
-  .constraints-container {
+  .show-document .constraints-container {
     margin-left: -.5%;
     width: 118%;
-    justify-self: center;
+    align-items: center;
     justify-content: flex-start;
     display: flex;
     z-index: 1;
@@ -564,10 +564,10 @@ margin-bottom: 2%;  }
 
 
 @media screen and (min-width: $large_device) {
-  .constraints-container {
+  .show-document .constraints-container {
     margin-left: 0.5%;
     width: 140%;
-    justify-self: center;
+    align-items: center;
     justify-content: flex-start;
     display: flex;
     z-index: 1;
@@ -673,9 +673,9 @@ margin-bottom: 2%;  }
 
 
 @media screen and (min-width: $xlarge_device) {
-  .constraints-container {
+  .show-document .constraints-container {
     width: 144%;
-    justify-self: center;
+    align-items: center;
     justify-content: flex-start;
     display: flex;
     z-index: 1;

--- a/app/assets/stylesheets/customOverrides/show_page.scss
+++ b/app/assets/stylesheets/customOverrides/show_page.scss
@@ -203,6 +203,14 @@ dt.blacklight-ancestordisplaystrings_tesim.metadata-block__label-key {
   padding: 0.5rem 0.25rem 1rem;
 }
 
+.nav-link a {
+  text-decoration: none;
+}
+
+.nav-link a:hover, .nav-link a:focus, .nav-link a:active {
+  text-decoration:  underline;
+}
+
 #citationLink:after, #manifestLink:after, #miradorLink:after, #pdfLink:after {
   content: ' >';
 }
@@ -350,6 +358,12 @@ dt.blacklight-ancestordisplaystrings_tesim.metadata-block__label-key {
 
 .single-item-show.metadata-block a {
   color: $light_blue;
+  text-decoration: none;
+}
+
+.single-item-show.metadata-block a:hover, .single-item-show.metadata-block a:focus, .single-item-show.metadata-block a:active {
+  color: $light_blue;
+  text-decoration: underline;
 }
 
 .single-item-show .metadata-block dt {

--- a/app/components/yul/system/modal_component.html.erb
+++ b/app/components/yul/system/modal_component.html.erb
@@ -11,7 +11,7 @@
       <h1 class="modal-title"><%= title %></h1>
     <% end) %>
 
-    <button type="button" class="blacklight-modal-close btn-close close" data-bs-dismiss="modal" data-dismiss="modal" aria-label="<%= t('blacklight.modal.close') %>">
+    <button type="button" class="blacklight-modal-close btn-close close" data-bs-dismiss="modal" aria-label="<%= t('blacklight.modal.close') %>">
       <span aria-hidden="true" class="visually-hidden">&times;</span>
     </button>
   </div>

--- a/app/views/catalog/_citation.html.erb
+++ b/app/views/catalog/_citation.html.erb
@@ -1,6 +1,6 @@
 <div class="modal-header">
   <h1><%= t('blacklight.tools.citation') %></h1>
-  <button type="button" class="blacklight-modal-close close" data-dismiss="modal" aria-label="<%= t('blacklight.modal.close') %>">
+  <button type="button" class="blacklight-modal-close close" data-bs-dismiss="modal" aria-label="<%= t('blacklight.modal.close') %>">
     <span aria-hidden="true">&times;</span>
 </button>
 </div>


### PR DESCRIPTION
# Summary
Fixes alignment of New Search links, citation modal not closing, and hover underline of metadata links.

# Related Ticket
[#2936](https://github.com/yalelibrary/YUL-DC/issues/2936)


# Screenshots

<details>

<img width="1306" alt="image" src="https://github.com/user-attachments/assets/8cea0642-fab8-4234-8bf5-0ef036433b73" />

<img width="1155" alt="image" src="https://github.com/user-attachments/assets/c2815568-35d9-479a-b4b9-9209ad453bf1" />

<img width="994" alt="image" src="https://github.com/user-attachments/assets/2d862dd7-c4c1-4f8f-b694-7af43f49d9b3" />

<img width="685" alt="image" src="https://github.com/user-attachments/assets/ef286f0a-24aa-4738-8fbe-ba1afe897477" />

<img width="597" alt="image" src="https://github.com/user-attachments/assets/10fd773e-7f9e-4bb6-b02e-9c43df537933" />

<img width="616" alt="image" src="https://github.com/user-attachments/assets/69afa599-7a42-4d2f-ba2b-dd209a3f92e4" />

<img width="665" alt="image" src="https://github.com/user-attachments/assets/5d903f04-1fdb-45b7-9253-b6c373c6729f" />

<img width="1017" alt="image" src="https://github.com/user-attachments/assets/b749f48d-3ab7-479b-af32-b3f8f4dbe641" />

<img width="1294" alt="image" src="https://github.com/user-attachments/assets/03ad830e-4e85-477c-a446-87c8d7576b6b" />

<img width="1431" alt="image" src="https://github.com/user-attachments/assets/00285dd8-b68c-46c9-a870-f7ce64171f0c" />



</details>