### PR TITLE
Uses Random UUID for Guest Users

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,7 +29,7 @@ class ApplicationController < ActionController::Base
   # rubocop:disable Lint/UselessAssignment
   def guest_uid_authentication_key(key)
     key &&= nil unless /^guest/.match?(key.to_s)
-    key ||= "guest_" + Array.new(5) { SecureRandom.rand(0..9) }.join
+    key ||= "guest_" + Digest::UUID.uuid_v5(Digest::UUID::DNS_NAMESPACE, ENV['BLACKLIGHT_HOST'] || 'localhost')
   end
   # rubocop:enable Lint/UselessAssignment
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -40,7 +40,7 @@ class ApplicationController < ActionController::Base
   # rubocop:disable Lint/UselessAssignment
   def guest_uid_authentication_key(key)
     key &&= nil unless /^guest/.match?(key.to_s)
-    key ||= "guest_" + Digest::UUID.uuid_v5(Digest::UUID::DNS_NAMESPACE, ENV['BLACKLIGHT_HOST'] || 'localhost')
+    key ||= "guest_" + SecureRandom.uuid
     session["warden.user.user.key"] = key
   end
   # rubocop:enable Lint/UselessAssignment

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,7 +30,7 @@ class ApplicationController < ActionController::Base
     # skip if user is logged in
     return if current_user.present?
     # skip for non-HTML requests to prevent breaking CSS and JS assets
-    return unless request.format.html?
+    return unless request.format.html? && !request.xhr?
     # create a unique guest UID if necessary
     guest_uid_authentication_key(session["warden.user.user.key"])
   end
@@ -41,6 +41,7 @@ class ApplicationController < ActionController::Base
   def guest_uid_authentication_key(key)
     key &&= nil unless /^guest/.match?(key.to_s)
     key ||= "guest_" + Digest::UUID.uuid_v5(Digest::UUID::DNS_NAMESPACE, ENV['BLACKLIGHT_HOST'] || 'localhost')
+    session["warden.user.user.key"] = key
   end
   # rubocop:enable Lint/UselessAssignment
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,8 @@ class ApplicationController < ActionController::Base
   include Blacklight::Controller
   include HttpAuthConcern
 
+  before_action :ensure_guest_uid_authentication_key
+
   layout :determine_layout if respond_to? :layout
 
   rescue_from Blacklight::Exceptions::RecordNotFound, with: :not_found
@@ -23,6 +25,15 @@ class ApplicationController < ActionController::Base
   end
 
   private
+
+  def ensure_guest_uid_authentication_key
+    # skip if user is logged in
+    return if current_user.present?
+    # skip for non-HTML requests to prevent breaking CSS and JS assets
+    return unless request.format.html?
+    # create a unique guest UID if necessary
+    guest_uid_authentication_key(session["warden.user.user.key"])
+  end
 
   # Needed for guest user authentication. Devise expects the authentication key to be present, but we want to allow it to be nil for non-guest users.
   # This method ensures that only keys starting with "guest" are considered valid, and generates a unique guest UID if the key is nil or invalid.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,4 +25,24 @@ class User < ApplicationRecord
   def to_s
     uid
   end
+
+  # Override serialize_from_session to fix Rails 8/Devise 4.9.4 compatibility
+  # See: https://github.com/heartcombo/devise/issues/5752
+  def self.serialize_from_session(key, _salt = nil)
+    # Handle both old format [id, salt] and new format (full record hash)
+    if key.is_a?(Hash)
+      # New format: full record hash from Rails 8
+      record_id = key["id"] || key[:id]
+      return nil unless record_id
+      find_by(id: record_id)
+    elsif key.is_a?(Array) && key.length >= 1
+      # Old format: [id] or [id, salt]
+      record_id = key.first
+      return nil unless record_id
+      find_by(id: record_id)
+    else
+      # Single ID value
+      find_by(id: key)
+    end
+  end
 end

--- a/spec/controllers/search_history_controller_spec.rb
+++ b/spec/controllers/search_history_controller_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe SearchHistoryController do
+  include Devise::Test::ControllerHelpers
   routes { Blacklight::Engine.routes }
 
   describe 'index' do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -8,5 +8,9 @@ FactoryBot.define do
     uid { FFaker::Internet.user_name }
     sub { "123" }
     provider { "openid" }
+    factory :guest_user do
+      uid { "guest_" + SecureRandom.uuid }
+      sub { FFaker::Number.number(digits: 10).to_s }
+    end
   end
 end


### PR DESCRIPTION
# Summary
Provides more unique values for guest user key generation, moves generation to a before action, and adds conditional logic for when to generate to prevent asset load collisions.  Also, includes an override for a Rails/Devise compatibility issue.

# Related Ticket 
[#3286](https://github.com/yalelibrary/YUL-DC/issues/3286)