### PR TITLE
Fix conflicting styles for pagination

### DIFF
--- a/app/assets/stylesheets/customOverrides/pagination.scss
+++ b/app/assets/stylesheets/customOverrides/pagination.scss
@@ -77,7 +77,12 @@ DEFAULT MOBILE STYLING
 
 // add a right border to all page numbers except the last page double arrows and Next button
 .page-item:nth-child(n+3):not(:nth-last-child(1)):not(:nth-last-child(2)):not(:nth-last-child(3)) {
-  border-right: 2px solid $medium_grey;
+  border-right: 1px solid $medium_grey;
+}
+
+// make sure bootstrap 5 styles do not hide pagination borders with negative gutter
+.page-item:not(:first-child) .page-link {
+  margin-left: 0;
 }
 
 //single item page pagination


### PR DESCRIPTION
# Summary
Bootstrap 5 assigned a negative gutter that hid the borders on the pagination design.  The addition of the margin left override restores consistent line weight for pagination options.

# Related Ticket
[#2936](https://github.com/yalelibrary/YUL-DC/issues/2936)

# Screenshot
![image](https://github.com/user-attachments/assets/90e56621-4040-4048-b17c-55dfdbea542f)
