### PR TITLE
Request Form Margins and Font

### DIFF
--- a/app/assets/stylesheets/customOverrides/permission_request_form.scss
+++ b/app/assets/stylesheets/customOverrides/permission_request_form.scss
@@ -1,11 +1,11 @@
 .request-form-cancel {
   color: white;
   background-color: #767676;
+  border: none;
   margin-right: 190px;
   margin-top: 5px;
   height: 40px;
   width: 100px;
-  font-size: 20px;
 }
 
 .request-form-submit {
@@ -50,11 +50,21 @@
   margin-top: 5px;
   height: 40px;
   width: 180px;
-  font-size: 20px;
+}
+
+.request-form-cancel,
+.request-form-submit {
+  text-transform: uppercase;
+  font-size: 16px;
+  font-family: $mallory_medium, Arial, Helvetica, sans-serif;
 }
 
 .request-form-metadata {
   padding-top: 50px;
+}
+
+.submit_form .form_buttons {
+  margin-bottom: 35px;
 }
 
 .request-key {


### PR DESCRIPTION
## Summary  
Increases bottom margins between request form buttons and footer. Also matches the button font with Yales font.  
  
## Screenshot:  
<img width="1783" height="1033" alt="image" src="https://github.com/user-attachments/assets/391fa5f7-43db-4e59-a223-70d5f1930f8e" />
