### PR TITLE
display copy-specific metadata on showpage

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -232,7 +232,10 @@ class CatalogController < ApplicationController
     config.add_show_field 'caption_tesim', label: 'Matching Captions', metadata: 'matching_captions', helper_method: :display_show_page_captions, if: :should_display_all_captions?
     config.add_show_field 'abstract_tesim', label: 'Abstract', metadata: 'description', helper_method: :join_as_paragraphs
     config.add_show_field 'description_tesim', label: 'Description', metadata: 'description', helper_method: :sanitize_join_with_br
+    config.add_show_field 'copyDescription_tesim', label: 'Notes on this Copy', metadata: 'description', if: :alma_source?
     config.add_show_field 'provenanceUncontrolled_tesi', label: 'Provenance', metadata: 'description'
+    config.add_show_field 'acquisitionSource_tesim', label: 'Source of Acquisition', metadata: 'description', if: :alma_source?
+    config.add_show_field 'bindingInfo_tesim', label: 'Binding', metadata: 'description', if: :alma_source?
     config.add_show_field 'extent_ssim', label: 'Extent', metadata: 'description', helper_method: :join_with_br
     config.add_show_field 'extentOfDigitization_ssim', label: 'Extent of Digitization', metadata: 'description', helper_method: :format_digitization
     config.add_show_field 'digitization_note_tesi', label: 'Digitization Note', metadata: 'description'
@@ -683,6 +686,11 @@ class CatalogController < ApplicationController
   def should_display_all_captions?(_field_config, _document)
     result = params[:show_captions] == 'true'
     result
+  end
+
+  # Conditional method to determine if a field should be displayed only for Alma-sourced records
+  def alma_source?(_field_config, document)
+    Array(document[:source_ssim]).include?('alma')
   end
 
   # This is for iiif_search

--- a/spec/presenters/yul/metadata_presenter_spec.rb
+++ b/spec/presenters/yul/metadata_presenter_spec.rb
@@ -70,6 +70,18 @@ RSpec.describe Yul::MetadataPresenter do
           expect(fields.any? { |field| field.include? 'description_tesim' }).to be_truthy
         end
 
+        it 'returns the Notes on this Copy Key' do
+          expect(fields.any? { |field| field.include? 'copyDescription_tesim' }).to be_truthy
+        end
+
+        it 'returns the Source of Acquisition Key' do
+          expect(fields.any? { |field| field.include? 'acquisitionSource_tesim' }).to be_truthy
+        end
+
+        it 'returns the Binding Key' do
+          expect(fields.any? { |field| field.include? 'bindingInfo_tesim' }).to be_truthy
+        end
+
         it 'returns the Extent Key' do
           expect(fields.any? { |field| field.include? 'extent_ssim' }).to be_truthy
         end

--- a/spec/support/solr_documents/all_fields_record.rb
+++ b/spec/support/solr_documents/all_fields_record.rb
@@ -52,5 +52,8 @@ WORK_WITH_ALL_FIELDS = {
   digital_ssim: "this is the digital, using ssim",
   coordinateDisplay_ssim: "this is the coordinates, using ssim",
   projection_tesim: "this is the projection, using ssim",
-  extent_ssim: "this is the extent, using ssim"
+  extent_ssim: "this is the extent, using ssim",
+  copyDescription_tesim: "this is the copy description",
+  acquisitionSource_tesim: "this is the acquisition source",
+  bindingInfo_tesim: "this is the binding info"
 }.freeze

--- a/spec/system/view_fields_in_display_spec.rb
+++ b/spec/system/view_fields_in_display_spec.rb
@@ -91,7 +91,10 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       coordinateDisplay_ssim: "this is the coordinates, using ssim",
       projection_tesim: "this is the projection, using ssim",
       extent_ssim: ["this is the extent, using ssim", "here is another extent"],
-      resourceVersionOnline_ssim: ["this is the online resource|http://this/is/the/link"]
+      resourceVersionOnline_ssim: ["this is the online resource|http://this/is/the/link"],
+      copyDescription_tesim: "First edition, cloth binding",
+      acquisitionSource_tesim: "Gift of Jane Doe",
+      bindingInfo_tesim: "Full leather binding with gold lettering"
     }
   end
   let(:test_aspace_record) do
@@ -151,7 +154,10 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       ancestorDisplayStrings_tesim: %w[seventh sixth fifth fourth third second first],
       ancestor_titles_hierarchy_ssim: ['first > ', 'first > second > ', 'first > second > third > ',
                                        'first > second > third > fourth > ', 'first > second > third > fourth > fifth > ',
-                                       'first > second > third > fourth > fifth > sixth > ', 'first > second > third > fourth > fifth > sixth > seventh > ']
+                                       'first > second > third > fourth > fifth > sixth > ', 'first > second > third > fourth > fifth > sixth > seventh > '],
+      copyDescription_tesim: "This is a copy description for an aspace record",
+      acquisitionSource_tesim: "This is an acquisition source for an aspace record",
+      bindingInfo_tesim: "This is binding info for an aspace record"
     }
   end
 
@@ -310,6 +316,17 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
       it 'does not display the Record Type in results' do
         expect(document).not_to have_content("this is the record type")
       end
+      it 'does not display Notes on this Copy for non-alma sources' do
+        expect(document).not_to have_content('Notes on this Copy')
+        expect(document).not_to have_content('This is a copy description for an aspace record')
+      end
+      it 'does not display Source of Acquisition for non-alma sources' do
+        expect(document).not_to have_content('Source of Acquisition')
+        expect(document).not_to have_content('This is an acquisition source for an aspace record')
+      end
+      it 'does not display Binding for non-alma sources' do
+        expect(document).not_to have_content('This is binding info for an aspace record')
+      end
       it 'displays the Source Title in results' do
         expect(document).to have_content("this is the source title")
       end
@@ -405,6 +422,18 @@ RSpec.feature "View Search Results", type: :system, clean: true, js: false do
         expect(page).to have_content('Catalog Record')
         expect(page).to have_link('777777777777', href: 'https://search.library.yale.edu/catalog/777777777777').once
         expect(page).not_to have_link('12345677', href: 'https://search.library.yale.edu/catalog/12345677')
+      end
+      it 'displays Notes on this Copy' do
+        expect(page).to have_content('Notes on this Copy')
+        expect(page).to have_content('First edition, cloth binding')
+      end
+      it 'displays Source of Acquisition' do
+        expect(page).to have_content('Source of Acquisition')
+        expect(page).to have_content('Gift of Jane Doe')
+      end
+      it 'displays Binding' do
+        expect(page).to have_content('Binding')
+        expect(page).to have_content('Full leather binding with gold lettering')
       end
     end
     context 'with sierra record' do


### PR DESCRIPTION
## Summary  
Adds the following metadata keys and values to object showpage:  
  
Blacklight label: Notes on this Copy
Placement: Directly underneath Description
  
Blacklight label: Source of Acquisition
Placement: Directly underneath Provenance
  
Blacklight label: Binding
Placement: Directly above Extent