### PR TITLE
Fixes Search from Download Tab

### DIFF
--- a/app/controllers/download_original_controller.rb
+++ b/app/controllers/download_original_controller.rb
@@ -9,7 +9,9 @@ class DownloadOriginalController < ApplicationController
   before_action :check_authorization
 
   def tiff
-    if S3Service.exists_in_s3(tiff_pairtree_path)
+    if params[:q].present?
+      redirect_to "#{root_url}catalog?search_field=all_fields&fulltext_search=1&q=#{params[:q]}"
+    elsif S3Service.exists_in_s3(tiff_pairtree_path)
       send_tiff
     else
       stage_download


### PR DESCRIPTION
# Summary
Enables users to search from the download original tab.

# Related Ticket
[#3292](https://github.com/yalelibrary/YUL-DC/issues/3292)