### PR TITLE
aligns container/volume metadata

### DIFF
--- a/app/assets/stylesheets/customOverrides/show_page.scss
+++ b/app/assets/stylesheets/customOverrides/show_page.scss
@@ -14,7 +14,7 @@ DEFAULT MOBILE STYLING
 }
 
 dt.blacklight-containergrouping_tesim.metadata-block__label-key {
-  width: 30.5%;
+  width: 25%;
   margin-bottom: 2%;
 }
 


### PR DESCRIPTION
## Summary  
Container/Volume metadata is now aligned correctly.  
  
## Screenshots:  
Before:  
<img width="1524" height="809" alt="image" src="https://github.com/user-attachments/assets/47f6e85b-d60e-46e6-89f3-202f6479c222" />

After:  
<img width="1483" height="806" alt="image" src="https://github.com/user-attachments/assets/762de7ee-a64b-442c-a62c-a4679cc7d6c8" />