### PR TITLE
Upgrade docker orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ jobs:
           tag: $CIRCLE_TAG
 
 orbs:
-  docker: circleci/docker@1.0.1
+  docker: circleci/docker@3.0.1
 version: 2.1
 workflows:
   commit:


### PR DESCRIPTION
# Summary
Removes deprecation warning in CircleCI for outdated deploy syntax by upgrading the docker orb.

# Related Ticket
[#3164](https://github.com/yalelibrary/YUL-DC/issues/3164)