### PR TITLE
Permission Request Refactor Terms

### DIFF
--- a/app/helpers/access_helper.rb
+++ b/app/helpers/access_helper.rb
@@ -110,6 +110,7 @@ module AccessHelper
 
   def safe_parse_management_response(response)
     return nil unless response.is_a?(Net::HTTPSuccess)
+    return nil if response.body.nil? || response.body.strip.empty?
     JSON.parse(response.body)
   rescue JSON::ParserError
     nil


### PR DESCRIPTION
## Summary  
New JSON parsing refactor didn't take in account a permission set with no active terms. Now returns nil if no active terms. This allows the correct controller routing to work if the @permission_set_terms is nil