### PR TITLE
Truncate Alternative Title

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -193,7 +193,7 @@ class CatalogController < ApplicationController
     config.add_index_field 'resourceType_tesim', label: 'Resource Type', highlight: true, solr_params: disp_req_fieldmatch_on_search_params
     config.add_index_field 'fulltext_tesim', label: 'Full Text', highlight: true, solr_params: disp_highlight_on_search_params.merge({ 'hl.snippets': 4 }), helper_method: :fulltext_snippet_separation
     config.add_index_field 'abstract_tesim', label: 'Abstract', highlight: true, solr_params: disp_highlight_on_search_params, helper_method: :display_max_abstract_characters
-    config.add_index_field 'alternativeTitle_tesim', label: 'Alternative Title', highlight: true, solr_params: disp_highlight_on_search_params
+    config.add_index_field 'alternativeTitle_tesim', label: 'Alternative Title', highlight: true, solr_params: disp_highlight_on_search_params, helper_method: :display_max_alternative_title_characters
     config.add_index_field 'description_tesim', label: 'Description', highlight: true, solr_params: disp_highlight_on_search_params, helper_method: :display_max_description_characters
     config.add_index_field 'orbisBidId_ssi', label: 'Orbis Record', highlight: true, solr_params: disp_highlight_on_search_params
     config.add_index_field 'publicatonPlace_tesim', label: 'Publication Place', highlight: true, solr_params: disp_highlight_on_search_params

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -258,6 +258,13 @@ module BlacklightHelper
     args[:document][:description_tesim].first.length > 250 ? args[:document][:description_tesim].first[0..250].concat("...") : args[:document][:description_tesim].first
   end
 
+  def display_max_alternative_title_characters(args)
+    highlights = args[:document].highlight_field('alternativeTitle_tesim')
+    return highlights.first if highlights.present?
+
+    args[:document][:alternativeTitle_tesim].first.length > 250 ? args[:document][:alternativeTitle_tesim].first[0..250].concat("...") : args[:document][:alternativeTitle_tesim].first
+  end
+
   def language_codes_as_links(args)
     out = []
 


### PR DESCRIPTION
## Summary  
Truncates alternative title index field if over 250 characters. Matches same pattern as other truncated index fields (description and abstract).