### PR TITLE
Login Link and Landing Images

### DIFF
--- a/app/assets/javascripts/landing_hero.js
+++ b/app/assets/javascripts/landing_hero.js
@@ -1,4 +1,4 @@
-$(document).ready(function() {
+$(document).on('turbolinks:load', function() {
   const hero = document.getElementById('hero');
   if (!hero || !hero.dataset.heroImages) return;
 

--- a/app/assets/stylesheets/customOverrides/notifications.scss
+++ b/app/assets/stylesheets/customOverrides/notifications.scss
@@ -10,6 +10,10 @@ DEFAULT MOBILE STYLING
   text-decoration: none;
 }
 
+#main-flashes .landing-flash-login-link {
+  text-decoration: underline;
+}
+
 #main-flashes a:active, #main-flashes a:focus, #main-flashes a:hover {
   text-decoration: underline;
 }

--- a/app/controllers/concerns/blacklight/bookmarks.rb
+++ b/app/controllers/concerns/blacklight/bookmarks.rb
@@ -42,7 +42,7 @@ module Blacklight::Bookmarks
 
   def index
     if current_user.nil?
-      redirect_to((ENV['BLACKLIGHT_HOST']).to_s, notice: 'Please log in to gain access to this page.')
+      redirect_to((ENV['BLACKLIGHT_HOST']).to_s, flash: { login_required: request.fullpath })
       return false
     end
     @bookmarks = token_or_current_or_guest_user.bookmarks

--- a/app/controllers/permission_requests_controller.rb
+++ b/app/controllers/permission_requests_controller.rb
@@ -12,7 +12,7 @@ class PermissionRequestsController < ApplicationController
   def index
     @table_data = []
     if current_user.nil?
-      redirect_to((ENV['BLACKLIGHT_HOST']).to_s, notice: 'Please log in to gain access to this page.')
+      redirect_to((ENV['BLACKLIGHT_HOST']).to_s, flash: { login_required: request.fullpath })
       return false
     end
     if user_owp_permissions.nil?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,10 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
+  def login_return_path(path)
+    return nil if path.blank?
+    return nil unless path.start_with?('/')
+    return nil if path.start_with?('//', '/\\')
+    path
+  end
 end

--- a/app/views/application/landing.html.erb
+++ b/app/views/application/landing.html.erb
@@ -48,7 +48,7 @@
         src: asset_path("landing/hero-images/portolan-chart.jpg") }
     ].to_json %>'>
       <div class="intro">
-        <%= image_tag("", class: "d-block w-100", id: "hero-image", alt: "") %>
+        <%= tag.img(class: "d-block w-100", id: "hero-image", alt: "") %>
         <div class="image-overlay"></div>
         <div class="hero-caption d-md-block">
           <p id="hero-image-caption"></p>

--- a/app/views/shared/_landing_flash_msg.html.erb
+++ b/app/views/shared/_landing_flash_msg.html.erb
@@ -1,4 +1,11 @@
 <div class="landing_flash_messages">
+  <% if flash[:login_required].present? %>
+    <%= render(Blacklight::System::FlashMessageComponent.new(type: :notice)) do |component| %>
+      <% component.with_message do %>
+        Please <%= link_to 'log in', user_openid_connect_omniauth_authorize_path(origin: login_return_path(flash[:login_required])), method: :post, class: 'landing-flash-login-link' %> to gain access to this page.
+      <% end %>
+    <% end %>
+  <% end %>
   <% [:success, :notice, :error, :alert].each do |type| %>
     <%= render(Blacklight::System::FlashMessageComponent.with_collection(Array.wrap(flash[type]), type: type)) if flash[type] %>
   <% end %>


### PR DESCRIPTION
## Summary  
Login flash message now contains a clickable "Log in" link in the flash message. Also, redirects user to previous accessed page after logging in.
  
Landing Images now restored if the flash message is displayed.  
  
Screenshot:  
<img width="1781" height="767" alt="image" src="https://github.com/user-attachments/assets/b8aeaa04-85a6-4fd9-b7d9-659ecb63ea3b" />