### PR TITLE
adds toggle to hide sensitive materials object

### DIFF
--- a/app/assets/stylesheets/customOverrides/show_page.scss
+++ b/app/assets/stylesheets/customOverrides/show_page.scss
@@ -96,6 +96,11 @@ dt.blacklight-ancestordisplaystrings_tesim.metadata-block__label-key {
   margin-bottom: 1.5em;
 }
 
+.hide-object {
+  text-align: center;
+  margin-top: 10px;
+}
+
 //Control the appearance of hierarchy icons and space
 .aSpaceBranch {
   position: absolute;
@@ -618,6 +623,12 @@ p.yale-restricted-work-text{
     font-size: 1.6rem;
   }
 
+  .hide-object {
+    text-align: center;
+    margin-top: 10px;
+    padding-left: 10%;
+  }
+
   .show-header-container,
   .yale-restricted-work-text {
     width: 92%;
@@ -746,6 +757,12 @@ margin-bottom: 2%;  }
     margin-bottom: 1.5em; 
     margin-right: 1em;
     font-size: 1.60rem;
+  }
+
+  .hide-object {
+    text-align: center;
+    margin-top: 10px;
+    padding-left: 35%;
   }
 
   .show-header-container,
@@ -884,6 +901,12 @@ margin-bottom: 2%;  }
     margin-bottom: 2em;
     margin-right: 1em;
     font-size: 1.75rem;
+  }
+
+  .hide-object {
+    text-align: center;
+    margin-top: 10px;
+    padding-left: 35%;
   }
 
   .show-header-container,

--- a/app/views/catalog/_uv.html.erb
+++ b/app/views/catalog/_uv.html.erb
@@ -29,6 +29,9 @@
     frameborder='0'>
 </iframe>
 </div>
+<div class="hide-object">
+  <button id="hide-object-btn" class="overlay-button" style="display: none;">Hide Object</button>
+</div>
 </br>
 
 <div id='uv-pages'></div>
@@ -55,5 +58,21 @@
         $('#uv-pages').html(uv_thumbnail)
       }
     }, false)
+
+    // Overlay toggle
+    const overlay = document.getElementById('sensitive-overlay');
+    const hideBtn = document.getElementById('hide-object-btn');
+    if (overlay && hideBtn) {
+      // When overlay is hidden, show the Hide Object button
+      overlay.querySelector('.overlay-button').addEventListener('click', function() {
+        overlay.style.display = 'none';
+        hideBtn.style.display = 'inline-block';
+      });
+      // When Hide Object is clicked, show the overlay again
+      hideBtn.addEventListener('click', function() {
+        overlay.style.display = 'block';
+        hideBtn.style.display = 'none';
+      });
+    }
   })
 </script>


### PR DESCRIPTION
## Summary  
Overlay for an object with Sensitive materials can now be toggled via "Hide Object" button  
  
## Screenshots:  
<img width="1559" alt="image" src="https://github.com/user-attachments/assets/9adaab0e-7656-4e44-958d-bb202be51c32" />
  
<img width="1685" alt="image" src="https://github.com/user-attachments/assets/f97aafd5-33e0-4bb9-821b-4237a149ba67" />
