### PR TITLE
Resolve and Make Verbose CSP Violations

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,9 +1,8 @@
 //= require google_tag_manager
-//= require jquery
-//= require 'blacklight_advanced_search'
-
-
+// jQuery 3 only: jquery-rails' `jquery` is 1.12.4, whose feature detection sets
+// on* attributes, causing a script-src-attr CSP violation.
 //= require jquery3
+//= require 'blacklight_advanced_search'
 //= require rails-ujs
 //= require turbolinks
 //= require turbolinks_csp_nonce

--- a/app/views/kaminari/blacklight/_next_page.html.erb
+++ b/app/views/kaminari/blacklight/_next_page.html.erb
@@ -1,0 +1,22 @@
+<%# Link to the "Next" page
+  - available local variables
+    url:           url to the next page
+    current_page:  a page object for the currently displayed page
+    num_pages:     total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+
+  Override from Blacklight v7.38.0, which renders the disabled state as
+  <a href="#" onclick="return false;">. That inline handler is blocked by
+  `script_src_attr` in config/initializers/content_security_policy.rb, so it
+  logged a CSP violation on every paginated page. A <span> is also the
+  Bootstrap-documented markup for a disabled pagination item: it keeps the
+  page-link styling without a focusable anchor that goes nowhere.
+-%>
+<li class="page-item <%= 'disabled' if current_page.last? %>">
+  <% if current_page.last? %>
+    <span class="page-link"><%= raw(t 'views.pagination.next') %></span>
+  <% else %>
+    <%= link_to raw(t('views.pagination.next')), url, :rel => 'next', :remote => remote, class: 'page-link', aria: { label: t('views.pagination.aria.go_to_next_page') } %>
+  <% end %>
+</li>

--- a/app/views/kaminari/blacklight/_prev_page.html.erb
+++ b/app/views/kaminari/blacklight/_prev_page.html.erb
@@ -1,0 +1,22 @@
+<%# Link to the "Previous" page
+  - available local variables
+    url:           url to the previous page
+    current_page:  a page object for the currently displayed page
+    num_pages:     total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+
+  Override from Blacklight v7.38.0, which renders the disabled state as
+  <a href="#" onclick="return false;">. That inline handler is blocked by
+  `script_src_attr` in config/initializers/content_security_policy.rb, so it
+  logged a CSP violation on every paginated page. A <span> is also the
+  Bootstrap-documented markup for a disabled pagination item: it keeps the
+  page-link styling without a focusable anchor that goes nowhere.
+-%>
+<li class="page-item <%= 'disabled' if current_page.first? %>">
+  <% if current_page.first? %>
+    <span class="page-link"><%= raw(t 'views.pagination.previous') %></span>
+  <% else %>
+    <%= link_to raw(t('views.pagination.previous')), url, :rel => 'prev', :remote => remote, class: 'page-link', aria: { label: t('views.pagination.aria.go_to_previous_page') } %>
+  <% end %>
+</li>

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -15,7 +15,10 @@ if enforce_envs.include?(ENV['RAILS_ENV'])
       # ga.jspm.io serves chart.js for blacklight_range_limit; see config/importmap.rb
       policy.script_src      :self, 'siteimproveanalytics.com', 'www.googletagmanager.com', 'ga.jspm.io'
       policy.script_src_elem :self, 'siteimproveanalytics.com', 'www.googletagmanager.com', 'ga.jspm.io'
-      policy.script_src_attr :none
+      # :report_sample adds 'report-sample', which makes violation reports include
+      # a snippet of the offending handler in `script-sample`. Without it a
+      # script-src-attr report identifies no source beyond the document itself.
+      policy.script_src_attr :none, :report_sample
       policy.style_src       :self, :unsafe_inline
       policy.style_src_attr  :self, :unsafe_inline
       policy.style_src_elem  :self, :unsafe_inline, "#{ENV['IIIF_IMAGE_BASE_URL']}/"

--- a/spec/system/search_result_pagination_spec.rb
+++ b/spec/system/search_result_pagination_spec.rb
@@ -58,19 +58,26 @@ RSpec.describe "search result pagination", type: :system, clean: true, js: true 
   context "navigating with search context links" do
     it "has the appropriate context links on the first page of results" do
       visit '/catalog?per_page=2&q=&search_field=all_fields'
-      expect(page).to have_link "PREVIOUS"
-      # this link is disabled on the first page of results
-      expect(page).not_to have_link "«"
-      expect(page).to have_link "»"
-      expect(page).to have_link "NEXT"
+      within 'ul.pagination' do
+        # PREVIOUS and « are disabled on the first page, so they render as text
+        expect(page).not_to have_link "PREVIOUS"
+        expect(page).to have_css 'li.page-item.disabled span.page-link', text: 'PREVIOUS'
+        expect(page).not_to have_link "«"
+        expect(page).to have_link "»"
+        expect(page).to have_link "NEXT"
+      end
     end
 
     it "jumps to last page of results" do
       visit '/catalog?per_page=2&q=&search_field=all_fields'
       click_on "»"
       within 'ul.pagination' do
-        # next button is disabled on last page so it cannot be found
-        expect(page).not_to have_button("NEXT")
+        # NEXT and » are disabled on the last page, so they render as text
+        expect(page).not_to have_link "NEXT"
+        expect(page).to have_css 'li.page-item.disabled span.page-link', text: 'NEXT'
+        expect(page).not_to have_link "»"
+        expect(page).to have_link "PREVIOUS"
+        expect(page).to have_link "«"
       end
     end
 
@@ -79,8 +86,11 @@ RSpec.describe "search result pagination", type: :system, clean: true, js: true 
       click_on "»"
       click_on "«"
       within 'ul.pagination' do
-        # previous button is disabled on first page so it cannot be found
-        expect(page).not_to have_button("PREVIOUS")
+        # back on the first page, PREVIOUS and « render as text again
+        expect(page).not_to have_link "PREVIOUS"
+        expect(page).to have_css 'li.page-item.disabled span.page-link', text: 'PREVIOUS'
+        expect(page).not_to have_link "«"
+        expect(page).to have_link "NEXT"
       end
     end
   end


### PR DESCRIPTION
# Summary
In this PR are 3 changes:
* more detailed output from CSP violations in reports
* added partials and specs for pagination that override a behavior from kaminari's theme that violated CSP
* limits app to only load jquery3, not also a jquery 1.x version which contained code that violated CSP

# Related Ticket
[#3400](https://github.com/yalelibrary/YUL-DC/issues/3400)