### PR TITLE
Truncate multiple alt titles

### DIFF
--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -260,9 +260,12 @@ module BlacklightHelper
 
   def display_max_alternative_title_characters(args)
     highlights = args[:document].highlight_field('alternativeTitle_tesim')
-    return highlights.first if highlights.present?
+    return safe_join(highlights, '<br/>'.html_safe) if highlights.present?
 
-    args[:document][:alternativeTitle_tesim].first.length > 250 ? args[:document][:alternativeTitle_tesim].first[0..250].concat("...") : args[:document][:alternativeTitle_tesim].first
+    truncated = args[:document][:alternativeTitle_tesim].map do |title|
+      title.length > 250 ? "#{title[0..250]}..." : title
+    end
+    safe_join(truncated, '<br/>'.html_safe)
   end
 
   def language_codes_as_links(args)

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -262,10 +262,9 @@ module BlacklightHelper
     highlights = args[:document].highlight_field('alternativeTitle_tesim')
     return safe_join(highlights, '<br/>'.html_safe) if highlights.present?
 
-    truncated = args[:document][:alternativeTitle_tesim].map do |title|
-      title.length > 250 ? "#{title[0..250]}..." : title
-    end
-    safe_join(truncated, '<br/>'.html_safe)
+    combined = args[:document][:alternativeTitle_tesim].join("\n")
+    truncated = combined.length > 250 ? "#{combined[0..250]}..." : combined
+    safe_join(truncated.split("\n"), '<br/>'.html_safe)
   end
 
   def language_codes_as_links(args)


### PR DESCRIPTION
## Summary  
Previous Alt Title truncate only accounted for 1 alternative title in the array. This accounts for multiple alt titles.  
  
## Screenshot:  
<img width="902" height="705" alt="image" src="https://github.com/user-attachments/assets/1875ab73-8fec-43c2-b842-fe0ef9a3613b" />
