### PR TITLE
Changes text color of advanced search link on small screens

### DIFF
--- a/app/assets/stylesheets/customOverrides/landing.scss
+++ b/app/assets/stylesheets/customOverrides/landing.scss
@@ -109,7 +109,7 @@ DEFAULT MOBILE STYLING
 		font-size: 36px;
 		line-height: normal;
 		text-align: center;
-		color: #ffffff;
+		color: $white;
 	}
 
 	.hero-info {
@@ -129,6 +129,13 @@ DEFAULT MOBILE STYLING
 		min-height: 44px;
 		height: 50px;
 		font-size: 20px;
+		font-family: $mallory_mp_medium;
+	}
+
+	.adv-search-link a {
+		color: $white;
+		font-size: 14px;
+		font-weight: 500;
 		font-family: $mallory_mp_medium;
 	}
 }
@@ -560,14 +567,6 @@ DEFAULT MOBILE STYLING
 		.adv-search-link {
 			background-color: rgba(0, 0, 0, 0.5);
 			text-align: center;
-		}
-
-		.adv-search-link a {
-			color: #ffffff;
-			font-size: 14px;
-			font-weight: 500;
-			font-family: $mallory_mp_medium;
-			text-decoration: underline;
 		}
 	}
 


### PR DESCRIPTION
# Summary
Makes sure that the advanced search link does not return to default colors for links and remains visible on all screen sizes.

# Related Ticket
[#3166](https://github.com/yalelibrary/YUL-DC/issues/3166)

# Screenshot

<img width="1039" height="323" alt="image" src="https://github.com/user-attachments/assets/f1053ae4-8b36-4712-9e63-482440697166" />
