### PR TITLE
Adds character limit to Abstract and Description

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -192,9 +192,9 @@ class CatalogController < ApplicationController
     config.add_index_field 'imageCount_isi', label: 'Image Count'
     config.add_index_field 'resourceType_tesim', label: 'Resource Type', highlight: true, solr_params: disp_req_fieldmatch_on_search_params
     config.add_index_field 'fulltext_tesim', label: 'Full Text', highlight: true, solr_params: disp_highlight_on_search_params.merge({ 'hl.snippets': 4 }), helper_method: :fulltext_snippet_separation
-    config.add_index_field 'abstract_tesim', label: 'Abstract', highlight: true, solr_params: disp_highlight_on_search_params
+    config.add_index_field 'abstract_tesim', label: 'Abstract', highlight: true, solr_params: disp_highlight_on_search_params, helper_method: :set_max_abstract_characters
     config.add_index_field 'alternativeTitle_tesim', label: 'Alternative Title', highlight: true, solr_params: disp_highlight_on_search_params
-    config.add_index_field 'description_tesim', label: 'Description', highlight: true, solr_params: disp_highlight_on_search_params
+    config.add_index_field 'description_tesim', label: 'Description', highlight: true, solr_params: disp_highlight_on_search_params, helper_method: :set_max_description_characters
     config.add_index_field 'orbisBidId_ssi', label: 'Orbis Record', highlight: true, solr_params: disp_highlight_on_search_params
     config.add_index_field 'publicatonPlace_tesim', label: 'Publication Place', highlight: true, solr_params: disp_highlight_on_search_params
     config.add_index_field 'publisher_tesim', label: 'Publisher', highlight: true, solr_params: disp_highlight_on_search_params

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -51,6 +51,20 @@ module BlacklightHelper
     end.join(', ')
   end
 
+  def set_max_abstract_characters(args)
+    highlights = args[:document].highlight_field('abstract_tesim')
+    return highlights.first if highlights.present?
+
+    args[:document][:abstract_tesim].first.length > 250 ? args[:document][:abstract_tesim].first[0..250].concat("...") : args[:document][:abstract_tesim].first
+  end
+
+  def set_max_description_characters(args)
+    highlights = args[:document].highlight_field('description_tesim')
+    return highlights.first if highlights.present?
+
+    args[:document][:description_tesim].first.length > 250 ? args[:document][:description_tesim].first[0..250].concat("...") : args[:document][:description_tesim].first
+  end
+
   def language_codes_as_links(args)
     out = []
 


### PR DESCRIPTION
## Summary  
Adds a 250 character limit to Abstract and Description.  
  
## Screenshot:  
<img width="1075" alt="image" src="https://github.com/user-attachments/assets/5ecc2550-a925-4e9d-8899-94c8d02a91e8" />
  
Search highlighting maintained:  
<img width="1287" alt="image" src="https://github.com/user-attachments/assets/9c02ca1c-b179-498f-9385-ab0e3e50bc54" />
