### PR TITLE
Resolve spacing issues

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,20 +12,11 @@
 //= require twitter/typeahead
 //= require bootstrap
 //= require blacklight/blacklight
+//= require blacklight_date_range
 //= require download_original
 //= require show_more
-
-
-
-// For blacklight_range_limit built-in JS, if you don't want it you don't need
-// this:
+// For blacklight_range_limit built-in JS
 //= require blacklight_range_limit
-$('.blacklight-year_i').data('plot-config', {
-    selection: { color: '#C0FF83' },
-    colors: ['#ffffff'],
-    series: { lines: { fillColor: 'rgba(255,255,255, 0.5)' }},
-    grid: { color: '#aaaaaa', tickColor: '#aaaaaa', borderWidth: 0 }
-});
 
 /**
  * Setup button functionality.

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,6 +14,7 @@
 //= require blacklight/blacklight
 //= require blacklight_date_range
 //= require download_original
+//= require notifications
 //= require show_more
 // For blacklight_range_limit built-in JS
 //= require blacklight_range_limit

--- a/app/assets/javascripts/blacklight_date_range.js
+++ b/app/assets/javascripts/blacklight_date_range.js
@@ -1,0 +1,23 @@
+$('.blacklight-year_i').data('plot-config', {
+    selection: { color: '#C0FF83' },
+    colors: ['#ffffff'],
+    series: { lines: { fillColor: 'rgba(255,255,255, 0.5)' }},
+    grid: { color: '#aaaaaa', tickColor: '#aaaaaa', borderWidth: 0 }
+});
+
+// override blacklight date range facet behavior that hid the Apply button post upgrade to Bootstrap 5
+$(document).on('turbolinks:load', function () {
+    const submitButtons = $('.range-limit-input-group :input[value="Apply"]');
+    $.each(submitButtons, function( index, value ) {
+        $(value).removeClass('sr-only');
+    })
+});
+
+$(document).on('turbolinks:load', function () {
+    $("#blacklight-modal").on('show.bs.modal', function () {
+        const submitButtons = $('.range-limit-input-group :input[value="Apply"]');
+        $.each(submitButtons, function( index, value ) {
+            $(value).removeClass('sr-only');
+        })
+    })
+});

--- a/app/assets/javascripts/notifications.js
+++ b/app/assets/javascripts/notifications.js
@@ -1,0 +1,5 @@
+// override blacklight flash message behavior that created a double close X button post upgrade to Bootstrap 5
+$(document).on('turbolinks:load', function () {
+    const closeButton = $('#main-flashes .close');
+    closeButton.removeClass('btn-close');
+});

--- a/app/assets/stylesheets/customOverrides/advanced_search.scss
+++ b/app/assets/stylesheets/customOverrides/advanced_search.scss
@@ -178,7 +178,6 @@ span#advanced-fulltext-info {
   .adv-search-help {
     display: contents;
     position: relative;
-    width: 100%;
     padding-right: 15px;
     padding-left: 15px;
   }

--- a/app/assets/stylesheets/customOverrides/constraints.scss
+++ b/app/assets/stylesheets/customOverrides/constraints.scss
@@ -32,8 +32,7 @@ DEFAULT MOBILE STYLING
   background-color: $lighter_grey;
   margin-left: 0;
   overflow-wrap: break-word;
-  justify-content: space-between;
-  align-items: center;
+  display: block;
 }
 
 
@@ -43,6 +42,7 @@ DEFAULT MOBILE STYLING
   background-color: $lighter_grey;
   border-color: $lighter_grey;
   text-align: center;
+  float: right;
 }
 
 .constraints-group {
@@ -57,6 +57,7 @@ DEFAULT MOBILE STYLING
   width: fit-content;
   background-color: $white;
   font-size: 16px;
+  padding: 0 0 6px 3px;
 }
 
 .constraint-value.btn.btn-outline-secondary:hover {

--- a/app/assets/stylesheets/customOverrides/constraints.scss
+++ b/app/assets/stylesheets/customOverrides/constraints.scss
@@ -43,6 +43,7 @@ DEFAULT MOBILE STYLING
   border-color: $lighter_grey;
   text-align: center;
   float: right;
+  margin-top: -35px;
 }
 
 .constraints-group {

--- a/app/assets/stylesheets/customOverrides/facets.scss
+++ b/app/assets/stylesheets/customOverrides/facets.scss
@@ -108,6 +108,14 @@ div.card {
   border-top: 1px solid $light_grey !important;
 }
 
+#facets a {
+  text-decoration: none;
+}
+
+#facets a:active, #facets a:focus, #facets a:hover {
+  text-decoration: underline;
+}
+
 h2.facets-heading {
   font-family: $mallory_mp_black, $mallory_medium, Arial, Helvetica, sans-serif;
   font-size: 0.9rem;

--- a/app/assets/stylesheets/customOverrides/facets.scss
+++ b/app/assets/stylesheets/customOverrides/facets.scss
@@ -108,11 +108,13 @@ div.card {
   border-top: 1px solid $light_grey !important;
 }
 
-#facets a {
+#facets a, .facet-values a, .prev_next_links a {
   text-decoration: none;
 }
 
-#facets a:active, #facets a:focus, #facets a:hover {
+#facets a:active, #facets a:focus, #facets a:hover, 
+.facet-values a:active, .facet-values a:focus, .facet-values a:hover, 
+.prev_next_links a:active, .prev_next_links a:focus, .prev_next_links a:hover {
   text-decoration: underline;
 }
 
@@ -138,6 +140,15 @@ h2.facets-heading {
   margin-left: -5px;
   color: $light_blue;
   text-transform: capitalize;
+}
+
+
+.facet-pagination .prev_next_links, .facet-pagination .sort-options {
+  width: fit-content;
+}
+
+.facet-pagination .prev_next_links > * {
+  border: none;
 }
 
 @media screen and (min-width: $small_device) {

--- a/app/assets/stylesheets/customOverrides/footer.scss
+++ b/app/assets/stylesheets/customOverrides/footer.scss
@@ -65,17 +65,20 @@ DEFAULT MOBILE STYLING
 
 .footer-socmedia a {
   max-height: 2rem;
-  text-decoration: none;
-}
-
-.footer-socmedia a:active, .footer-socmedia a:focus, .footer-socmedia a:hover {
-  text-decoration: underline;
 }
 
 .footer-socmedia img {
   width: 1rem;
   height: 1rem;
   margin-right: 3px;
+}
+
+.footer-container a {
+  text-decoration: none;
+}
+
+.footer-container a:active, .footer-container a:focus, .footer-container a:hover {
+  text-decoration: underline;
 }
 
 @media screen and (min-width: $medium_device) {

--- a/app/assets/stylesheets/customOverrides/footer.scss
+++ b/app/assets/stylesheets/customOverrides/footer.scss
@@ -65,6 +65,11 @@ DEFAULT MOBILE STYLING
 
 .footer-socmedia a {
   max-height: 2rem;
+  text-decoration: none;
+}
+
+.footer-socmedia a:active, .footer-socmedia a:focus, .footer-socmedia a:hover {
+  text-decoration: underline;
 }
 
 .footer-socmedia img {

--- a/app/assets/stylesheets/customOverrides/notifications.scss
+++ b/app/assets/stylesheets/customOverrides/notifications.scss
@@ -1,0 +1,16 @@
+/********************************************************
+DEFAULT MOBILE STYLING
+********************************************************/
+
+#main-flashes .close {
+  float: right;
+}
+
+#main-flashes a {
+  text-decoration: none;
+}
+
+#main-flashes a:active, #main-flashes a:focus, #main-flashes a:hover {
+  text-decoration: underline;
+}
+

--- a/app/assets/stylesheets/customOverrides/show_page.scss
+++ b/app/assets/stylesheets/customOverrides/show_page.scss
@@ -203,6 +203,11 @@ dt.blacklight-ancestordisplaystrings_tesim.metadata-block__label-key {
   padding: 0.5rem 0.25rem 1rem;
 }
 
+// Cite Modal
+.modal-header {
+  justify-content: space-between;
+}
+
 .nav-link a {
   text-decoration: none;
 }

--- a/app/assets/stylesheets/customOverrides/subheader_users.scss
+++ b/app/assets/stylesheets/customOverrides/subheader_users.scss
@@ -19,6 +19,14 @@ DEFAULT MOBILE STYLING
   padding-top: 10%;
 }
 
+.user-subheader-title a {
+  text-decoration: none;
+}
+
+.user-subheader-title a:hover, .user-subheader-title a:focus, .user-subheader-title a:active {
+  text-decoration: underline;
+}
+
 .user-subheader-options {
   font-family: $mallory_medium;
   color: $medium_grey;

--- a/config/uv/uv.html
+++ b/config/uv/uv.html
@@ -19,15 +19,10 @@
             overflow: hidden;
         }
 
-        #wholeImageHighReslabel {
-            visibility: hidden;
-            display: none;
+        .options :nth-last-child(2) {
+        display: none;
         }
-        #wholeImageHighRes {
-            visibility: hidden;
-            display: none;
-        }
-        
+
         .mainPanel .centerPanel .title {
             font-family: Arial !important;
         }


### PR DESCRIPTION
# Summary
Additional Bootstrap upgrade styling fixes:
* no more duplicate 'Full Image (jpg)' Download option
* citation modal close button aligned to right side
* facet modal remove link underlines and align buttons
* footer remove underline for not active links
* advanced search tips are beside inputs on large screens, not below
* no more underlines on facet links or Digital Collections main link - except on hover/active/focus
* 'apply' button for date range filter is visible in facet and in modal
* search term results are left aligned
* close 'X' on notification messages is right aligned



# Related Ticket
[#2936](https://github.com/yalelibrary/YUL-DC/issues/2936)

# Screenshots

<details>

## download options without duplicate full image
<img width="409" alt="image" src="https://github.com/user-attachments/assets/038f2538-11cc-404c-8681-3bc6bcf92f3a" />

## citation modal
<img width="1366" alt="image" src="https://github.com/user-attachments/assets/98530e43-3ba2-4492-b37b-44f24b0de017" />

## links with no underline
<img width="449" alt="image" src="https://github.com/user-attachments/assets/e5fdc63d-3c8e-482e-9b11-5386708b3526" />

## facet more modal
<img width="1364" alt="image" src="https://github.com/user-attachments/assets/79753475-9327-4e9a-8857-484939960f0e" />

## footer links with no underline
<img width="1365" alt="image" src="https://github.com/user-attachments/assets/0bc39a15-5223-4cf9-81cf-5dca019110f8" />

## advanced search
<img width="1433" alt="image" src="https://github.com/user-attachments/assets/63c45dbe-be89-45f7-80e9-9cb850328581" />

## main link
<img width="436" alt="image" src="https://github.com/user-attachments/assets/cdcee319-1066-4ea4-a156-fba932b2941a" />

## date range facet
<img width="358" alt="image" src="https://github.com/user-attachments/assets/c809068a-d76d-4710-943b-678474f1f066" />
<img width="1437" alt="image" src="https://github.com/user-attachments/assets/455e0f76-7fd3-4d18-8fef-99d91dba1fff" />

## search result constraints
<img width="1429" alt="image" src="https://github.com/user-attachments/assets/af3ebf0e-5a32-4a2f-b2a1-72a046a9917d" />
<img width="1436" alt="image" src="https://github.com/user-attachments/assets/e5049861-c1de-47d4-9ef0-391a43fd0996" />

## notification message
<img width="1437" alt="image" src="https://github.com/user-attachments/assets/1e8c31ef-4231-4741-a4c0-58e0216c2dbd" />



</details>