### PR TITLE
Restore UV top navigation options

### DIFF
--- a/config/uv/uv.html
+++ b/config/uv/uv.html
@@ -19,10 +19,6 @@
             overflow: hidden;
         }
 
-        .options :nth-last-child(2) {
-        display: none;
-        }
-
         .mainPanel .centerPanel .title {
             font-family: Arial !important;
         }


### PR DESCRIPTION
# Summary
Solving the duplicate full jpg image download option hid the top navigation for the UV panel as well.  This restores the UV navigation as well as the duplicate option - which will be addressed in ticket [#3034](https://github.com/yalelibrary/YUL-DC/issues/3034).

# Related Ticket
[#3035](https://github.com/yalelibrary/YUL-DC/issues/3035)

# Screenshot
![image](https://github.com/user-attachments/assets/371c4e37-e240-410d-80f3-e977d4e73d77)
