### PR TITLE
'New Search' button alignment and centering

### DIFF
--- a/app/assets/stylesheets/customOverrides/constraints.scss
+++ b/app/assets/stylesheets/customOverrides/constraints.scss
@@ -4,7 +4,9 @@ DEFAULT MOBILE STYLING
 
 #appliedParams {
   padding: 16px;
+  padding-right: 170px;
   width: 100%;
+  position: relative;
 }
 
 .btn-group.applied-filter.constraint {
@@ -49,7 +51,9 @@ DEFAULT MOBILE STYLING
   width: fit-content;
   display: block;
   position: absolute;
-  right: 1%;
+  top: 50%;
+  right: 16px;
+  transform: translateY(-50%);
 }
 
 .constraints-group {
@@ -126,10 +130,6 @@ DEFAULT MOBILE STYLING
   .constraints-group{
     width: 62%;
   }
-
-  #startOverButtonContainer {
-    right: 6%;
-  }
 }
 
 @media screen and (min-width: $medium_device) {
@@ -142,18 +142,10 @@ DEFAULT MOBILE STYLING
   .constraints-group{
     width: 55%;
   }
-
-  #startOverButtonContainer {
-    right: 5%;
-  }
 }
 
 @media screen and (min-width: $xlarge_device) {
   .constraints-group{
     width: 62%;
-  }
-
-  #startOverButtonContainer {
-    right: 7%;
   }
 }


### PR DESCRIPTION
## Summary  
'New Search' button was overlapping search constraints, regardless of screen size. This PR will keep the 'New Search' button from overlapping searched constraints. 'New Search' button will now always be in the center of the searched constraints.
  
## Screenshots:  
  
**Before:**  
<img width="1626" height="656" alt="image" src="https://github.com/user-attachments/assets/a38d3f86-d2aa-4b03-ac16-c002f407b73d" />  
  
<img width="583" height="870" alt="image" src="https://github.com/user-attachments/assets/be31081c-0f0b-4dd5-884f-91c35419741b" />

    
  

**After:**  
  
<img width="1679" height="676" alt="image" src="https://github.com/user-attachments/assets/9df71f9e-7a6f-4c16-8941-c1001120ed3b" />  
  
  
<img width="628" height="907" alt="image" src="https://github.com/user-attachments/assets/52cd704e-1d68-4836-b702-df480e11d606" />  
  
  
<img width="1219" height="918" alt="image" src="https://github.com/user-attachments/assets/1e424d07-b1f3-451e-8768-8b4920b331c6" />

