### PR TITLE
Remove duplicate option and add line breaks to UV download dialogue

### DIFF
--- a/config/uv/uv-config.json
+++ b/config/uv/uv-config.json
@@ -119,6 +119,9 @@
             "options": {
                 "confinedImageSize": 1000,
                 "currentViewDisabledPercentage": 90,
+                "downloadCurrentViewEnabled": true,
+                "downloadWholeImageHighResEnabled": true,
+                "downloadWholeImageLowResEnabled": true,
                 "maxImageWidth": 5000,
                 "optionsExplanatoryTextEnabled": false,
                 "selectionEnabled": false
@@ -132,6 +135,7 @@
                 "editSettings": "Edit Settings",
                 "entireDocument": "Entire document ({0})",
                 "entireFileAsOriginal": "Entire file",
+                "individualPages": "",
                 "noneAvailable": "No download options are available.",
                 "pagingNote": "Please turn off Two Page View for additional options.",
                 "preview": "Preview",
@@ -252,7 +256,8 @@
                 "galleryButtonEnabled": true,
                 "imageSelectionBoxEnabled": false,
                 "pageModeEnabled": false,
-                "pagingToggleEnabled": true
+                "pagingToggleEnabled": true,
+                "centerOptionsEnabled": true
             },
             "content": {
                 "close": "Close",
@@ -282,7 +287,7 @@
                 "twoUp": "Two page view"
             }
         },
-        "seadragonCenterPanel": {
+        "openSeadragonCenterPanel": {
             "options": {
                 "animationTime": 0.15,
                 "autoHideControls": true,

--- a/config/uv/uv.html
+++ b/config/uv/uv.html
@@ -27,6 +27,20 @@
             font-family: Arial !important;
         }
 
+        .overlay.download .options:nth-child(3) li:nth-child(2) {
+            display: none;
+        }
+
+        .overlay.download .options:nth-child(3) li:nth-child(4) {
+            border-top: 1px solid #dddddd;
+        }
+
+        .overlay.download .options:nth-child(3) li:nth-child(5) {
+            border-bottom: 1px solid #dddddd;
+        }
+
+
+
         @media only screen and (min-width: 600px) {
             #uv .centerPanel .content .viewer .viewportNavButton {
                 display: inline-block !important;


### PR DESCRIPTION
# Summary
Restores some styling of the download dialogue box for UV to pre - bootstrap upgrade styles.

# Related Ticket
[#3034](https://github.com/yalelibrary/YUL-DC/issues/3034)

# Screenshot
![image](https://github.com/user-attachments/assets/4284f9d7-748b-4139-9de9-f3866e7cc979)
