### PR TITLE
OAI-PMH Filter

### DIFF
--- a/config/initializers/oai_security_patch.rb
+++ b/config/initializers/oai_security_patch.rb
@@ -1,12 +1,7 @@
 # frozen_string_literal: true
 # Hardens BlacklightOaiProvider so that ListRecords / ListIdentifiers / GetRecord
 # only expose records whose visibility is in the catalog UI's metadata-viewable set.
-# OAI_ALLOWED_VISIBILITIES MUST stay in sync with AccessHelper#viewable_metadata_visibilities.
-# Defense-in-depth: this enforces the policy explicitly, independent of whether the
-# Blacklight SearchBuilder processor chain (filter_by_visibility) fires for OAI requests.
 #
-# Implemented via Module#prepend so that #conditions can call `super` and chain to
-# the gem's original implementation instead of replacing it.
 module BlacklightOaiProvider
   module OaiVisibilityPatch
     OAI_ALLOWED_VISIBILITIES = ["Public", "Yale Community Only", "Open with Permission"].freeze
@@ -29,8 +24,6 @@ module BlacklightOaiProvider
       end
     end
 
-    # Defense-in-depth: also enforce on the :all / resumption-token paths,
-    # which build their query via the gem's inherited `conditions`.
     def conditions(constraints)
       query = super
       query.append_filter_query(OaiVisibilityPatch.allowed_visibility_fq)

--- a/config/initializers/oai_security_patch.rb
+++ b/config/initializers/oai_security_patch.rb
@@ -1,19 +1,42 @@
 # frozen_string_literal: true
+# Hardens BlacklightOaiProvider so that ListRecords / ListIdentifiers / GetRecord
+# only expose records whose visibility is in the catalog UI's metadata-viewable set.
+# OAI_ALLOWED_VISIBILITIES MUST stay in sync with AccessHelper#viewable_metadata_visibilities.
+# Defense-in-depth: this enforces the policy explicitly, independent of whether the
+# Blacklight SearchBuilder processor chain (filter_by_visibility) fires for OAI requests.
+#
+# Implemented via Module#prepend so that #conditions can call `super` and chain to
+# the gem's original implementation instead of replacing it.
 module BlacklightOaiProvider
-  class SolrDocumentWrapper < ::OAI::Provider::Model
+  module OaiVisibilityPatch
+    OAI_ALLOWED_VISIBILITIES = ["Public", "Yale Community Only", "Open with Permission"].freeze
+
+    def self.allowed_visibility_fq
+      "(" + OAI_ALLOWED_VISIBILITIES.map { |v| "visibility_ssi:\"#{v}\"" }.join(" OR ") + ")"
+    end
+
     def find(selector, options = {})
       return next_set(options[:resumption_token]) if options[:resumption_token]
 
       if selector == :all
         response = search_service.repository.search(conditions(options))
-
         return select_partial(BlacklightOaiProvider::ResumptionToken.new(options.merge(last: 0), nil, response.total)) if limit && response.total > limit
         response.documents
       else
-        # search_service.fetch(selector).first.documents.first
         query = search_service.search_builder.where(id: selector).query
+        query.append_filter_query(OaiVisibilityPatch.allowed_visibility_fq)
         search_service.repository.search(query).documents.first
       end
     end
+
+    # Defense-in-depth: also enforce on the :all / resumption-token paths,
+    # which build their query via the gem's inherited `conditions`.
+    def conditions(constraints)
+      query = super
+      query.append_filter_query(OaiVisibilityPatch.allowed_visibility_fq)
+      query
+    end
   end
+
+  SolrDocumentWrapper.prepend(OaiVisibilityPatch)
 end

--- a/spec/requests/catalog_controller_request_spec.rb
+++ b/spec/requests/catalog_controller_request_spec.rb
@@ -4,10 +4,13 @@ require 'rails_helper'
 RSpec.describe "/catalog", clean: true, type: :request do
   let(:public_work) { WORK_WITH_PUBLIC_VISIBILITY.merge({ "child_oids_ssim": ["5555555"] }) }
   let(:private_work) { WORK_WITH_PRIVATE_VISIBILITY }
+  let(:yco_work) { WORK_WITH_YALE_ONLY_VISIBILITY }
+  let(:owp_work) { WORK_WITH_OWP_VISIBILITY }
+  let(:redirect_work) { WORK_REDIRECTED }
 
   before do
     solr = Blacklight.default_index.connection
-    solr.add([public_work, private_work])
+    solr.add([public_work, private_work, yco_work, owp_work, redirect_work])
     solr.commit
   end
 
@@ -280,6 +283,61 @@ RSpec.describe "/catalog", clean: true, type: :request do
         xml.remove_namespaces!
         url_thumb = xml.xpath('//location/url[@access=\'preview\']', ns_hash).attr("href")
         expect(url_thumb.text).to eq(WORK_WITH_PUBLIC_VISIBILITY[:thumbnail_path_ss])
+      end
+    end
+  end
+
+  describe 'OAI visibility filtering' do
+    let(:unknown_identifier_msg) { "The value of the identifier argument is unknown or illegal in this repository." }
+
+    def oai_id(work)
+      "oai:collections.library.yale.edu:#{work[:id]}"
+    end
+
+    describe 'ListRecords' do
+      before { get "/catalog/oai?verb=ListRecords&metadataPrefix=oai_mods" }
+
+      it 'includes Public, YCO, and OWP identifiers' do
+        expect(response.body).to include(oai_id(WORK_WITH_PUBLIC_VISIBILITY))
+        expect(response.body).to include(oai_id(WORK_WITH_YALE_ONLY_VISIBILITY))
+        expect(response.body).to include(oai_id(WORK_WITH_OWP_VISIBILITY))
+      end
+
+      it 'omits Private and Redirect identifiers' do
+        expect(response.body).not_to include(oai_id(WORK_WITH_PRIVATE_VISIBILITY))
+        expect(response.body).not_to include(oai_id(WORK_REDIRECTED))
+      end
+    end
+
+    describe 'ListIdentifiers' do
+      before { get "/catalog/oai?verb=ListIdentifiers&metadataPrefix=oai_mods" }
+
+      it 'includes Public, YCO, and OWP identifiers' do
+        expect(response.body).to include(oai_id(WORK_WITH_PUBLIC_VISIBILITY))
+        expect(response.body).to include(oai_id(WORK_WITH_YALE_ONLY_VISIBILITY))
+        expect(response.body).to include(oai_id(WORK_WITH_OWP_VISIBILITY))
+      end
+
+      it 'omits Private and Redirect identifiers' do
+        expect(response.body).not_to include(oai_id(WORK_WITH_PRIVATE_VISIBILITY))
+        expect(response.body).not_to include(oai_id(WORK_REDIRECTED))
+      end
+    end
+
+    describe 'GetRecord' do
+      it 'returns data for Yale Community Only visibility' do
+        get "/catalog/oai?verb=GetRecord&metadataPrefix=oai_mods&identifier=#{oai_id(WORK_WITH_YALE_ONLY_VISIBILITY)}"
+        expect(response.body).not_to include(unknown_identifier_msg)
+      end
+
+      it 'returns data for Open with Permission visibility' do
+        get "/catalog/oai?verb=GetRecord&metadataPrefix=oai_mods&identifier=#{oai_id(WORK_WITH_OWP_VISIBILITY)}"
+        expect(response.body).not_to include(unknown_identifier_msg)
+      end
+
+      it 'rejects Redirect visibility' do
+        get "/catalog/oai?verb=GetRecord&metadataPrefix=oai_mods&identifier=#{oai_id(WORK_REDIRECTED)}"
+        expect(response.body).to include(unknown_identifier_msg)
       end
     end
   end

--- a/spec/support/solr_documents/metadata_cloud_with_visibility.rb
+++ b/spec/support/solr_documents/metadata_cloud_with_visibility.rb
@@ -115,6 +115,35 @@ WORK_WITH_YALE_ONLY_VISIBILITY = {
   "visibility_ssi": "Yale Community Only"
 }.freeze
 
+WORK_WITH_OWP_VISIBILITY = {
+  "id": "16189097-owp",
+  "title_tesim": ["[Map of China]. [open-with-permission copy]"],
+  "extent_ssim": ["1 map ; folded in covers 25 x 16 cm."],
+  "format": ["cartographic"],
+  "language_ssim": ["Japanese"],
+  "description_tesim": ["In Japanese.",
+                        "Japanese reprint of a Chinese map published in 1663.",
+                        "Transliteration supplied by cataloger."],
+  "genre_ssim": ["Maps."],
+  "resourceType_ssim": ["Maps, Atlases & Globes"],
+  "extentOfDigitization_ssim": ["Complete work digitized."],
+  "rights_ssim": ["The use of this image may be subject to the copyright law of the United States (Title 17, United States Code) or to site license or other rights management terms and conditions. The person using the image is liable for any infringement."],
+  "creationPlace_ssim": ["Kyoto [Japan] :"],
+  "publisher_ssim": ["Umemura Yahaku,"],
+  "source_ssim": ["ladybird"],
+  "recordType_ssi": "oid",
+  "illustrativeMatter_tesim": "080815s189u    ja ",
+  "oid_ssi": "16189097-owp",
+  "callNumber_ssim": ["Lanman Covers 56 189x"],
+  "containerGrouping_ssim": ["Lanman Covers 56 189x"],
+  "orbisBibId_ssi": "8330740",
+  "scale_tesim": ["Scale not given."],
+  "coordinateDisplay_ssim": ["a"],
+  "date_ssim": ["[189x?]"],
+  "public_bsi": true,
+  "visibility_ssi": "Open with Permission"
+}.freeze
+
 WORK_WITH_SENSITIVE_MATERIALS = {
   "id": "2055095",
   "title_tesim": ["A General dictionary of the English language"],


### PR DESCRIPTION
## Summary  
Explicitly list valid visibilities for OAI instead of relying on viewable_visibilities.  
  
## Screenshots:  
Valid visibility (Public):  
<img width="1125" height="918" alt="image" src="https://github.com/user-attachments/assets/1102caa5-9fcc-4a36-962f-0442d4a7c5ee" />

  
Invalid Visibility (Private):  
<img width="1771" height="629" alt="image" src="https://github.com/user-attachments/assets/e4d20137-ff0b-4381-b785-3f672171cdb3" />
