### PR TITLE
Defaults UV side panel to closed

### DIFF
--- a/config/uv/uv-config.json
+++ b/config/uv/uv-config.json
@@ -79,7 +79,7 @@
                 "panelAnimationDuration": 250,
                 "panelCollapsedWidth": 30,
                 "panelExpandedWidth": 255,
-                "panelOpen": true,
+                "panelOpen": false,
                 "tabOrder": "",
                 "thumbsCacheInvalidation": {
                     "enabled": true,


### PR DESCRIPTION
# Summary
Changes side panel for Contents behavior to now default to closed instead of open.

# Related Ticket 
[#3377](https://github.com/yalelibrary/YUL-DC/issues/3377)

# Screenshot
<img width="1831" height="1084" alt="image" src="https://github.com/user-attachments/assets/02139216-4071-4627-a29d-96b159b2330f" />
