### PR TITLE
Fixes zoom level

### DIFF
--- a/config/uv/uv.html
+++ b/config/uv/uv.html
@@ -68,19 +68,54 @@
             });
             uv = UV.init('uv', data);
 
+            // ensure fresh package
             uv.on("configure", function ({ config, cb }) {
-                  cb(
+                cb(
                     new Promise(function (resolve) {
-                      fetch("uv-config.json?v=v1.60.25").then(function (response) {
+                        fetch("uv-config.json?v=v1.60.25").then(function (response) {
                         resolve(response.json());
-                      });
+                        });
                     })
-                  );
-                });
+                );
+            });
 
+            // Post messages to the parent page when the canvas changes
             uv.on('canvasIndexChange', function (event) {
                 window.parent.postMessage(event, "*")
             })
+
+            // Fix initial zoom when coming from Thumbnail view, or whenever the initial zoom is set to a value that doesn't fill the viewport
+            uv.on(UV.Events.CREATED, function uvCreatedEvent() { 
+                const OSD = uv.get().extension.centerPanel; // OpenSeaDragon
+                if (OSD && OSD.viewer) {
+                    let viewportSize = null;
+                    let fixingZoom = false;
+                    const targetCoverage = uv.get().options.initialZoomMin ?? 1;
+
+                    OSD.viewer.addHandler("resize", (event) => {
+                        viewportSize = event.newContainerSize;
+                        fixingZoom = false;
+                    });
+
+                    OSD.viewer.addHandler("tile-drawn", (event) => {
+                        if (fixingZoom) {
+                            return;
+                        }
+
+                        fixingZoom = true;
+                        const zoomedSize = event.tiledImage.getSizeInWindowCoordinates();
+                        const filledRatio = Math.max(
+                            zoomedSize.x / viewportSize.x,
+                            zoomedSize.y / viewportSize.y,
+                        );
+
+                        if (filledRatio < targetCoverage) {
+                            const factor = targetCoverage / filledRatio;
+                            OSD.viewer.viewport.zoomBy(factor);
+                        }
+                    });
+                }    
+            });
         }, false);
     </script>
 </head>

--- a/spec/views/catalog/_uv.html.erb_spec.rb
+++ b/spec/views/catalog/_uv.html.erb_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe 'catalog/_uv.html.erb' do
       image_width = page.evaluate_script("document.querySelector('#uv iframe').contentWindow.document.querySelector('.uv-canvas').clientWidth")
       # calculate the filled ratio
       filled_ratio = [image_width.to_f / viewport_width, image_height.to_f / viewport_height].max
-      # expect the ratio to be 1
-      expect(filled_ratio).to eq(1)
+      # expect the ratio to be what zoom level is set to in the UV config
+      expect(filled_ratio).to eq(UV.modules.openSeadragonCenterPanel.options.defaultZoomLevel)
     end
   end
 end

--- a/spec/views/catalog/_uv.html.erb_spec.rb
+++ b/spec/views/catalog/_uv.html.erb_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
+
+RSpec.describe 'catalog/_uv.html.erb' do
+  let(:document) { SolrDocument.new id: 'xyz', bib_id_ssm: ['123'], visibility_ssi: "Public" }
+  let(:document2) { SolrDocument.new id: 'xyz', bib_id_ssm: ['123'], visibility_ssi: "Yale-Community Only" }
+  let(:blacklight_config) { Blacklight::Configuration.new }
+  let(:current_search_session) { double('SearchSession', id: 'abc') }
+
+  before do
+    assign :document, document
+    without_partial_double_verification do
+      allow(view).to receive(:blacklight_config).and_return blacklight_config
+      allow(view).to receive(:current_search_session).and_return current_search_session
+      allow(view).to receive(:show_doc_actions?).and_return true
+    end
+  end
+
+  it 'renders the iiif manifest image with proper zoom level' do
+    render partial: 'catalog/uv', locals: { document: document }
+    within '#uv' do
+      expect(rendered).to have_selector "iframe[src='http://test.host/uv/123/manifest.json?canvas=0&cv=0']"
+      # get viewport size
+      expect(rendered).to have_selector "iframe[width='400']"
+      expect(rendered).to have_selector "iframe[height='400']"
+      # get zoom level
+      viewport_height = page.evaluate_script("document.querySelector('#uv iframe').contentWindow.document.querySelector('.uv-viewport').clientHeight")
+      viewport_width = page.evaluate_script("document.querySelector('#uv iframe').contentWindow.document.querySelector('.uv-viewport').clientWidth")
+      image_height = page.evaluate_script("document.querySelector('#uv iframe').contentWindow.document.querySelector('.uv-canvas').clientHeight")
+      image_width = page.evaluate_script("document.querySelector('#uv iframe').contentWindow.document.querySelector('.uv-canvas').clientWidth")
+      # calculate the filled ratio
+      filled_ratio = [image_width.to_f / viewport_width, image_height.to_f / viewport_height].max
+      # expect the ratio to be 1
+      expect(filled_ratio).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
# Summary
Adds an override to the Universal Viewer configuration that sets the zoom level to the one in the configuration and if that is not available defaults to a zoom level of 1.

# Related Ticket
[#3280](https://github.com/yalelibrary/YUL-DC/issues/3280)