### PR TITLE
Updates Banner Handling

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -211,51 +211,57 @@ $(document).on('turbolinks:load', function() {
     renderBanner();
 });
 
+// Only accept a strict #RRGGBB hex color; reject anything else so a
+// compromised banner host cannot inject arbitrary CSS values.
+function sanitizeBannerColor(color) {
+    return /^#[0-9a-fA-F]{6}$/.test(color) ? color : "";
+}
+
+function applyBanner(data) {
+    let allBanners = data.banners;
+    if (!allBanners || !("global" in allBanners)) {
+        return;
+    }
+    let banners = allBanners.global;
+    if (banners.length === 0) {
+        return;
+    }
+    let banner = banners[0];
+    let container = document.getElementById("banner");
+    if (!container) {
+        return;
+    }
+
+    // Apply colors only when they pass strict #RRGGBB validation.
+    let backgroundColor = sanitizeBannerColor(banner.backgroundColor);
+    let textColor = sanitizeBannerColor(banner.textColor);
+    if (backgroundColor) {
+        container.style.backgroundColor = backgroundColor;
+    }
+    if (textColor) {
+        container.style.color = textColor;
+    }
+
+    // Use textContent (not innerHTML) so the third-party message is rendered
+    // as plain text and cannot inject markup or event handlers.
+    container.textContent = "";
+    let paragraph = document.createElement("p");
+    paragraph.textContent = banner.message == null ? "" : String(banner.message);
+    container.appendChild(paragraph);
+    container.style.display = "block";
+}
+
 function renderBanner() {
-    if (document.URL.indexOf('https://collections.library') !== -1) {
-        fetch("https://banner.library.yale.edu/banner.json")
-            .then(response => response.json())
-            .then(data => {
-                let allBanners = data.banners;
-                if ("global" in allBanners) {
-                    let banners = allBanners.global;
-                    if (banners.length > 0) {
-                        let banner = banners[0];
-                        let container = document.getElementById("banner");
-                        // Code to apply text and background color directly
-                        container.style.backgroundColor = banner.backgroundColor;
-                        container.style.color = banner.textColor;
-                        container.innerHTML = "<p>" + banner.message + "</p>";
-                        container.style.display = "block";
-                    }
-                }
-            })
-            .catch(error => {
-                console.error('Error:', error);
-                $("#banner").remove();
-            });
-    } else {
+    let bannerUrl = document.URL.indexOf('https://collections.library') !== -1
+        ? "https://banner.library.yale.edu/banner.json"
         // Use test banner for all non prod environments
-        fetch("https://banner.library.yale.edu/test/banner.json")
+        : "https://banner.library.yale.edu/test/banner.json";
+
+    fetch(bannerUrl)
         .then(response => response.json())
-        .then(data => {
-            let allBanners = data.banners;
-            if ("global" in allBanners) {
-                let banners = allBanners.global;
-                if (banners.length > 0) {
-                    let banner = banners[0];
-                    let container = document.getElementById("banner");
-                    // Code to apply text and background color directly
-                    container.style.backgroundColor = banner.backgroundColor;
-                    container.style.color = banner.textColor;
-                    container.innerHTML = "<p>" + banner.message + "</p>";
-                    container.style.display = "block";
-                }
-            }
-        })
+        .then(applyBanner)
         .catch(error => {
             console.error('Error:', error);
             $("#banner").remove();
         });
-    }
 }

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -217,6 +217,54 @@ function sanitizeBannerColor(color) {
     return /^#[0-9a-fA-F]{6}$/.test(color) ? color : "";
 }
 
+function isSafeBannerHref(href) {
+    return /^(https?:|mailto:)/i.test((href || "").trim());
+}
+
+var BANNER_ALLOWED_TAGS = { A: true };
+
+var BANNER_DROP_TAGS = { SCRIPT: true, STYLE: true, TEMPLATE: true, NOSCRIPT: true, IFRAME: true, OBJECT: true, EMBED: true };
+
+function sanitizeBannerNode(node) {
+    if (node.nodeType === Node.TEXT_NODE) {
+        return document.createTextNode(node.textContent);
+    }
+    if (node.nodeType !== Node.ELEMENT_NODE) {
+        return document.createTextNode("");
+    }
+    if (BANNER_DROP_TAGS[node.tagName]) {
+        return document.createDocumentFragment();
+    }
+
+    var target;
+    if (BANNER_ALLOWED_TAGS[node.tagName]) {
+        target = document.createElement(node.tagName.toLowerCase());
+        if (node.tagName === "A") {
+            var href = (node.getAttribute("href") || "").trim();
+            if (isSafeBannerHref(href)) {
+                target.setAttribute("href", href);
+                target.setAttribute("rel", "noopener noreferrer");
+            }
+        }
+    } else {
+        target = document.createDocumentFragment();
+    }
+
+    node.childNodes.forEach(function(child) {
+        target.appendChild(sanitizeBannerNode(child));
+    });
+    return target;
+}
+
+function sanitizeBannerMessage(message) {
+    var fragment = document.createDocumentFragment();
+    var doc = new DOMParser().parseFromString(String(message == null ? "" : message), "text/html");
+    doc.body.childNodes.forEach(function(node) {
+        fragment.appendChild(sanitizeBannerNode(node));
+    });
+    return fragment;
+}
+
 function applyBanner(data) {
     let allBanners = data.banners;
     if (!allBanners || !("global" in allBanners)) {
@@ -242,11 +290,9 @@ function applyBanner(data) {
         container.style.color = textColor;
     }
 
-    // Use textContent (not innerHTML) so the third-party message is rendered
-    // as plain text and cannot inject markup or event handlers.
     container.textContent = "";
     let paragraph = document.createElement("p");
-    paragraph.textContent = banner.message == null ? "" : String(banner.message);
+    paragraph.appendChild(sanitizeBannerMessage(banner.message));
     container.appendChild(paragraph);
     container.style.display = "block";
 }

--- a/spec/system/banner_spec.rb
+++ b/spec/system/banner_spec.rb
@@ -7,15 +7,92 @@ RSpec.describe 'Banner', type: :system, js: true, clean: true do
     visit "/catalog"
   end
 
-  context 'when viewing page' do
-    xit 'is visible' do
-      expect(page).to have_css("#banner")
+  def banner_state(*payloads)
+    applies = payloads.map { |p| "applyBanner(#{p.to_json});" }.join("\n")
+    page.evaluate_script(<<~JS)
+      (function() {
+        var el = document.getElementById('banner');
+        if (!el) { el = document.createElement('div'); el.id = 'banner'; document.body.prepend(el); }
+        el.textContent = '';
+        el.removeAttribute('style');
+        #{applies}
+        el = document.getElementById('banner');
+        var p = el && el.querySelector('p');
+        return {
+          paraCount: el ? el.querySelectorAll('p').length : 0,
+          text: p ? p.textContent : null,
+          bg: el ? el.style.backgroundColor : null,
+          color: el ? el.style.color : null,
+          display: el ? el.style.display : null,
+          imgCount: el ? el.querySelectorAll('img').length : 0,
+          xss: (typeof window.__xss === 'undefined') ? null : window.__xss
+        };
+      })();
+    JS
+  end
+
+  context 'with a well-formed banner' do
+    let(:state) do
+      banner_state(banners: { global: [{ message: 'Library closed Monday',
+                                         backgroundColor: '#003366',
+                                         textColor: '#ffffff' }] })
     end
 
-    xit 'does not create duplicates if renderBanner() is called again' do
-      page.evaluate_script('renderBanner()')
-      expect(page).to have_css("#banner")
-      expect(page.evaluate_script('$("#banner p").length')).to eq(1)
+    it 'renders the message as a single paragraph and makes the banner visible' do
+      expect(state['text']).to eq('Library closed Monday')
+      expect(state['paraCount']).to eq(1)
+      expect(state['display']).to eq('block')
+    end
+
+    it 'applies valid #RRGGBB colors' do
+      expect(state['bg']).to eq('rgb(0, 51, 102)')
+      expect(state['color']).to eq('rgb(255, 255, 255)')
+    end
+  end
+
+  context 'when the message contains HTML (supply-chain / XSS attempt)' do
+    let(:state) do
+      banner_state(banners: { global: [{ message: '<img src=x onerror="window.__xss=true">hello' }] })
+    end
+
+    it 'renders the markup as inert text instead of executing it' do
+      expect(state['imgCount']).to eq(0)
+      expect(state['xss']).to be_nil
+      expect(state['text']).to eq('<img src=x onerror="window.__xss=true">hello')
+    end
+  end
+
+  context 'when colors are not valid #RRGGBB values' do
+    let(:state) do
+      banner_state(banners: { global: [{ message: 'hi',
+                                         backgroundColor: 'red; background-image: url(evil)',
+                                         textColor: '#fff' }] })
+    end
+
+    it 'rejects malformed and 3-digit shorthand hex colors' do
+      expect(state['bg']).to eq('')
+      expect(state['color']).to eq('')
+    end
+  end
+
+  context 'when applyBanner runs more than once (turbolinks re-render)' do
+    let(:state) do
+      banner_state({ banners: { global: [{ message: 'first' }] } },
+                   { banners: { global: [{ message: 'second' }] } })
+    end
+
+    it 'does not create duplicate paragraphs' do
+      expect(state['paraCount']).to eq(1)
+      expect(state['text']).to eq('second')
+    end
+  end
+
+  context 'with malformed or empty feed data' do
+    it 'does not raise for missing or empty structures' do
+      expect { banner_state({}) }.not_to raise_error
+      expect { banner_state(banners: {}) }.not_to raise_error
+      expect { banner_state(banners: { global: [] }) }.not_to raise_error
+      expect { banner_state(banners: { global: [{}] }) }.not_to raise_error
     end
   end
 end

--- a/spec/system/banner_spec.rb
+++ b/spec/system/banner_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe 'Banner', type: :system, js: true, clean: true do
 
     it 'keeps the text but drops the unsafe href so nothing can execute' do
       expect(state['xss']).to be_nil
-      expect(state['linkHref']).to be_nil        # javascript: href rejected
+      expect(state['linkHref']).to be_nil # javascript: href rejected
       expect(state['linkText']).to eq('click')
     end
   end

--- a/spec/system/banner_spec.rb
+++ b/spec/system/banner_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe 'Banner', type: :system, js: true, clean: true do
         #{applies}
         el = document.getElementById('banner');
         var p = el && el.querySelector('p');
+        var a = el && el.querySelector('a');
         return {
           paraCount: el ? el.querySelectorAll('p').length : 0,
           text: p ? p.textContent : null,
@@ -25,6 +26,10 @@ RSpec.describe 'Banner', type: :system, js: true, clean: true do
           color: el ? el.style.color : null,
           display: el ? el.style.display : null,
           imgCount: el ? el.querySelectorAll('img').length : 0,
+          boldCount: el ? el.querySelectorAll('b').length : 0,
+          linkCount: el ? el.querySelectorAll('a').length : 0,
+          linkHref: a ? a.getAttribute('href') : null,
+          linkText: a ? a.textContent : null,
           xss: (typeof window.__xss === 'undefined') ? null : window.__xss
         };
       })();
@@ -50,15 +55,54 @@ RSpec.describe 'Banner', type: :system, js: true, clean: true do
     end
   end
 
-  context 'when the message contains HTML (supply-chain / XSS attempt)' do
+  context 'when the message contains dangerous HTML (supply-chain / XSS attempt)' do
     let(:state) do
       banner_state(banners: { global: [{ message: '<img src=x onerror="window.__xss=true">hello' }] })
     end
 
-    it 'renders the markup as inert text instead of executing it' do
+    it 'strips the dangerous element and never executes it, keeping safe text' do
       expect(state['imgCount']).to eq(0)
       expect(state['xss']).to be_nil
-      expect(state['text']).to eq('<img src=x onerror="window.__xss=true">hello')
+      # The disallowed <img> is dropped; its surrounding text survives.
+      expect(state['text']).to eq('hello')
+    end
+  end
+
+  context 'when the message contains a safe link' do
+    let(:state) do
+      banner_state(banners: { global: [{ message: 'See <a href="https://library.yale.edu/news">the news</a>' }] })
+    end
+
+    it 'preserves the link as a real, clickable anchor' do
+      expect(state['linkCount']).to eq(1)
+      expect(state['linkHref']).to eq('https://library.yale.edu/news')
+      expect(state['linkText']).to eq('the news')
+      expect(state['text']).to eq('See the news')
+    end
+  end
+
+  context 'when a link uses a dangerous URL scheme' do
+    let(:state) do
+      banner_state(banners: { global: [{ message: '<a href="javascript:window.__xss=true">click</a>' }] })
+    end
+
+    it 'keeps the text but drops the unsafe href so nothing can execute' do
+      expect(state['xss']).to be_nil
+      expect(state['linkHref']).to be_nil        # javascript: href rejected
+      expect(state['linkText']).to eq('click')
+    end
+  end
+
+  context 'when the message uses non-link tags' do
+    let(:state) do
+      banner_state(banners: { global: [{ message: '<script>window.__xss=true</script>hi <b>there</b>' }] })
+    end
+
+    it 'drops dangerous tags and flattens other formatting to text (only links are kept)' do
+      expect(state['xss']).to be_nil
+      expect(state['text']).to eq('hi there')
+      # Only <a> is allowlisted, so <b> is unwrapped to plain text.
+      expect(state['boldCount']).to eq(0)
     end
   end
 


### PR DESCRIPTION
## Summary  
Render the banner message with textContent instead of innerHTML so third-party feed content can't inject or execute markup, and validate background/text colors against a strict #RRGGBB regex before applying them.  
  
## Screenshot:  
Allows links to persist through sanitizing: 
<img width="1783" height="574" alt="image" src="https://github.com/user-attachments/assets/ebd564b4-3183-43cc-8393-11985beba723" />

